### PR TITLE
Add independently verified Ada-native QUIC crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,15 @@
 /flyology_iri/benchmarks/bin/
 /flyology_iri/benchmarks/config/
 /flyology_iri/benchmarks/obj/
+/flyology_quic/alire/
+/flyology_quic/config/
+/flyology_quic/lib/
+/flyology_quic/obj/
+/flyology_quic/docs/api/
+/flyology_quic/tests/alire/
+/flyology_quic/tests/bin/
+/flyology_quic/tests/config/
+/flyology_quic/tests/obj/
+/flyology_quic/proof/alire/
+/flyology_quic/proof/config/
+/flyology_quic/proof/obj/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ includes bounded client pools, an origin-bound WebSocket client, streaming
 request and response bodies, routing, middleware, server-sent events,
 WebSocket servers, and plain or TLS transports built on Flyology I/O.
 
+This repository also contains `flyology_quic`, an independently built
+Ada-native QUIC transport crate. Its current foundation covers proved wire
+primitives and RFC-vector-checked Initial packet cryptography. HTTP/3 client
+and server support is not implemented yet.
+
 Documentation is published at [http.flyology.org](https://http.flyology.org/).
 The [client guide](https://http.flyology.org/guide/client/), dedicated
 [HTTP/2 guide](https://http.flyology.org/guide/http2/), and

--- a/flyology_quic/README.md
+++ b/flyology_quic/README.md
@@ -1,0 +1,29 @@
+# Flyology QUIC
+
+Flyology QUIC is an experimental, Ada-native QUIC transport crate. Protocol
+state, packet parsing, recovery, congestion control, streams, and connection
+management live in Ada. The native cryptography adapter supplies only the
+standard cryptographic operations required by QUIC.
+
+The crate lives in the Flyology HTTP repository because HTTP/3 is its first
+consumer, but it is built and tested independently. Task-aware UDP sockets,
+buffers, deadlines, cancellation, and runtime integration remain in Flyology.
+
+This initial foundation implements proved QUIC variable integers, packet
+number selection and reconstruction, nonce and header-protection policy, and
+the QUIC v1 Initial key schedule and packet protection using OpenSSL 3.
+
+## Build and test
+
+```sh
+alr build
+./scripts/test.sh
+./scripts/prove.sh
+```
+
+The tests use published RFC 9000 and RFC 9001 vectors. Network interoperability
+qualification will use external QUIC implementations as black-box peers; they
+are test oracles, not library dependencies.
+
+The staged acceptance matrix is recorded in
+[`tests/qualification.md`](tests/qualification.md).

--- a/flyology_quic/alire.toml
+++ b/flyology_quic/alire.toml
@@ -1,0 +1,18 @@
+name = "flyology_quic"
+description = "Ada-native QUIC transport for Flyology tasks"
+version = "0.1.0-dev"
+
+authors = ["Yurii Rashkovskii"]
+maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]
+maintainers-logins = ["yrashk"]
+licenses = "MIT OR Apache-2.0"
+website = "https://http.flyology.org/"
+tags = ["ada", "quic", "transport", "udp"]
+project-files = ["flyology_quic.gpr"]
+
+[[depends-on]]
+flyology = "~0.1.0-dev"
+
+[[actions]]
+type = "test"
+command = ["./scripts/test.sh"]

--- a/flyology_quic/flyology_quic.gpr
+++ b/flyology_quic/flyology_quic.gpr
@@ -1,0 +1,46 @@
+with "flyology.gpr";
+with "config/flyology_quic_config.gpr";
+
+library project Flyology_QUIC is
+   for Languages use ("Ada", "C");
+   for Source_Dirs use ("src", "src/native");
+   for Object_Dir use "obj/" & Flyology_Quic_Config.Build_Profile;
+   for Library_Name use "Flyology_QUIC";
+   for Library_Dir use "lib";
+   for Library_Kind use "static";
+   for Create_Missing_Dirs use "True";
+
+   type Documentation_Mode_Type is ("false", "true");
+   Documentation_Mode : Documentation_Mode_Type :=
+     external ("FLYOLOGY_QUIC_DOCUMENTATION", "false");
+   case Documentation_Mode is
+      when "false" =>
+         null;
+      when "true" =>
+         for Languages use ("Ada");
+         for Source_Files use ("flyology-quic.ads");
+   end case;
+
+   package Compiler is
+      for Default_Switches ("Ada") use
+        Flyology_Quic_Config.Ada_Compiler_Switches & ("-gnatwJ");
+      for Default_Switches ("C") use
+        ("-std=c11", "-O2", "-Wall", "-Wextra", "-Wpedantic");
+   end Compiler;
+
+   package Linker is
+      case Flyology_Quic_Config.Alire_Host_OS is
+         when "linux" =>
+            for Linker_Options use ("-ldl");
+         when others =>
+            null;
+      end case;
+   end Linker;
+
+   package Documentation is
+      for Output_Dir ("html") use "docs/api";
+      for Excluded_Project_Files use
+        (external ("FLYOLOGY_ROOT", "") & "/flyology.gpr",
+         "config/flyology_quic_config.gpr");
+   end Documentation;
+end Flyology_QUIC;

--- a/flyology_quic/proof/alire.toml
+++ b/flyology_quic/proof/alire.toml
@@ -1,0 +1,16 @@
+name = "flyology_quic_proof"
+description = "Development-only SPARK proof harness for Flyology QUIC"
+version = "0.1.0-dev"
+
+authors = ["Yurii Rashkovskii"]
+maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]
+licenses = "MIT OR Apache-2.0"
+tags = ["ada", "quic", "spark", "proof"]
+project-files = ["quic_policy.gpr"]
+
+[[depends-on]]
+flyology_quic = "*"
+gnatprove = "^16.1.0"
+
+[[pins]]
+flyology_quic = { path = ".." }

--- a/flyology_quic/proof/quic_policy.gpr
+++ b/flyology_quic/proof/quic_policy.gpr
@@ -1,0 +1,7 @@
+with "../flyology_quic.gpr";
+
+project QUIC_Policy is
+   for Source_Dirs use ();
+   for Object_Dir use "obj";
+   for Create_Missing_Dirs use "True";
+end QUIC_Policy;

--- a/flyology_quic/scripts/docs.sh
+++ b/flyology_quic/scripts/docs.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+crate_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+cd "$crate_root"
+FLYOLOGY_QUIC_DOCUMENTATION=true
+export FLYOLOGY_QUIC_DOCUMENTATION
+alr build
+alr exec -- gnatdoc \
+  --backend=html \
+  --warnings \
+  --style=leading \
+  -P flyology_quic.gpr \
+  -O docs/api
+
+test -f docs/api/index.html

--- a/flyology_quic/scripts/prove.sh
+++ b/flyology_quic/scripts/prove.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+crate_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+cd "$crate_root/proof"
+alr build --stop-after=generation
+alr gnatprove \
+  -P "$crate_root/flyology_quic.gpr" \
+  --mode=all \
+  --level=1 \
+  -j0 \
+  --output=oneline \
+  --output-header \
+  --report=all \
+  -f \
+  -u \
+  flyology-quic-packet_number_policy.adb \
+  flyology-quic-protection_policy.adb \
+  flyology-quic-varint_policy.adb
+
+printf '%s\n' "Flyology QUIC SPARK proof suite passed"

--- a/flyology_quic/scripts/test.sh
+++ b/flyology_quic/scripts/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+crate_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+cd "$crate_root/tests"
+alr build
+
+for test in \
+  flyology-quic-crypto_openssl-smoke \
+  flyology-quic-packet_number_policy-smoke \
+  flyology-quic-protection_policy-smoke \
+  flyology-quic-varint_policy-smoke
+do
+  printf '%s\n' "flyology_quic test: BEGIN $test"
+  "$crate_root/tests/bin/$test"
+  printf '%s\n' "flyology_quic test: PASS $test"
+done

--- a/flyology_quic/src/flyology-quic-crypto_openssl.adb
+++ b/flyology_quic/src/flyology-quic-crypto_openssl.adb
@@ -1,0 +1,205 @@
+with Interfaces.C;
+with Interfaces.C.Strings;
+
+package body Flyology.QUIC.Crypto_OpenSSL is
+   package C renames Interfaces.C;
+   package CS renames Interfaces.C.Strings;
+
+   use type C.int;
+   use type System.Address;
+
+   Error_Capacity : constant := 1_024;
+   subtype Error_Buffer is C.char_array (0 .. C.size_t (Error_Capacity - 1));
+
+   function C_Create
+     (Directory  : CS.chars_ptr;
+      Error      : System.Address;
+      Error_Size : C.size_t) return System.Address;
+   pragma Import (C, C_Create, "flyology_quic_openssl_create");
+
+   procedure C_Release (Handle : System.Address);
+   pragma Import (C, C_Release, "flyology_quic_openssl_release");
+
+   function C_Initial_Keys
+     (Handle        : System.Address;
+      Connection_ID : System.Address;
+      ID_Length     : C.size_t;
+      Client_Secret : System.Address;
+      Client_Key    : System.Address;
+      Client_IV     : System.Address;
+      Client_HP     : System.Address;
+      Server_Secret : System.Address;
+      Server_Key    : System.Address;
+      Server_IV     : System.Address;
+      Server_HP     : System.Address;
+      Error         : System.Address;
+      Error_Size    : C.size_t) return C.int;
+   pragma Import
+     (C, C_Initial_Keys, "flyology_quic_openssl_initial_keys");
+
+   function C_Protect
+     (Handle            : System.Address;
+      Key               : System.Address;
+      Nonce             : System.Address;
+      Header            : System.Address;
+      Header_Length     : C.size_t;
+      Plaintext         : System.Address;
+      Plaintext_Length  : C.size_t;
+      Ciphertext        : System.Address;
+      Ciphertext_Length : C.size_t;
+      Error             : System.Address;
+      Error_Size        : C.size_t) return C.int;
+   pragma Import (C, C_Protect, "flyology_quic_openssl_protect");
+
+   function C_Header_Mask
+     (Handle     : System.Address;
+      Key        : System.Address;
+      Sample     : System.Address;
+      Mask       : System.Address;
+      Error      : System.Address;
+      Error_Size : C.size_t) return C.int;
+   pragma Import
+     (C, C_Header_Mask, "flyology_quic_openssl_header_mask");
+
+   function Image (Buffer : Error_Buffer) return String is
+     (C.To_Ada (Buffer, Trim_Nul => True));
+
+   function Contains_Nul (Value : String) return Boolean is
+   begin
+      for Element of Value loop
+         if Element = Character'Val (0) then
+            return True;
+         end if;
+      end loop;
+      return False;
+   end Contains_Nul;
+
+   procedure Initialize_Provider
+     (Item              : in out Provider;
+      Library_Directory : String := "")
+   is
+      Directory : CS.chars_ptr := CS.Null_Ptr;
+      Error     : aliased Error_Buffer := (others => C.nul);
+   begin
+      if Item.Handle /= System.Null_Address then
+         raise Program_Error with
+           "QUIC crypto provider is already initialized";
+      elsif Contains_Nul (Library_Directory) then
+         raise Program_Error with
+           "OpenSSL library path contains an embedded NUL";
+      end if;
+
+      Directory := CS.New_String (Library_Directory);
+      Item.Handle :=
+        C_Create
+          (Directory, Error (Error'First)'Address, C.size_t (Error'Length));
+      CS.Free (Directory);
+      if Item.Handle = System.Null_Address then
+         raise Crypto_Error with "OpenSSL: " & Image (Error);
+      end if;
+   exception
+      when others =>
+         CS.Free (Directory);
+         raise;
+   end Initialize_Provider;
+
+   function Is_Available (Item : Provider) return Boolean is
+     (Item.Handle /= System.Null_Address);
+
+   procedure Derive_V1_Initial
+     (Item                       : Provider;
+      Destination_Connection_ID : Ada.Streams.Stream_Element_Array;
+      Keys                       : out Initial_Keys)
+   is
+      Result : aliased Initial_Keys :=
+        (Client_Secret | Client_Key | Client_IV | Client_HP |
+         Server_Secret | Server_Key | Server_IV | Server_HP => (others => 0));
+      Error  : aliased Error_Buffer := (others => C.nul);
+      Status : C.int;
+   begin
+      if Item.Handle = System.Null_Address then
+         raise Crypto_Error with "OpenSSL QUIC crypto provider is unavailable";
+      end if;
+      Status :=
+        C_Initial_Keys
+          (Item.Handle,
+           (if Destination_Connection_ID'Length = 0
+            then System.Null_Address
+            else Destination_Connection_ID
+              (Destination_Connection_ID'First)'Address),
+           C.size_t (Destination_Connection_ID'Length),
+           Result.Client_Secret (Result.Client_Secret'First)'Address,
+           Result.Client_Key (Result.Client_Key'First)'Address,
+           Result.Client_IV (Result.Client_IV'First)'Address,
+           Result.Client_HP (Result.Client_HP'First)'Address,
+           Result.Server_Secret (Result.Server_Secret'First)'Address,
+           Result.Server_Key (Result.Server_Key'First)'Address,
+           Result.Server_IV (Result.Server_IV'First)'Address,
+           Result.Server_HP (Result.Server_HP'First)'Address,
+           Error (Error'First)'Address, C.size_t (Error'Length));
+      if Status /= 0 then
+         raise Crypto_Error with "OpenSSL: " & Image (Error);
+      end if;
+      Keys := Result;
+   end Derive_V1_Initial;
+
+   procedure Protect
+     (Item       : Provider;
+      Key        : AES_128_Key;
+      Nonce      : AES_GCM_IV;
+      Header     : Ada.Streams.Stream_Element_Array;
+      Plaintext  : Ada.Streams.Stream_Element_Array;
+      Ciphertext : out Ada.Streams.Stream_Element_Array)
+   is
+      Error  : aliased Error_Buffer := (others => C.nul);
+      Status : C.int;
+   begin
+      if Item.Handle = System.Null_Address then
+         raise Crypto_Error with "OpenSSL QUIC crypto provider is unavailable";
+      end if;
+      Status :=
+        C_Protect
+          (Item.Handle, Key (Key'First)'Address, Nonce (Nonce'First)'Address,
+           (if Header'Length = 0 then System.Null_Address
+            else Header (Header'First)'Address),
+           C.size_t (Header'Length),
+           (if Plaintext'Length = 0 then System.Null_Address
+            else Plaintext (Plaintext'First)'Address),
+           C.size_t (Plaintext'Length), Ciphertext (Ciphertext'First)'Address,
+           C.size_t (Ciphertext'Length), Error (Error'First)'Address,
+           C.size_t (Error'Length));
+      if Status /= 0 then
+         raise Crypto_Error with "OpenSSL: " & Image (Error);
+      end if;
+   end Protect;
+
+   procedure Make_Header_Mask
+     (Item   : Provider;
+      Key    : AES_128_Key;
+      Sample : Header_Sample;
+      Mask   : out Header_Mask)
+   is
+      Error  : aliased Error_Buffer := (others => C.nul);
+      Status : C.int;
+   begin
+      if Item.Handle = System.Null_Address then
+         raise Crypto_Error with "OpenSSL QUIC crypto provider is unavailable";
+      end if;
+      Status :=
+        C_Header_Mask
+          (Item.Handle, Key (Key'First)'Address, Sample (Sample'First)'Address,
+           Mask (Mask'First)'Address, Error (Error'First)'Address,
+           C.size_t (Error'Length));
+      if Status /= 0 then
+         raise Crypto_Error with "OpenSSL: " & Image (Error);
+      end if;
+   end Make_Header_Mask;
+
+   overriding procedure Finalize (Item : in out Provider) is
+   begin
+      if Item.Handle /= System.Null_Address then
+         C_Release (Item.Handle);
+         Item.Handle := System.Null_Address;
+      end if;
+   end Finalize;
+end Flyology.QUIC.Crypto_OpenSSL;

--- a/flyology_quic/src/flyology-quic-crypto_openssl.ads
+++ b/flyology_quic/src/flyology-quic-crypto_openssl.ads
@@ -1,0 +1,64 @@
+with Ada.Finalization;
+with Ada.Streams;
+with System;
+
+--  OpenSSL-backed cryptographic primitives used by the Ada QUIC engine.
+--  OpenSSL supplies cryptography only; protocol state and wire handling remain
+--  in Ada.
+private package Flyology.QUIC.Crypto_OpenSSL is
+   subtype SHA256_Secret is Ada.Streams.Stream_Element_Array (1 .. 32);
+   subtype AES_128_Key is Ada.Streams.Stream_Element_Array (1 .. 16);
+   subtype AES_GCM_IV is Ada.Streams.Stream_Element_Array (1 .. 12);
+   subtype Header_Sample is Ada.Streams.Stream_Element_Array (1 .. 16);
+   subtype Header_Mask is Ada.Streams.Stream_Element_Array (1 .. 5);
+
+   --  QUIC v1 Initial secrets and traffic keys. Initial secrets are derived
+   --  from the public Destination Connection ID; later encryption levels use
+   --  separate owning, zeroizing key containers.
+   type Initial_Keys is record
+      Client_Secret : SHA256_Secret;
+      Client_Key    : AES_128_Key;
+      Client_IV     : AES_GCM_IV;
+      Client_HP     : AES_128_Key;
+      Server_Secret : SHA256_Secret;
+      Server_Key    : AES_128_Key;
+      Server_IV     : AES_GCM_IV;
+      Server_HP     : AES_128_Key;
+   end record;
+
+   Crypto_Error : exception;
+   type Provider is limited private;
+
+   procedure Initialize_Provider
+     (Item              : in out Provider;
+      Library_Directory : String := "");
+
+   function Is_Available (Item : Provider) return Boolean;
+
+   procedure Derive_V1_Initial
+     (Item                       : Provider;
+      Destination_Connection_ID : Ada.Streams.Stream_Element_Array;
+      Keys                       : out Initial_Keys)
+   with Pre => Destination_Connection_ID'Length <= 20;
+
+   procedure Protect
+     (Item       : Provider;
+      Key        : AES_128_Key;
+      Nonce      : AES_GCM_IV;
+      Header     : Ada.Streams.Stream_Element_Array;
+      Plaintext  : Ada.Streams.Stream_Element_Array;
+      Ciphertext : out Ada.Streams.Stream_Element_Array)
+   with Pre => Ciphertext'Length = Plaintext'Length + 16;
+
+   procedure Make_Header_Mask
+     (Item   : Provider;
+      Key    : AES_128_Key;
+      Sample : Header_Sample;
+      Mask   : out Header_Mask);
+private
+   type Provider is new Ada.Finalization.Limited_Controlled with record
+      Handle : System.Address := System.Null_Address;
+   end record;
+
+   overriding procedure Finalize (Item : in out Provider);
+end Flyology.QUIC.Crypto_OpenSSL;

--- a/flyology_quic/src/flyology-quic-packet_number_policy.adb
+++ b/flyology_quic/src/flyology-quic-packet_number_policy.adb
@@ -1,0 +1,64 @@
+package body Flyology.QUIC.Packet_Number_Policy
+  with SPARK_Mode => On
+is
+   function Window (Length : Encoded_Length) return Interfaces.Unsigned_64 is
+     (case Length is
+         when 1 => 2**8,
+         when 2 => 2**16,
+         when 3 => 2**24,
+         when 4 => 2**32);
+
+   function Is_Representable
+     (Full                 : Packet_Number;
+      Has_Largest_Acked    : Boolean;
+      Largest_Acknowledged : Packet_Number) return Boolean
+   is
+     ((if Has_Largest_Acked
+       then Full - Largest_Acknowledged
+       else Full + 1) <= 2**31);
+
+   function Select_Length
+     (Full                 : Packet_Number;
+      Has_Largest_Acked    : Boolean;
+      Largest_Acknowledged : Packet_Number) return Encoded_Length
+   is
+      Unacknowledged : constant Interfaces.Unsigned_64 :=
+        (if Has_Largest_Acked
+         then Full - Largest_Acknowledged
+         else Full + 1);
+   begin
+      if Unacknowledged <= 2**7 then
+         return 1;
+      elsif Unacknowledged <= 2**15 then
+         return 2;
+      elsif Unacknowledged <= 2**23 then
+         return 3;
+      else
+         return 4;
+      end if;
+   end Select_Length;
+
+   function Reconstruct
+     (Largest   : Packet_Number;
+      Truncated : Interfaces.Unsigned_64;
+      Length    : Encoded_Length) return Packet_Number
+   is
+      Expected  : constant Interfaces.Unsigned_64 := Largest + 1;
+      PN_Window : constant Interfaces.Unsigned_64 := Window (Length);
+      Half      : constant Interfaces.Unsigned_64 := PN_Window / 2;
+      Candidate : Interfaces.Unsigned_64 :=
+        (Expected / PN_Window) * PN_Window + Truncated;
+   begin
+      if Expected >= Half
+        and then Candidate <= Expected - Half
+        and then Candidate < 2**62 - PN_Window
+      then
+         Candidate := Candidate + PN_Window;
+      elsif Candidate > Expected + Half
+        and then Candidate >= PN_Window
+      then
+         Candidate := Candidate - PN_Window;
+      end if;
+      return Packet_Number (Candidate);
+   end Reconstruct;
+end Flyology.QUIC.Packet_Number_Policy;

--- a/flyology_quic/src/flyology-quic-packet_number_policy.ads
+++ b/flyology_quic/src/flyology-quic-packet_number_policy.ads
@@ -1,0 +1,54 @@
+with Interfaces;
+
+--  Internal, proved selection and reconstruction of QUIC packet numbers.
+private package Flyology.QUIC.Packet_Number_Policy
+  with Preelaborate,
+       SPARK_Mode => On
+is
+   use type Interfaces.Unsigned_64;
+
+   subtype Packet_Number is Interfaces.Unsigned_64 range 0 .. 2**62 - 1;
+   type Encoded_Length is range 1 .. 4;
+
+   function Window (Length : Encoded_Length) return Interfaces.Unsigned_64
+   with
+     Global => null,
+     Post =>
+       Window'Result =
+         (case Length is
+             when 1 => 2**8,
+             when 2 => 2**16,
+             when 3 => 2**24,
+             when 4 => 2**32);
+
+   function Is_Representable
+     (Full                 : Packet_Number;
+      Has_Largest_Acked    : Boolean;
+      Largest_Acknowledged : Packet_Number) return Boolean
+   with
+     Global => null,
+     Pre =>
+       not Has_Largest_Acked
+       or else Largest_Acknowledged < Full;
+
+   function Select_Length
+     (Full                 : Packet_Number;
+      Has_Largest_Acked    : Boolean;
+      Largest_Acknowledged : Packet_Number) return Encoded_Length
+   with
+     Global => null,
+     Pre =>
+       (not Has_Largest_Acked or else Largest_Acknowledged < Full)
+       and then Is_Representable
+         (Full, Has_Largest_Acked, Largest_Acknowledged);
+
+   function Reconstruct
+     (Largest   : Packet_Number;
+      Truncated : Interfaces.Unsigned_64;
+      Length    : Encoded_Length) return Packet_Number
+   with
+     Global => null,
+     Pre =>
+       Largest < Packet_Number'Last
+       and then Truncated < Window (Length);
+end Flyology.QUIC.Packet_Number_Policy;

--- a/flyology_quic/src/flyology-quic-protection_policy.adb
+++ b/flyology_quic/src/flyology-quic-protection_policy.adb
@@ -1,0 +1,51 @@
+package body Flyology.QUIC.Protection_Policy
+  with SPARK_Mode => On
+is
+   use type Ada.Streams.Stream_Element;
+   use type Ada.Streams.Stream_Element_Offset;
+
+   function Make_Nonce
+     (IV : Nonce; Number : Packet_Number) return Nonce
+   is
+      Result : Nonce := IV;
+   begin
+      for Offset in Natural range 0 .. 7 loop
+         Result
+           (Result'Last - Ada.Streams.Stream_Element_Offset (Offset)) :=
+             Result
+               (Result'Last - Ada.Streams.Stream_Element_Offset (Offset))
+             xor Ada.Streams.Stream_Element
+               (Interfaces.Shift_Right (Number, 8 * Offset) and 16#FF#);
+      end loop;
+      return Result;
+   end Make_Nonce;
+
+   procedure Apply_Header_Protection
+     (First_Byte            : in out Ada.Streams.Stream_Element;
+      Encoded_Packet_Number : in out Ada.Streams.Stream_Element_Array;
+      Long_Header           : Boolean;
+      Mask                  : Header_Mask)
+   is
+      First : constant Ada.Streams.Stream_Element_Offset :=
+        Encoded_Packet_Number'First;
+   begin
+      First_Byte :=
+        First_Byte xor
+          (Mask (Mask'First)
+             and (if Long_Header then 16#0F# else 16#1F#));
+      Encoded_Packet_Number (First) :=
+        Encoded_Packet_Number (First) xor Mask (2);
+      if Encoded_Packet_Number'Length >= 2 then
+         Encoded_Packet_Number (First + 1) :=
+           Encoded_Packet_Number (First + 1) xor Mask (3);
+      end if;
+      if Encoded_Packet_Number'Length >= 3 then
+         Encoded_Packet_Number (First + 2) :=
+           Encoded_Packet_Number (First + 2) xor Mask (4);
+      end if;
+      if Encoded_Packet_Number'Length = 4 then
+         Encoded_Packet_Number (First + 3) :=
+           Encoded_Packet_Number (First + 3) xor Mask (5);
+      end if;
+   end Apply_Header_Protection;
+end Flyology.QUIC.Protection_Policy;

--- a/flyology_quic/src/flyology-quic-protection_policy.ads
+++ b/flyology_quic/src/flyology-quic-protection_policy.ads
@@ -1,0 +1,23 @@
+with Ada.Streams;
+with Interfaces;
+
+private package Flyology.QUIC.Protection_Policy
+  with Preelaborate,
+       SPARK_Mode => On
+is
+   use type Interfaces.Unsigned_64;
+
+   subtype Packet_Number is Interfaces.Unsigned_64 range 0 .. 2**62 - 1;
+   subtype Nonce is Ada.Streams.Stream_Element_Array (1 .. 12);
+   subtype Header_Mask is Ada.Streams.Stream_Element_Array (1 .. 5);
+
+   function Make_Nonce
+     (IV : Nonce; Number : Packet_Number) return Nonce;
+
+   procedure Apply_Header_Protection
+     (First_Byte            : in out Ada.Streams.Stream_Element;
+      Encoded_Packet_Number : in out Ada.Streams.Stream_Element_Array;
+      Long_Header           : Boolean;
+      Mask                  : Header_Mask)
+   with Pre => Encoded_Packet_Number'Length in 1 .. 4;
+end Flyology.QUIC.Protection_Policy;

--- a/flyology_quic/src/flyology-quic-varint_policy.adb
+++ b/flyology_quic/src/flyology-quic-varint_policy.adb
@@ -1,0 +1,124 @@
+package body Flyology.QUIC.Varint_Policy
+  with SPARK_Mode => On
+is
+   use type Ada.Streams.Stream_Element;
+   use type Ada.Streams.Stream_Element_Offset;
+
+   function Required_Length (Value : Value_Type) return Encoded_Length is
+     (if Value <= 63 then 1
+      elsif Value <= 16_383 then 2
+      elsif Value <= 1_073_741_823 then 4
+      else 8);
+
+   function Encode (Value : Value_Type) return Encoded_Value is
+      Result : Encoded_Value;
+   begin
+      Result.Length := Required_Length (Value);
+      case Result.Length is
+         when 1 =>
+            Result.Data (1) := Ada.Streams.Stream_Element (Value);
+         when 2 =>
+            Result.Data (1) :=
+              16#40# + Ada.Streams.Stream_Element (Value / 2**8);
+            Result.Data (2) := Ada.Streams.Stream_Element (Value mod 2**8);
+         when 4 =>
+            Result.Data (1) :=
+              16#80# + Ada.Streams.Stream_Element (Value / 2**24);
+            Result.Data (2) :=
+              Ada.Streams.Stream_Element ((Value / 2**16) mod 2**8);
+            Result.Data (3) :=
+              Ada.Streams.Stream_Element ((Value / 2**8) mod 2**8);
+            Result.Data (4) := Ada.Streams.Stream_Element (Value mod 2**8);
+         when 8 =>
+            Result.Data (1) :=
+              16#C0# + Ada.Streams.Stream_Element (Value / 2**56);
+            Result.Data (2) :=
+              Ada.Streams.Stream_Element ((Value / 2**48) mod 2**8);
+            Result.Data (3) :=
+              Ada.Streams.Stream_Element ((Value / 2**40) mod 2**8);
+            Result.Data (4) :=
+              Ada.Streams.Stream_Element ((Value / 2**32) mod 2**8);
+            Result.Data (5) :=
+              Ada.Streams.Stream_Element ((Value / 2**24) mod 2**8);
+            Result.Data (6) :=
+              Ada.Streams.Stream_Element ((Value / 2**16) mod 2**8);
+            Result.Data (7) :=
+              Ada.Streams.Stream_Element ((Value / 2**8) mod 2**8);
+            Result.Data (8) := Ada.Streams.Stream_Element (Value mod 2**8);
+         when others =>
+            raise Program_Error;
+      end case;
+      return Result;
+   end Encode;
+
+   function Decode
+     (Data : Ada.Streams.Stream_Element_Array) return Decode_Result
+   is
+      subtype Byte_Offset is Natural range 0 .. 7;
+
+      function Byte_At (Offset : Byte_Offset) return Interfaces.Unsigned_64
+      with
+        Pre =>
+          (case Offset is
+              when 0 => Data'Length >= 1,
+              when 1 => Data'Length >= 2,
+              when 2 => Data'Length >= 3,
+              when 3 => Data'Length >= 4,
+              when 4 => Data'Length >= 5,
+              when 5 => Data'Length >= 6,
+              when 6 => Data'Length >= 7,
+              when 7 => Data'Length >= 8),
+        Post => Byte_At'Result <= 255;
+
+      function Byte_At (Offset : Byte_Offset) return Interfaces.Unsigned_64 is
+        (Interfaces.Unsigned_64
+           (Data
+              (Data'First + Ada.Streams.Stream_Element_Offset (Offset))));
+
+      First  : Interfaces.Unsigned_64;
+      Length : Encoded_Length;
+      Value  : Interfaces.Unsigned_64;
+   begin
+      if Data'Length = 0 then
+         return (Status => Truncated, Value => 0, Consumed => 0);
+      end if;
+
+      First := Byte_At (0);
+      Length :=
+        (if First < 16#40# then 1
+         elsif First < 16#80# then 2
+         elsif First < 16#C0# then 4
+         else 8);
+      if (case Length is
+             when 1 => Data'Length < 1,
+             when 2 => Data'Length < 2,
+             when 4 => Data'Length < 4,
+             when 8 => Data'Length < 8,
+             when others => True)
+      then
+         return (Status => Truncated, Value => 0, Consumed => 0);
+      end if;
+
+      Value := First mod 16#40#;
+      case Length is
+         when 1 =>
+            null;
+         when 2 =>
+            Value := Value * 2**8 + Byte_At (1);
+         when 4 =>
+            Value :=
+              ((Value * 2**8 + Byte_At (1)) * 2**8 + Byte_At (2))
+              * 2**8 + Byte_At (3);
+         when 8 =>
+            Value :=
+              ((((((Value * 2**8 + Byte_At (1)) * 2**8 + Byte_At (2))
+                    * 2**8 + Byte_At (3)) * 2**8 + Byte_At (4))
+                  * 2**8 + Byte_At (5)) * 2**8 + Byte_At (6))
+                * 2**8 + Byte_At (7);
+         when others =>
+            raise Program_Error;
+      end case;
+      return
+        (Status => Decoded, Value => Value_Type (Value), Consumed => Length);
+   end Decode;
+end Flyology.QUIC.Varint_Policy;

--- a/flyology_quic/src/flyology-quic-varint_policy.ads
+++ b/flyology_quic/src/flyology-quic-varint_policy.ads
@@ -1,0 +1,60 @@
+with Ada.Streams;
+with Interfaces;
+
+--  Internal, proved QUIC variable-length integer encoding policy.
+--
+--  The wire representation follows RFC 9000 Section 16. Decode accepts every
+--  permitted width, including values encoded in more bytes than necessary;
+--  Encode always selects the shortest representation.
+private package Flyology.QUIC.Varint_Policy
+  with Preelaborate,
+       SPARK_Mode => On
+is
+   use type Interfaces.Unsigned_64;
+
+   subtype Value_Type is Interfaces.Unsigned_64 range 0 .. 2**62 - 1;
+   subtype Encoded_Length is Positive range 1 .. 8;
+
+   type Encoded_Value is record
+      Data   : Ada.Streams.Stream_Element_Array (1 .. 8) := (others => 0);
+      Length : Encoded_Length := 1;
+   end record;
+
+   type Decode_Status is (Decoded, Truncated);
+
+   type Decode_Result is record
+      Status   : Decode_Status := Truncated;
+      Value    : Value_Type := 0;
+      Consumed : Natural range 0 .. 8 := 0;
+   end record;
+
+   function Required_Length (Value : Value_Type) return Encoded_Length
+   with
+     Global => null,
+     Post => Required_Length'Result in 1 | 2 | 4 | 8;
+
+   function Encode (Value : Value_Type) return Encoded_Value
+   with
+     Global => null,
+     Post =>
+       Encode'Result.Length = Required_Length (Value)
+       and then Encode'Result.Length in 1 | 2 | 4 | 8;
+
+   function Decode
+     (Data : Ada.Streams.Stream_Element_Array) return Decode_Result
+   with
+     Global => null,
+     Post =>
+       (if Decode'Result.Status = Decoded then
+           Decode'Result.Consumed in 1 | 2 | 4 | 8
+           and then
+             (case Decode'Result.Consumed is
+                 when 1 => Data'Length >= 1,
+                 when 2 => Data'Length >= 2,
+                 when 4 => Data'Length >= 4,
+                 when 8 => Data'Length >= 8,
+                 when others => False)
+        else
+           Decode'Result.Consumed = 0
+           and then Decode'Result.Value = 0);
+end Flyology.QUIC.Varint_Policy;

--- a/flyology_quic/src/flyology-quic.ads
+++ b/flyology_quic/src/flyology-quic.ads
@@ -1,0 +1,8 @@
+--  Ada-native QUIC transport for Flyology tasks.
+--
+--  Protocol state and wire handling are implemented in Ada. Native adapters
+--  are restricted to cryptographic operations and Flyology-provided I/O.
+package Flyology.QUIC
+  with Preelaborate
+is
+end Flyology.QUIC;

--- a/flyology_quic/src/native/flyology_quic_openssl.c
+++ b/flyology_quic/src/native/flyology_quic_openssl.c
@@ -1,0 +1,375 @@
+#define _POSIX_C_SOURCE 200809L
+
+/* OpenSSL 3 dynamic cryptography adapter for Flyology QUIC.  This adapter
+ * contains no QUIC protocol state. */
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct evp_cipher_st EVP_CIPHER;
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+typedef struct evp_md_st EVP_MD;
+
+struct quic_crypto_module {
+   void *crypto;
+   unsigned long (*OpenSSL_version_num)(void);
+   void (*ERR_clear_error)(void);
+   unsigned long (*ERR_get_error)(void);
+   void (*ERR_error_string_n)(unsigned long, char *, size_t);
+   const EVP_MD *(*EVP_sha256)(void);
+   unsigned char *(*HMAC)(const EVP_MD *, const void *, int,
+                          const unsigned char *, size_t,
+                          unsigned char *, unsigned int *);
+   void (*OPENSSL_cleanse)(void *, size_t);
+   const EVP_CIPHER *(*EVP_aes_128_ecb)(void);
+   const EVP_CIPHER *(*EVP_aes_128_gcm)(void);
+   EVP_CIPHER_CTX *(*EVP_CIPHER_CTX_new)(void);
+   void (*EVP_CIPHER_CTX_free)(EVP_CIPHER_CTX *);
+   int (*EVP_CIPHER_CTX_ctrl)(EVP_CIPHER_CTX *, int, int, void *);
+   int (*EVP_CIPHER_CTX_set_padding)(EVP_CIPHER_CTX *, int);
+   int (*EVP_EncryptInit_ex)(EVP_CIPHER_CTX *, const EVP_CIPHER *, void *,
+                             const unsigned char *, const unsigned char *);
+   int (*EVP_EncryptUpdate)(EVP_CIPHER_CTX *, unsigned char *, int *,
+                            const unsigned char *, int);
+   int (*EVP_EncryptFinal_ex)(EVP_CIPHER_CTX *, unsigned char *, int *);
+};
+
+static void set_error(char *buffer, size_t size, const char *message)
+{
+   if (buffer != NULL && size != 0)
+      snprintf(buffer, size, "%s", message != NULL ? message : "unknown error");
+}
+
+static void loader_error(char *buffer, size_t size, const char *name)
+{
+   const char *detail = dlerror();
+   if (buffer != NULL && size != 0)
+      snprintf(buffer, size, "%s: %s", name,
+               detail != NULL ? detail : "dynamic loader failure");
+}
+
+static int make_path(char *out, size_t size, const char *directory,
+                     const char *name)
+{
+   int count = directory == NULL || directory[0] == '\0'
+     ? snprintf(out, size, "%s", name)
+     : snprintf(out, size, "%s/%s", directory, name);
+   return count >= 0 && (size_t)count < size;
+}
+
+static void *required_symbol(void *handle, const char *name,
+                             char *error, size_t error_size)
+{
+   void *symbol;
+   dlerror();
+   symbol = dlsym(handle, name);
+   if (symbol == NULL) loader_error(error, error_size, name);
+   return symbol;
+}
+
+#define LOAD(module, member) do {                                               \
+   void *symbol = required_symbol((module)->crypto, #member, error, error_size); \
+   if (symbol == NULL) goto fail;                                                \
+   _Static_assert(sizeof((module)->member) == sizeof(symbol),                    \
+                  "function and data pointers must have equal size");           \
+   memcpy(&(module)->member, &symbol, sizeof((module)->member));                  \
+} while (0)
+
+static void release_module(struct quic_crypto_module *module)
+{
+   if (module == NULL) return;
+   if (module->crypto != NULL) dlclose(module->crypto);
+   free(module);
+}
+
+static struct quic_crypto_module *load_from_directory
+  (const char *directory, char *error, size_t error_size)
+{
+   struct quic_crypto_module *module = NULL;
+   char path[1024];
+#if defined(__APPLE__)
+   const char *name = "libcrypto.3.dylib";
+#else
+   const char *name = "libcrypto.so.3";
+#endif
+
+   if (!make_path(path, sizeof path, directory, name)) {
+      set_error(error, error_size, "OpenSSL library directory is too long");
+      return NULL;
+   }
+   module = calloc(1, sizeof *module);
+   if (module == NULL) {
+      set_error(error, error_size, "cannot allocate OpenSSL module table");
+      return NULL;
+   }
+   module->crypto = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+   if (module->crypto == NULL) {
+      loader_error(error, error_size, path);
+      goto fail;
+   }
+
+   LOAD(module, OpenSSL_version_num);
+   if ((module->OpenSSL_version_num() >> 28) != 3) {
+      set_error(error, error_size, "QUIC requires OpenSSL 3.x");
+      goto fail;
+   }
+   LOAD(module, ERR_clear_error);
+   LOAD(module, ERR_get_error);
+   LOAD(module, ERR_error_string_n);
+   LOAD(module, EVP_sha256);
+   LOAD(module, HMAC);
+   LOAD(module, OPENSSL_cleanse);
+   LOAD(module, EVP_aes_128_ecb);
+   LOAD(module, EVP_aes_128_gcm);
+   LOAD(module, EVP_CIPHER_CTX_new);
+   LOAD(module, EVP_CIPHER_CTX_free);
+   LOAD(module, EVP_CIPHER_CTX_ctrl);
+   LOAD(module, EVP_CIPHER_CTX_set_padding);
+   LOAD(module, EVP_EncryptInit_ex);
+   LOAD(module, EVP_EncryptUpdate);
+   LOAD(module, EVP_EncryptFinal_ex);
+   return module;
+
+fail:
+   release_module(module);
+   return NULL;
+}
+
+static struct quic_crypto_module *load_module
+  (const char *directory, char *error, size_t error_size)
+{
+   struct quic_crypto_module *module;
+   if (directory != NULL && directory[0] != '\0')
+      return load_from_directory(directory, error, error_size);
+#if defined(__APPLE__)
+   static const char *directories[] = {
+      "/opt/homebrew/opt/openssl@3/lib",
+      "/usr/local/opt/openssl@3/lib",
+      ""
+   };
+#else
+   static const char *directories[] = { "" };
+#endif
+   for (size_t index = 0;
+        index < sizeof directories / sizeof directories[0]; ++index) {
+      module = load_from_directory(directories[index], error, error_size);
+      if (module != NULL) return module;
+   }
+   return NULL;
+}
+
+static void provider_error(struct quic_crypto_module *module,
+                           char *buffer, size_t size, const char *fallback)
+{
+   unsigned long code = module->ERR_get_error();
+   if (code != 0) module->ERR_error_string_n(code, buffer, size);
+   else set_error(buffer, size, fallback);
+}
+
+#define SHA256_LENGTH 32
+
+static int hmac_sha256(struct quic_crypto_module *module,
+                       const unsigned char *key, size_t key_length,
+                       const unsigned char *data, size_t data_length,
+                       unsigned char output[SHA256_LENGTH])
+{
+   unsigned int output_length = 0;
+   if (key_length > INT32_MAX) return 0;
+   module->ERR_clear_error();
+   return module->HMAC(module->EVP_sha256(), key, (int)key_length,
+                       data, data_length, output, &output_length) != NULL &&
+          output_length == SHA256_LENGTH;
+}
+
+static int hkdf_expand_label
+  (struct quic_crypto_module *module,
+   const unsigned char secret[SHA256_LENGTH], const char *label,
+   unsigned char *output, size_t output_length)
+{
+   static const unsigned char prefix[] = "tls13 ";
+   unsigned char input[256];
+   unsigned char digest[SHA256_LENGTH];
+   size_t label_length = strlen(label);
+   size_t full_label_length = sizeof prefix - 1 + label_length;
+   size_t cursor = 0;
+   int success = 0;
+
+   if (output_length > SHA256_LENGTH || full_label_length > 255 ||
+       2 + 1 + full_label_length + 1 + 1 > sizeof input)
+      return 0;
+   input[cursor++] = (unsigned char)(output_length >> 8);
+   input[cursor++] = (unsigned char)output_length;
+   input[cursor++] = (unsigned char)full_label_length;
+   memcpy(input + cursor, prefix, sizeof prefix - 1);
+   cursor += sizeof prefix - 1;
+   memcpy(input + cursor, label, label_length);
+   cursor += label_length;
+   input[cursor++] = 0;
+   input[cursor++] = 1;
+   if (hmac_sha256(module, secret, SHA256_LENGTH, input, cursor, digest)) {
+      memcpy(output, digest, output_length);
+      success = 1;
+   }
+   module->OPENSSL_cleanse(digest, sizeof digest);
+   module->OPENSSL_cleanse(input, sizeof input);
+   return success;
+}
+
+static int initial_direction
+  (struct quic_crypto_module *module,
+   const unsigned char initial_secret[SHA256_LENGTH], const char *direction,
+   unsigned char secret[SHA256_LENGTH], unsigned char key[16],
+   unsigned char iv[12], unsigned char hp[16])
+{
+   return hkdf_expand_label(module, initial_secret, direction,
+                            secret, SHA256_LENGTH) &&
+          hkdf_expand_label(module, secret, "quic key", key, 16) &&
+          hkdf_expand_label(module, secret, "quic iv", iv, 12) &&
+          hkdf_expand_label(module, secret, "quic hp", hp, 16);
+}
+
+void *flyology_quic_openssl_create(const char *directory,
+                                    char *error, size_t error_size)
+{
+   return load_module(directory, error, error_size);
+}
+
+void flyology_quic_openssl_release(void *handle)
+{
+   release_module(handle);
+}
+
+int flyology_quic_openssl_initial_keys
+  (void *handle, const unsigned char *connection_id, size_t connection_id_length,
+   unsigned char client_secret[32], unsigned char client_key[16],
+   unsigned char client_iv[12], unsigned char client_hp[16],
+   unsigned char server_secret[32], unsigned char server_key[16],
+   unsigned char server_iv[12], unsigned char server_hp[16],
+   char *error, size_t error_size)
+{
+   static const unsigned char initial_salt[20] = {
+      0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17,
+      0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a
+   };
+   struct quic_crypto_module *module = handle;
+   unsigned char initial_secret[SHA256_LENGTH];
+   int success = 0;
+
+   if (module == NULL || (connection_id_length != 0 && connection_id == NULL) ||
+       client_secret == NULL || client_key == NULL || client_iv == NULL ||
+       client_hp == NULL || server_secret == NULL || server_key == NULL ||
+       server_iv == NULL || server_hp == NULL) {
+      set_error(error, error_size, "invalid QUIC initial-key arguments");
+      return -1;
+   }
+   if (!hmac_sha256(module, initial_salt, sizeof initial_salt,
+                    connection_id, connection_id_length, initial_secret) ||
+       !initial_direction(module, initial_secret, "client in",
+                          client_secret, client_key, client_iv, client_hp) ||
+       !initial_direction(module, initial_secret, "server in",
+                          server_secret, server_key, server_iv, server_hp)) {
+      provider_error(module, error, error_size,
+                     "OpenSSL QUIC initial-key derivation failed");
+      goto done;
+   }
+   success = 1;
+done:
+   module->OPENSSL_cleanse(initial_secret, sizeof initial_secret);
+   return success ? 0 : -1;
+}
+
+#define EVP_CTRL_AEAD_SET_IVLEN 0x9
+#define EVP_CTRL_AEAD_GET_TAG 0x10
+
+int flyology_quic_openssl_protect
+  (void *handle, const unsigned char key[16], const unsigned char nonce[12],
+   const unsigned char *header, size_t header_length,
+   const unsigned char *plaintext, size_t plaintext_length,
+   unsigned char *ciphertext, size_t ciphertext_length,
+   char *error, size_t error_size)
+{
+   struct quic_crypto_module *module = handle;
+   EVP_CIPHER_CTX *context = NULL;
+   int produced = 0;
+   int final_length = 0;
+   int success = 0;
+
+   if (module == NULL || key == NULL || nonce == NULL || ciphertext == NULL ||
+       plaintext_length > INT32_MAX || header_length > INT32_MAX ||
+       plaintext_length > SIZE_MAX - 16 ||
+       ciphertext_length != plaintext_length + 16 ||
+       (header_length != 0 && header == NULL) ||
+       (plaintext_length != 0 && plaintext == NULL)) {
+      set_error(error, error_size, "invalid QUIC payload-protection arguments");
+      return -1;
+   }
+   module->ERR_clear_error();
+   context = module->EVP_CIPHER_CTX_new();
+   if (context == NULL ||
+       module->EVP_EncryptInit_ex(context, module->EVP_aes_128_gcm(), NULL,
+                                  NULL, NULL) != 1 ||
+       module->EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_AEAD_SET_IVLEN,
+                                   12, NULL) != 1 ||
+       module->EVP_EncryptInit_ex(context, NULL, NULL, key, nonce) != 1 ||
+       (header_length != 0 &&
+        module->EVP_EncryptUpdate(context, NULL, &produced, header,
+                                  (int)header_length) != 1) ||
+       (plaintext_length != 0 &&
+        module->EVP_EncryptUpdate(context, ciphertext, &produced, plaintext,
+                                  (int)plaintext_length) != 1) ||
+       module->EVP_EncryptFinal_ex(context, ciphertext + produced,
+                                   &final_length) != 1 ||
+       (size_t)(produced + final_length) != plaintext_length ||
+       module->EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_AEAD_GET_TAG, 16,
+                                   ciphertext + plaintext_length) != 1) {
+      provider_error(module, error, error_size,
+                     "OpenSSL QUIC payload protection failed");
+      goto done;
+   }
+   success = 1;
+done:
+   if (context != NULL) module->EVP_CIPHER_CTX_free(context);
+   return success ? 0 : -1;
+}
+
+int flyology_quic_openssl_header_mask
+  (void *handle, const unsigned char key[16],
+   const unsigned char sample[16], unsigned char mask[5],
+   char *error, size_t error_size)
+{
+   struct quic_crypto_module *module = handle;
+   EVP_CIPHER_CTX *context = NULL;
+   unsigned char block[16];
+   int produced = 0;
+   int final_length = 0;
+   int success = 0;
+
+   memset(block, 0, sizeof block);
+   if (module == NULL || key == NULL || sample == NULL || mask == NULL) {
+      set_error(error, error_size, "invalid QUIC header-mask arguments");
+      return -1;
+   }
+   module->ERR_clear_error();
+   context = module->EVP_CIPHER_CTX_new();
+   if (context == NULL ||
+       module->EVP_EncryptInit_ex(context, module->EVP_aes_128_ecb(), NULL,
+                                  key, NULL) != 1 ||
+       module->EVP_CIPHER_CTX_set_padding(context, 0) != 1 ||
+       module->EVP_EncryptUpdate(context, block, &produced, sample, 16) != 1 ||
+       module->EVP_EncryptFinal_ex(context, block + produced,
+                                   &final_length) != 1 ||
+       produced + final_length != 16) {
+      provider_error(module, error, error_size,
+                     "OpenSSL QUIC header protection failed");
+      goto done;
+   }
+   memcpy(mask, block, 5);
+   success = 1;
+done:
+   module->OPENSSL_cleanse(block, sizeof block);
+   if (context != NULL) module->EVP_CIPHER_CTX_free(context);
+   return success ? 0 : -1;
+}

--- a/flyology_quic/tests/alire.toml
+++ b/flyology_quic/tests/alire.toml
@@ -1,0 +1,19 @@
+name = "flyology_quic_tests"
+description = "RFC-vector tests for flyology_quic"
+version = "0.1.0-dev"
+
+authors = ["Yurii Rashkovskii"]
+maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]
+licenses = "MIT OR Apache-2.0"
+executables = [
+  "flyology-quic-crypto_openssl-smoke",
+  "flyology-quic-packet_number_policy-smoke",
+  "flyology-quic-protection_policy-smoke",
+  "flyology-quic-varint_policy-smoke",
+]
+
+[[depends-on]]
+flyology_quic = "*"
+
+[[pins]]
+flyology_quic = { path = ".." }

--- a/flyology_quic/tests/flyology_quic_tests.gpr
+++ b/flyology_quic/tests/flyology_quic_tests.gpr
@@ -1,0 +1,19 @@
+with "flyology_quic";
+
+project Flyology_QUIC_Tests is
+   for Languages use ("Ada");
+   for Source_Dirs use ("src");
+   for Object_Dir use "obj";
+   for Exec_Dir use "bin";
+   for Main use
+     ("flyology-quic-crypto_openssl-smoke.adb",
+      "flyology-quic-packet_number_policy-smoke.adb",
+      "flyology-quic-protection_policy-smoke.adb",
+      "flyology-quic-varint_policy-smoke.adb");
+   for Create_Missing_Dirs use "True";
+
+   package Compiler is
+      for Default_Switches ("Ada") use
+        ("-gnat2022", "-O2", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ");
+   end Compiler;
+end Flyology_QUIC_Tests;

--- a/flyology_quic/tests/qualification.md
+++ b/flyology_quic/tests/qualification.md
@@ -1,0 +1,49 @@
+# QUIC qualification contract
+
+Flyology QUIC uses layered oracles. Passing a lower layer does not substitute
+for the next layer.
+
+## Wire and cryptography
+
+- RFC 9000 examples cover variable integers and packet-number reconstruction.
+- Boundary tests cover every variable-integer width and the maximum packet
+  number gap representable by QUIC's four-byte packet-number field.
+- RFC 9001 Appendix A covers both v1 Initial traffic secrets, keys, IVs,
+  header-protection keys, AES-GCM output, authentication tag, and header mask.
+- SPARK discharges the arithmetic, range, index, and contract checks in the
+  wire-policy units.
+
+These checks are deterministic and run in `./scripts/test.sh` and
+`./scripts/prove.sh`.
+
+## Network interoperability
+
+Once the first complete Initial handshake exists, `scripts/interop.sh` will
+run the Ada endpoint in both roles against two independent black-box peers:
+
+- quic-go, for a separately implemented QUIC transport and HTTP/3 stack;
+- aioquic, for packet-level diagnostics and scripted adverse-network cases.
+
+The peers are test processes only. They are not linked, vendored into the
+library, or used to implement protocol state. quiche and ngtcp2 are excluded
+from both the library and the primary oracle matrix.
+
+The interop lock will pin exact peer revisions and artifact hashes. The gate
+will cover at least:
+
+1. Ada client to each oracle server and each oracle client to the Ada server.
+2. Version negotiation, Retry, connection-ID changes, and stateless reset.
+3. Coalesced Initial and Handshake packets, reordered packets, duplicates,
+   loss, PTO, and key discard.
+4. Flow control, stream limits, reset/stop semantics, graceful close, and idle
+   timeout.
+5. Wildcard and concrete IPv4/IPv6 binds, local-address preservation,
+   truncation rejection, NAT rebinding, and path validation.
+6. Anti-amplification accounting, 1200-byte Initial datagrams, PMTU boundaries,
+   and ECN when the platform exposes it.
+7. HTTP/3 control streams, SETTINGS, QPACK blocking limits, requests,
+   responses, cancellation, and malformed peer behavior.
+
+The initial handshake milestone is not complete until both directions pass
+against at least one oracle. Client/server publication is not complete until
+the full two-oracle matrix passes in CI.

--- a/flyology_quic/tests/src/flyology-quic-crypto_openssl-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-crypto_openssl-smoke.adb
@@ -1,0 +1,110 @@
+procedure Flyology.QUIC.Crypto_OpenSSL.Smoke is
+   use type Ada.Streams.Stream_Element;
+   use type Ada.Streams.Stream_Element_Array;
+   use type Ada.Streams.Stream_Element_Offset;
+
+   function Nibble (Value : Character) return Natural is
+     (case Value is
+         when '0' .. '9' => Character'Pos (Value) - Character'Pos ('0'),
+         when 'a' .. 'f' => Character'Pos (Value) - Character'Pos ('a') + 10,
+         when 'A' .. 'F' => Character'Pos (Value) - Character'Pos ('A') + 10,
+         when others => raise Constraint_Error);
+
+   function Hex (Value : String) return Ada.Streams.Stream_Element_Array is
+      Result : Ada.Streams.Stream_Element_Array
+        (1 .. Ada.Streams.Stream_Element_Offset (Value'Length / 2));
+      Source : Positive := Value'First;
+   begin
+      pragma Assert (Value'Length mod 2 = 0);
+      for Element of Result loop
+         Element :=
+           Ada.Streams.Stream_Element
+             (16 * Nibble (Value (Source)) + Nibble (Value (Source + 1)));
+         Source := Source + 2;
+      end loop;
+      return Result;
+   end Hex;
+
+   Backend : Provider;
+   Keys    : Initial_Keys;
+begin
+   Initialize_Provider (Backend);
+   pragma Assert (Is_Available (Backend));
+   Derive_V1_Initial (Backend, Hex ("8394c8f03e515708"), Keys);
+
+   --  RFC 9001 Appendix A.1 verifies both directions of the v1 Initial key
+   --  schedule independently of the implementation.
+   pragma Assert
+     (Keys.Client_Secret =
+        Hex ("c00cf151ca5be075ed0ebfb5c80323c4" &
+             "2d6b7db67881289af4008f1f6c357aea"));
+   pragma Assert
+     (Keys.Client_Key = Hex ("1f369613dd76d5467730efcbe3b1a22d"));
+   pragma Assert (Keys.Client_IV = Hex ("fa044b2f42a3fd3b46fb255c"));
+   pragma Assert
+     (Keys.Client_HP = Hex ("9f50449e04a0e810283a1e9933adedd2"));
+   pragma Assert
+     (Keys.Server_Secret =
+        Hex ("3c199828fd139efd216c155ad844cc81" &
+             "fb82fa8d7446fa7d78be803acdda951b"));
+   pragma Assert
+     (Keys.Server_Key = Hex ("cf3a5331653c364c88f0f379b6067e37"));
+   pragma Assert (Keys.Server_IV = Hex ("0ac1493ca1905853b0bba03e"));
+   pragma Assert
+     (Keys.Server_HP = Hex ("c206b8d9b9f0f37644430b490eeaa314"));
+
+   declare
+      Crypto_Frame : constant Ada.Streams.Stream_Element_Array :=
+        Hex
+          ("060040f1010000ed0303ebf8fa56f129" &
+           "39b9584a3896472ec40bb863cfd3e868" &
+           "04fe3a47f06a2b69484c000004130113" &
+           "02010000c000000010000e00000b6578" &
+           "616d706c652e636f6dff01000100000a" &
+           "00080006001d00170018001000070005" &
+           "04616c706e0005000501000000000033" &
+           "00260024001d00209370b2c9caa47fba" &
+           "baf4559fedba753de171fa71f50f1ce1" &
+           "5d43e994ec74d748002b000302030400" &
+           "0d0010000e0403050306030203080408" &
+           "050806002d00020101001c0002400100" &
+           "3900320408ffffffffffffffff050480" &
+           "00ffff07048000ffff08011001048000" &
+           "75300901100f088394c8f03e51570806" &
+           "048000ffff");
+      Header : constant Ada.Streams.Stream_Element_Array :=
+        Hex ("c300000001088394c8f03e5157080000449e00000002");
+      Plaintext  : Ada.Streams.Stream_Element_Array (1 .. 1_162) :=
+        (others => 0);
+      Ciphertext : Ada.Streams.Stream_Element_Array (1 .. 1_178);
+      Nonce      : AES_GCM_IV := Keys.Client_IV;
+      Sample     : Header_Sample;
+      Mask       : Header_Mask;
+      Protected_Header : Ada.Streams.Stream_Element_Array (Header'Range) :=
+        Header;
+   begin
+      Plaintext (1 .. Crypto_Frame'Length) := Crypto_Frame;
+      Nonce (Nonce'Last) := Nonce (Nonce'Last) xor 2;
+      Protect
+        (Backend, Keys.Client_Key, Nonce, Header, Plaintext, Ciphertext);
+
+      Sample := Ciphertext (1 .. 16);
+      pragma Assert (Sample = Hex ("d1b1c98dd7689fb8ec11d242b123dc9b"));
+      pragma Assert
+        (Ciphertext (Ciphertext'Last - 15 .. Ciphertext'Last) =
+           Hex ("e221af44860018ab0856972e194cd934"));
+
+      Make_Header_Mask (Backend, Keys.Client_HP, Sample, Mask);
+      pragma Assert (Mask = Hex ("437b9aec36"));
+      Protected_Header (Protected_Header'First) :=
+        Protected_Header (Protected_Header'First) xor (Mask (1) and 16#0F#);
+      for Offset in Ada.Streams.Stream_Element_Offset range 0 .. 3 loop
+         Protected_Header (Protected_Header'Last - 3 + Offset) :=
+           Protected_Header (Protected_Header'Last - 3 + Offset)
+             xor Mask (Offset + 2);
+      end loop;
+      pragma Assert
+        (Protected_Header =
+           Hex ("c000000001088394c8f03e5157080000449e7b9aec34"));
+   end;
+end Flyology.QUIC.Crypto_OpenSSL.Smoke;

--- a/flyology_quic/tests/src/flyology-quic-crypto_openssl-smoke.ads
+++ b/flyology_quic/tests/src/flyology-quic-crypto_openssl-smoke.ads
@@ -1,0 +1,1 @@
+private procedure Flyology.QUIC.Crypto_OpenSSL.Smoke;

--- a/flyology_quic/tests/src/flyology-quic-packet_number_policy-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-packet_number_policy-smoke.adb
@@ -1,0 +1,20 @@
+procedure Flyology.QUIC.Packet_Number_Policy.Smoke is
+begin
+   pragma Assert
+     (Select_Length (16#AC5C02#, True, 16#ABE8B3#) = 2);
+   pragma Assert
+     (Select_Length (16#ACE8FE#, True, 16#ABE8B3#) = 3);
+   pragma Assert (Select_Length (0, False, 0) = 1);
+
+   --  Four bytes represent at most 2**31 contiguous unacknowledged numbers.
+   pragma Assert (Is_Representable (2**31 - 1, False, 0));
+   pragma Assert (Select_Length (2**31 - 1, False, 0) = 4);
+   pragma Assert (not Is_Representable (2**31, False, 0));
+   pragma Assert (Is_Representable (2**31, True, 0));
+   pragma Assert (not Is_Representable (2**31 + 1, True, 0));
+
+   pragma Assert (Reconstruct (16#A82F30EA#, 16#9B32#, 2) = 16#A82F9B32#);
+   pragma Assert (Reconstruct (16#01F0#, 16#10#, 1) = 16#0210#);
+   pragma Assert (Reconstruct (16#01FF#, 16#F0#, 1) = 16#01F0#);
+   pragma Assert (Reconstruct (16#00FF#, 16#80#, 1) = 16#0180#);
+end Flyology.QUIC.Packet_Number_Policy.Smoke;

--- a/flyology_quic/tests/src/flyology-quic-packet_number_policy-smoke.ads
+++ b/flyology_quic/tests/src/flyology-quic-packet_number_policy-smoke.ads
@@ -1,0 +1,1 @@
+private procedure Flyology.QUIC.Packet_Number_Policy.Smoke;

--- a/flyology_quic/tests/src/flyology-quic-protection_policy-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-protection_policy-smoke.adb
@@ -1,0 +1,28 @@
+procedure Flyology.QUIC.Protection_Policy.Smoke is
+   use type Ada.Streams.Stream_Element;
+   use type Ada.Streams.Stream_Element_Array;
+
+   IV : constant Nonce :=
+     (16#FA#, 16#04#, 16#4B#, 16#2F#, 16#42#, 16#A3#,
+      16#FD#, 16#3B#, 16#46#, 16#FB#, 16#25#, 16#5C#);
+begin
+   pragma Assert
+     (Make_Nonce (IV, 2) =
+        Nonce'
+          (16#FA#, 16#04#, 16#4B#, 16#2F#, 16#42#, 16#A3#,
+           16#FD#, 16#3B#, 16#46#, 16#FB#, 16#25#, 16#5E#));
+
+   declare
+      First  : Ada.Streams.Stream_Element := 16#C3#;
+      Number : Ada.Streams.Stream_Element_Array := (0, 0, 0, 2);
+      Mask   : constant Header_Mask :=
+        (16#43#, 16#7B#, 16#9A#, 16#EC#, 16#36#);
+   begin
+      Apply_Header_Protection (First, Number, True, Mask);
+      pragma Assert (First = 16#C0#);
+      pragma Assert (Number = (16#7B#, 16#9A#, 16#EC#, 16#34#));
+      Apply_Header_Protection (First, Number, True, Mask);
+      pragma Assert (First = 16#C3#);
+      pragma Assert (Number = (0, 0, 0, 2));
+   end;
+end Flyology.QUIC.Protection_Policy.Smoke;

--- a/flyology_quic/tests/src/flyology-quic-protection_policy-smoke.ads
+++ b/flyology_quic/tests/src/flyology-quic-protection_policy-smoke.ads
@@ -1,0 +1,1 @@
+private procedure Flyology.QUIC.Protection_Policy.Smoke;

--- a/flyology_quic/tests/src/flyology-quic-varint_policy-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-varint_policy-smoke.adb
@@ -1,0 +1,71 @@
+procedure Flyology.QUIC.Varint_Policy.Smoke is
+   use type Ada.Streams.Stream_Element;
+   use type Ada.Streams.Stream_Element_Array;
+
+   procedure Check
+     (Wire  : Ada.Streams.Stream_Element_Array;
+      Value : Value_Type)
+   is
+      Result  : constant Decode_Result := Decode (Wire);
+      Encoded : constant Encoded_Value := Encode (Value);
+   begin
+      pragma Assert (Result.Status = Decoded);
+      pragma Assert (Result.Value = Value);
+      pragma Assert (Result.Consumed = Wire'Length);
+      pragma Assert
+        (Encoded.Data (1 .. Ada.Streams.Stream_Element_Offset (Encoded.Length))
+         = Wire);
+   end Check;
+
+   procedure Check_Roundtrip (Value : Value_Type) is
+      Encoded : constant Encoded_Value := Encode (Value);
+      Result  : constant Decode_Result :=
+        Decode
+          (Encoded.Data
+             (1 .. Ada.Streams.Stream_Element_Offset (Encoded.Length)));
+   begin
+      pragma Assert (Result.Status = Decoded);
+      pragma Assert (Result.Value = Value);
+      pragma Assert (Result.Consumed = Encoded.Length);
+   end Check_Roundtrip;
+begin
+   --  Published RFC 9000 Appendix A.1 values.
+   Check ((1 => 16#25#), 37);
+   Check ((16#7B#, 16#BD#), 15_293);
+   Check ((16#9D#, 16#7F#, 16#3E#, 16#7D#), 494_878_333);
+   Check
+     ((16#C2#, 16#19#, 16#7C#, 16#5E#,
+       16#FF#, 16#14#, 16#E8#, 16#8C#),
+      151_288_809_941_952_652);
+
+   Check_Roundtrip (0);
+   Check_Roundtrip (63);
+   Check_Roundtrip (64);
+   Check_Roundtrip (16_383);
+   Check_Roundtrip (16_384);
+   Check_Roundtrip (1_073_741_823);
+   Check_Roundtrip (1_073_741_824);
+   Check_Roundtrip (Value_Type'Last);
+
+   declare
+      State : Value_Type := 16#0123_4567_89AB_CDEF#;
+   begin
+      for Iteration in 1 .. 10_000 loop
+         State := (State * 6_364_136_223_846_793_005 + 1) mod 2**62;
+         Check_Roundtrip (State);
+      end loop;
+   end;
+
+   declare
+      Result  : constant Decode_Result := Decode ((16#40#, 16#25#));
+      Encoded : constant Encoded_Value := Encode (37);
+   begin
+      pragma Assert (Result.Status = Decoded and then Result.Value = 37);
+      pragma Assert (Encoded.Length = 1 and then Encoded.Data (1) = 16#25#);
+   end;
+
+   pragma Assert (Decode ((1 => 16#40#)).Status = Truncated);
+   pragma Assert (Decode ((16#80#, 0, 0)).Status = Truncated);
+   pragma Assert (Decode ((16#C0#, 0, 0, 0, 0, 0, 0)).Status = Truncated);
+   pragma Assert (Decode ((1 .. 0 => 0)).Status = Truncated);
+end Flyology.QUIC.Varint_Policy.Smoke;

--- a/flyology_quic/tests/src/flyology-quic-varint_policy-smoke.ads
+++ b/flyology_quic/tests/src/flyology-quic-varint_policy-smoke.ads
@@ -1,0 +1,1 @@
+private procedure Flyology.QUIC.Varint_Policy.Smoke;

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -22,6 +22,8 @@ if ! command -v gnatdoc >/dev/null 2>&1; then
   export PATH
 fi
 
+"$project_root/flyology_quic/scripts/docs.sh"
+
 cd "$project_root"
 FLYOLOGY_HTTP_DOCUMENTATION=true
 export FLYOLOGY_HTTP_DOCUMENTATION

--- a/scripts/prove.sh
+++ b/scripts/prove.sh
@@ -4,6 +4,8 @@ set -eu
 http_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 alr=$("$http_root/scripts/find-alr.sh")
 
+"$http_root/flyology_quic/scripts/prove.sh"
+
 cd "$http_root/proof"
 "$alr" build --stop-after=generation
 "$alr" gnatprove \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -81,6 +81,16 @@ compile_and_link () {
 
 cd "$http_root"
 "$http_root/flyology_iri/scripts/test.sh"
+if [ -n "${FLYOLOGY_HTTP_TEST_IN_ALIRE:-}" ]; then
+  env \
+    -u FLYOLOGY_ALIRE_PREFIX \
+    -u FLYOLOGY_ROOT \
+    -u GPR_CONFIG \
+    -u GPR_PROJECT_PATH \
+    "$http_root/flyology_quic/scripts/test.sh"
+else
+  "$http_root/flyology_quic/scripts/test.sh"
+fi
 "$http_root/scripts/prepare-test-tls.sh"
 if [ -z "${FLYOLOGY_HTTP_TEST_IN_ALIRE:-}" ]; then
   "$alr" build


### PR DESCRIPTION
## What changed

- add `flyology_quic` as an independent nested Alire crate in the Flyology HTTP repository
- keep QUIC wire policy and OpenSSL cryptographic operations outside the Flyology runtime crate
- prove variable-integer, packet-number, nonce, and header-protection policy
- verify the QUIC v1 Initial key schedule and packet protection against RFC 9001 vectors
- reject packet-number gaps that cannot be represented in QUIC's maximum four-byte field
- define the future quic-go/aioquic black-box qualification matrix
- include the nested crate in repository test, proof, and documentation gates

## Why

QUIC and HTTP/3 policy belong with the HTTP protocol project, while Flyology
should expose only task-aware UDP, buffers, deadlines, cancellation, and runtime
integration. This makes that boundary explicit and lets the QUIC transport be
built and qualified independently.

## Validation

- `flyology_quic/scripts/test.sh`: pass (4 RFC-vector programs)
- `flyology_quic/scripts/prove.sh`: pass (all 120 checks proved)
- `flyology_quic/scripts/docs.sh`: pass
- `./scripts/prove.sh`: pass (120 QUIC and 247 HTTP checks proved)
- `./scripts/docs.sh`: pass
- `./scripts/test.sh`: pass after rebasing onto repaired `main`
  (`ce4563e8041571a64f3a45edf11f6a866348d0db`)
- repaired `main` CI: pass on Linux, macOS, and HTTP/2 qualification:
  https://github.com/flyology-ada/flyology-http/actions/runs/31200932399
