### PR TITLE
Align body-adapter smoke test with zero-timeout file reads

### DIFF
--- a/tests/http_client_body_adapters_smoke.adb
+++ b/tests/http_client_body_adapters_smoke.adb
@@ -317,16 +317,12 @@ procedure HTTP_Client_Body_Adapters_Smoke is
          declare
             Buffer : Stream_Element_Array (1 .. 1);
             Last   : Stream_Element_Offset;
-            Raised : Boolean := False;
          begin
-            begin
-               Files.Read_At
-                 (File, 0, Buffer, Last, Timeout => 0.0);
-            exception
-               when Flyology.IO.Timeout_Error =>
-                  Raised := True;
-            end;
-            pragma Assert (Raised);
+            Files.Read_At (File, 0, Buffer, Last, Timeout => 0.0);
+            pragma Assert
+              (Last = Buffer'Last
+                 and then Buffer (Buffer'First) =
+                   Stream_Element (Character'Pos ('x')));
          end;
          Files.Close (File);
       exception


### PR DESCRIPTION
## What changed

The file-body adapter smoke test now verifies that the borrowed file descriptor remains usable after upload by performing the documented zero-timeout immediate read and checking the exact byte returned.

## Root cause

`Flyology.IO.Files.Read_At` defines `Timeout => 0.0` as one immediate positional read attempt; it does not raise `Timeout_Error`. The old assertion therefore failed after the `/file` exchange. Stack unwinding finalized the HTTP client and closed the keep-alive connection while the raw server was waiting for `/channel`, causing the secondary EOF assertion at line 127.

## Validation

- focused `http_client_body_adapters_smoke`: 10 consecutive passes on macOS
- `./scripts/test.sh`: complete pass, including `PASS http_client_body_adapters_smoke` and `Flyology HTTP behavioral suite passed`

No public specifications or proved policy units changed, so AGENTS.md does not require docs or proof runs.
