### PR TITLE
Improve HTTP stack throughput and bring H3 to local H2 parity

### DIFF
--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -89,7 +89,7 @@ connection-retirement/lifecycle pressure signal, not a steady-state result.
 ## Baselines and final measurements
 
 The baseline table uses medians of three controlled trials where available.
-The final row is the last clean 16-loop post-change run after qualification.
+The final H3 row is the last clean 16-loop post-change run after qualification.
 Latency values are milliseconds. All requests succeeded.
 
 | Configuration | Requests/s | p50 | p95 | p99 | Concurrency and reuse |
@@ -98,6 +98,7 @@ Latency values are milliseconds. All requests succeeded.
 | H2, 1 loop, baseline | 19,783 | 3.17 | 4.09 | 4.54 | 4 connections x 16 streams |
 | H2, 1 loop, reusable handlers median | **29,002** | 1.929 | 3.198 | 6.005 | same; +49.2% against fresh 19,444 median |
 | H2, 1 loop, direct HPACK match median | **39,187** | 1.637 | 1.710 | 1.891 | same; +35.1% over reusable handlers |
+| H2, 1 loop, retained wake sources median | **44,804** | 1.4 | 1.5 | 1.6 | same; +14.3% over direct HPACK match |
 | H3, 1 Python worker, baseline | 13,768 | 10.320 | 18.111 | 19.454 | 16 connections x 16 streams |
 | H3, 1 server loop saturated, baseline | 25,725 | 36.64 | — | — | 4 workers, 64 connections x 16 streams |
 | H3, 1 server loop, ACK candidate | 26,827 | 35.25 | — | — | same; +4.3% rate, -3.8% p50 |
@@ -107,6 +108,7 @@ Latency values are milliseconds. All requests succeeded.
 | H2, 16 loops, baseline median | 32,035 | 1.946 | 2.552 | 2.795 | 4 connections x 16 streams |
 | H2, 16 loops, reusable handlers median | **89,856** | 0.533 | 0.987 | 5.762 | same; +180.5% |
 | H2, 16 loops, direct HPACK match median | 90,237 | 0.540 | 0.855 | 3.927 | same; +0.4%, neutral |
+| H2, 16 loops, retained wake sources median | **147,435** | 0.3 | 0.6 | 3.0 | same; +63.4% over direct HPACK match |
 | H3, 16 loops, baseline | 54,123 | — | — | — | 8 workers, 128 connections x 16 streams |
 | H3, 16 loops, pre-QPACK best | **58,935** | 24.896 | 51.082 | 78.762 | 8 workers, 128 connections x 16 streams; reuse 6,250x |
 | H3, 16 loops, QPACK median | 57,222 | 26.617 | 46.145 | 65.833 | same; neutral within run noise |
@@ -174,6 +176,29 @@ sampled throughput increased by about 26%. At 16 loops, three trials were
 90.629k, 89.036k, and 90.237k (90.237k median, +0.4%); the change is neutral
 once other work limits throughput.
 
+The next profile showed that stream teardown still called `close` 181 times
+and `pipe` 136 times in the sample, beside `fcntl` 301. Each completed request
+released the wake source owned by its bounded stream slot, so the next stream
+occupying that slot recreated and configured a pipe pair. The controller now
+drains any pending notification but retains the descriptor generation until
+the connection's controlled finalization. Ownership remains bounded to at
+most 32 lazy wake sources per H2 connection.
+
+With the identical one-loop command, three retained-source trials were
+44.804k, 44.862k, and 43.991k requests/s (44.804k median, +14.3% over
+39.187k). The median p50 was 1.4 ms, p95 1.5 ms, and p99 1.6 ms. In the
+candidate sample, `pipe`, `close`, and `fcntl` disappeared from the leading
+list while sampled throughput rose; the remaining named leaders included
+socket `write` 678, scheduler current-task 421, task-local lookup 301, socket
+`read` 275, `memcmp` 263, and HPACK static lookup 110.
+
+A clean 16-loop build, positively probed as 16, measured 147.643k, 143.649k,
+and 147.435k requests/s (147.435k median, +63.4%). A longer 30-second run
+sustained 149.576k requests/s and validated 4,489,030 responses before the
+time deadline. These short-body localhost results are machine-local and show
+that descriptor lifecycle had also limited scaling; they are not a portable
+server rating.
+
 The post-change 16-loop connection sweep held streams per connection at 16
 and sent 100,000 validated requests per point:
 
@@ -187,6 +212,24 @@ and sent 100,000 validated requests per point:
 
 Throughput saturates around 128 in flight. Doubling concurrency beyond that
 reduces rate and sharply worsens tail latency.
+
+A second post-change sweep held total maximum concurrency at 64 while trading
+connections against streams per connection. This separates useful parallel
+connection ownership from merely adding more in-flight work:
+
+| Connections x streams | Maximum in flight | Requests/s |
+| ---: | ---: | ---: |
+| 2 x 32 | 64 | 93,273 |
+| 4 x 16 | 64 | **146,961** |
+| 8 x 8 | 64 | 127,019 |
+| 16 x 4 | 64 | 71,391 |
+| 32 x 2 | 64 | 38,779 |
+| 64 x 1 | 64 | 22,923 |
+
+Four reused connections were the local optimum. Two connections expose
+per-connection controller serialization; eight or more add TLS/socket and
+scheduling work faster than they add useful parallelism. Consequently, the
+147k result is not evidence that connection count itself should be maximized.
 
 ### H3 client concurrency
 
@@ -252,7 +295,17 @@ builds were excluded from all reported rates.
    The independent 500-case HPACK and 1,000-case Huffman differential suites,
    full repository tests, and complete H2 qualification passed.
 
-3. **Packet output and descriptor/source-address work dominate the H3
+3. **HTTP/2 stream-slot reuse recreated wake descriptors per request.** Each
+   released slot destroyed its lazy wake source, so reuse paid for pipe
+   creation, descriptor configuration, and close even though the controller
+   and its 32 slots remained alive. Completed slots now drain pending wakeups
+   and retain their source until connection finalization. One-loop median
+   throughput improved from 39.187k to 44.804k requests/s (+14.3%), and the
+   16-loop median improved from 90.237k to 147.435k (+63.4%). `pipe`, `close`,
+   and `fcntl` disappeared from the leading post-change sample. Full repository
+   tests and the complete H2 qualification passed again.
+
+4. **Packet output and descriptor/source-address work dominate the H3
    server.** In the active 16-loop server sample the leading stacks included
    `sendmsg` (56,142 samples), `kevent` (7,759), `memmove` (4,822), `fcntl`
    (3,052), `memset` (1,684), `setsockopt` (1,364), scheduler current-fiber
@@ -263,7 +316,7 @@ builds were excluded from all reported rates.
    call. Caching verified local endpoint data and packet batching are plausible
    upstream work. This crate was not changed to work around Flyology core.
 
-4. **QPACK response encoding repeatedly constructed static-table names.** At
+5. **QPACK response encoding repeatedly constructed static-table names.** At
    one-loop server saturation, the encoder's exact lookup called the static
    table `Name` function for up to 99 entries per response header. Returning
    unconstrained strings drove secondary-stack allocation and lightweight-task
@@ -278,7 +331,7 @@ builds were excluded from all reported rates.
    and 55.65k, neutral relative to the previous 58.94k best once client and
    packet I/O dominate.
 
-5. **ACK processing copied large retransmission tables per packet.** The
+6. **ACK processing copied large retransmission tables per packet.** The
    application-space packet transaction copied a roughly 72 KiB
    retransmittable table plus packet-frame table before applying ACK events.
    The accepted change stages only the bounded packet-event resolution log,
@@ -287,7 +340,7 @@ builds were excluded from all reported rates.
    25,725 to 26,827 requests/s (+4.3%); 16-loop results were neutral within
    noise, so no multi-loop gain is attributed to this change.
 
-6. **The Ada H3 client allocated a large event object twice per request.** A
+7. **The Ada H3 client allocated a large event object twice per request.** A
    pooled connection now retains one event object and frees it with the
    transport. In a 640,000-request, 64-connection optimized Ada-client run,
    rate improved from 31,543 to 35,284 requests/s (+11.9%) and mean latency
@@ -298,7 +351,7 @@ builds were excluded from all reported rates.
    totals differed, so counts support the allocation mechanism rather than an
    exact percentage claim.
 
-7. **Eager per-connection request header slots inflated server memory.** Eight
+8. **Eager per-connection request header slots inflated server memory.** Eight
    bounded slots embedded full header blocks even when unused. Header blocks
    are now allocated on first slot use, retained for the connection, and freed
    during cleanup. At 64 H3 connections peak physical memory fell from 309.9
@@ -306,7 +359,7 @@ builds were excluded from all reported rates.
    MB (about 22%). Throughput remained in the 50k+ band. This is a capacity
    improvement, not a claimed request-rate win.
 
-8. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
+9. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
    13k even against 16 loops. Four workers sustained about 50k; eight reached
    54-59k. The benchmark now records workers explicitly so “single client” is
    not confused with “single Flyology loop.”
@@ -365,6 +418,13 @@ lifecycle pressure.
   itself to eight fields and 1,024 input bytes. It measured 27.250k and
   27.947k requests/s versus a fresh 28.484k baseline median. The lookup and
   retained state cost more than encoding the small response; reverted.
+- Replacing the HTTP/3 datagram channel's fixed-record copies with a bounded
+  preallocated handle pool targeted the leading one-loop `memmove` stack. A
+  clean explicit-custom-RTS baseline measured 30.801k requests/s and the
+  candidate measured 30.837k (+0.12%) with `--requests 400000 --workers 4
+  --connections 64 --streams 16 --timeout 20`. P50/p95/p99 latency was
+  effectively unchanged. The extra ownership machinery had no material
+  benefit, so it was reverted.
 
 ## Correctness qualification
 
@@ -386,7 +446,7 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
 - Full repository behavioral suite: pass, including all 42 QUIC checks.
 - H2: Go, Node, and nghttpd peers passed in native and lightweight models;
   fault campaign and bounded soak passed; h2spec 146/146 passed. The full H2
-  qualification was repeated after both accepted H2 changes. The HPACK and
+  qualification was repeated after all three accepted H2 changes. The HPACK and
   Huffman differential suites passed 500 and 1,000 cases respectively.
 - H3: aioquic and quic-go passed in both Ada client and Ada server roles.
 - h3spec 0.1.13: a first run passed all HTTP/3 and QPACK cases but was 48/49
@@ -411,9 +471,12 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
   throughput decay with a lifecycle-focused diagnostic build.
 - Reduce multi-process client scheduling and packet receive overhead before
   treating 59k as a server ceiling.
-- The post-HPACK H2 profile is led by TLS/socket calls, scheduler/task-local
-  lookup, byte comparison, and remaining bounded header construction. The
-  16-loop sweep saturates around 128 in flight, where client/TLS/socket work
-  limits another codec-only gain.
+- The post-wake-source H2 profile is led by TLS/socket calls,
+  scheduler/task-local lookup, byte comparison, and remaining bounded header
+  construction. One loop reached a 44.8k median and 16 loops a 147.4k median
+  with four connections x 16 streams. At the same total concurrency, both
+  fewer and additional connections regress, locating the next scaling work in
+  per-connection serialization versus TLS/socket/scheduler overhead rather
+  than another indiscriminate concurrency increase.
 - Repeat on a quiescent, thermally controlled machine and on Linux before
   making cross-platform claims.

--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -1,0 +1,251 @@
+# HTTP stack performance notebook, 2026-08-09
+
+These are local experimental measurements, not portable or production-level
+claims. The server, route, clients, machine power state, and process lifecycle
+all materially affect the results.
+
+## Scope and environment
+
+- Baseline: `main` at `8b09b0f4830683d6d76c4e31ffa5dd31a2386988`.
+- Working branch: `codex/http-stack-performance`.
+- Flyology: Alire `0.1.0-dev` at
+  `3808aabcb33d75b06a6a9472eb2342094a66d018`.
+- Machine: MacBook Pro `Mac15,9`, Apple M3 Max, 16 cores (12 performance,
+  4 efficiency), 48 GB RAM.
+- OS: macOS 26.5.2, Darwin 25.5.0, arm64.
+- Clients: oha 1.7.0 for H1/H2; aioquic 1.3.0 for H3.
+- Route: the same Routing API handler at `GET /hello/{name}` over H1, H2,
+  and H3. The default benchmark target was `/hello/test`, status 200 and body
+  `hello test` (10 bytes).
+- Build: release switches (`-O3`, inlining), assertions and validity checks
+  retained by the showcase project, `FLYOLOGY_QUIC_TRACE=false`.
+
+## Runtime preparation and fail-closed checks
+
+Every performance and standalone H3 qualification/stress binary used an
+explicit Flyology lightweight RTS. No H3 performance harness was built or run
+with GNAT's default RTS. The one-loop and 16-loop roots were
+`build/perf-rts-l1` and `build/perf-rts-l16`.
+
+Representative 16-loop preparation and clean build:
+
+```sh
+alr update
+alr with flyology=0.1.0-dev
+
+FLYOLOGY_RTS_DIR="$PWD/build/perf-rts-l16" \
+FLYOLOGY_DEFAULT=lightweight \
+FLYOLOGY_LOOP_POOL_SIZE=16 \
+  /path/to/resolved/flyology/scripts/prepare-rts.sh
+
+test -f build/perf-rts-l16/.flyology-rts-root
+grep -q 'Flyology prepared RTS version' \
+  build/perf-rts-l16/.flyology-rts-root
+grep -q 'Lightweight : constant Boolean := True;' \
+  build/perf-rts-l16/adainclude/s-fldeex.ads
+
+./showcases/prepare-alire.sh release
+cd showcases
+FLYOLOGY_RTS_DIR=../build/perf-rts-l16 \
+  alr exec -- env -u GPR_CONFIG gprclean -r -q -P showcases.gpr
+FLYOLOGY_RTS_DIR=../build/perf-rts-l16 \
+FLYOLOGY_SHOWCASE_PROFILE=release \
+FLYOLOGY_QUIC_TRACE=false \
+  alr exec -- env -u GPR_CONFIG gprbuild \
+    --RTS=../build/perf-rts-l16 -p -P showcases.gpr \
+    http3_application_server.adb http_benchmark_runtime_probe.adb
+./bin/http_benchmark_runtime_probe
+```
+
+The last command must print `16` (`1` for the single-loop build). A prior
+incremental build retained a one-loop binder despite selecting the 16-loop
+directory. Cleaning recursively and requiring the runtime probe prevents that
+metadata error. The H3 interop, h3spec, and stress scripts now also verify both
+the Flyology root marker and the lightweight constant before building.
+
+Server and client commands:
+
+```sh
+FLYOLOGY_QUIC_TRACE=false \
+  ./showcases/bin/http3_application_server 18443 18080
+
+oha -n 200000 -c 64 --http-version 1.1 --insecure --no-tui --json \
+  https://127.0.0.1:18443/hello/test
+oha -n 200000 -c 4 -p 16 --http-version 2 --insecure --no-tui --json \
+  https://127.0.0.1:18443/hello/test
+build/oracle/aioquic/bin/python showcases/http3_benchmark.py \
+  --port 18443 --path /hello/test --requests 800000 \
+  --workers 8 --connections 128 --streams 16 --timeout 20
+```
+
+The H3 fixture keeps connections open, validates every status/body, separates
+handshake and request latency, reports connection reuse, and uses multiple
+processes when one Python event loop would be the limiting component. A fresh
+server was used for each high-connection trial. Reusing one server across
+successive 128-new-connection trials degraded from 53.9k to 41.7k to 35.4k
+requests/s while median handshake latency rose from 69 to 200 ms; this is a
+connection-retirement/lifecycle pressure signal, not a steady-state result.
+
+## Baselines and final measurements
+
+The baseline table uses medians of three controlled trials where available.
+The final row is the last clean 16-loop post-change run after qualification.
+Latency values are milliseconds. All requests succeeded.
+
+| Configuration | Requests/s | p50 | p95 | p99 | Concurrency and reuse |
+| --- | ---: | ---: | ---: | ---: | --- |
+| H1, 1 loop, baseline | 34,784 | 0.431 | 0.540 | 0.737 | 16 connections, keep-alive |
+| H2, 1 loop, baseline | 19,783 | 3.17 | 4.09 | 4.54 | 4 connections x 16 streams |
+| H3, 1 Python worker, baseline | 13,768 | 10.320 | 18.111 | 19.454 | 16 connections x 16 streams |
+| H3, 1 server loop saturated, baseline | 25,725 | 36.64 | — | — | 4 workers, 64 connections x 16 streams |
+| H3, 1 server loop, ACK candidate | 26,827 | 35.25 | — | — | same; +4.3% rate, -3.8% p50 |
+| H1, 16 loops, baseline median | 98,299 | 0.459 | 1.700 | 3.285 | 64 connections |
+| H2, 16 loops, baseline median | 32,035 | 1.946 | 2.552 | 2.795 | 4 connections x 16 streams |
+| H3, 16 loops, baseline | 54,123 | — | — | — | 8 workers, 128 connections x 16 streams |
+| H3, 16 loops, final | **58,935** | 24.896 | 51.082 | 78.762 | 8 workers, 128 connections x 16 streams; reuse 6,250x |
+
+The final H3 wall time was 13.574 s for 800,000 requests. Handshake latency was
+55.118 ms mean, 54.984 ms p50, 58.172 ms p95, and 97.680 ms max. The final H1
+and H2 spot checks after the long qualification session were 79,340 and 29,091
+requests/s respectively; both were below their earlier controlled medians, so
+they are recorded as thermal/order-sensitive spot checks rather than
+regressions. Their success rates were 100%.
+
+The original approximately 13.9k H3 result is reproducible, but it measures a
+single aioquic process: the Python client was about 98.5% of one core while the
+server was about 66% of one core. Multiprocess load exposes server capacity.
+With 16 positively probed Flyology loops, sustained H3 crossed 50k and peaked
+in the final clean run at 58.9k. Scaling saturated around 8 client workers:
+16 workers regressed to about 42k because handshake/process/packet pressure
+grew faster than useful server work.
+
+### Size sensitivity
+
+The maintained H3 fixture's `--response-bytes` option expands the same route
+parameter, so both request target and response grow without changing routing
+or protocol behavior. A 1,024-byte case used:
+
+```sh
+build/oracle/aioquic/bin/python showcases/http3_benchmark.py \
+  --port 18443 --response-bytes 1024 --requests 200000 \
+  --workers 8 --connections 128 --streams 16 --timeout 20
+```
+
+| Protocol, 16 loops | Bytes | Requests/s | p50 | p95 | p99 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| H1 | 1,024 | 86,548 | 0.620 | 1.432 | 3.101 |
+| H2 | 1,024 | 25,054 | 2.546 | 2.858 | 3.004 |
+| H3 | 1,024 | 33,746 | 28.916 | 73.220 | 179.143 |
+
+H1's larger-body rate exceeded its immediately preceding 10-byte spot check,
+which confirms material run-order/noise on this laptop; use the latency and H3
+rate drop as the useful size signal, not a cross-run H1 throughput conclusion.
+
+## Profiles and ranked hypotheses
+
+macOS `sample` was used for low-drag server and client sampling. Trace-enabled
+builds were excluded from all reported rates.
+
+1. **Packet output and descriptor/source-address work dominate the H3
+   server.** In the active 16-loop server sample the leading stacks included
+   `sendmsg` (56,142 samples), `kevent` (7,759), `memmove` (4,822), `fcntl`
+   (3,052), `memset` (1,684), `setsockopt` (1,364), scheduler current-fiber
+   work (850), `recvmsg` (715), and `getsockname` (681). QPACK field-name work
+   was only 533 samples and crypto was sparse. Routing and response construction
+   did not dominate. Flyology's native `flyology_socket_send_datagram` calls
+   `getsockname` for every source-selected datagram and emits one `sendmsg` per
+   call. Caching verified local endpoint data and packet batching are plausible
+   upstream work. This crate was not changed to work around Flyology core.
+
+2. **ACK processing copied large retransmission tables per packet.** The
+   application-space packet transaction copied a roughly 72 KiB
+   retransmittable table plus packet-frame table before applying ACK events.
+   The accepted change stages only the bounded packet-event resolution log,
+   applies it after all fallible frame processing succeeds, then commits the
+   smaller sent/recovery candidates. Controlled one-loop median rate improved
+   25,725 to 26,827 requests/s (+4.3%); 16-loop results were neutral within
+   noise, so no multi-loop gain is attributed to this change.
+
+3. **The Ada H3 client allocated a large event object twice per request.** A
+   pooled connection now retains one event object and frees it with the
+   transport. In a 640,000-request, 64-connection optimized Ada-client run,
+   rate improved from 31,543 to 35,284 requests/s (+11.9%) and mean latency
+   from 1.990 to 1.790 ms (-10.1%). Pool diagnostics were 64 created, 639,936
+   reused, 64 idle, zero closed. Before, `madvise` appeared 2,944 times and the
+   body reader's allocation path was hot; afterward `madvise` disappeared from
+   the leading sample and `memset` samples fell from 5,577 to 2,276. Sample
+   totals differed, so counts support the allocation mechanism rather than an
+   exact percentage claim.
+
+4. **Eager per-connection request header slots inflated server memory.** Eight
+   bounded slots embedded full header blocks even when unused. Header blocks
+   are now allocated on first slot use, retained for the connection, and freed
+   during cleanup. At 64 H3 connections peak physical memory fell from 309.9
+   to 250.1 MB (about 19%); at 128 connections RSS fell from about 632 to 495
+   MB (about 22%). Throughput remained in the 50k+ band. This is a capacity
+   improvement, not a claimed request-rate win.
+
+5. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
+   13k even against 16 loops. Four workers sustained about 50k; eight reached
+   54-59k. The benchmark now records workers explicitly so “single client” is
+   not confused with “single Flyology loop.”
+
+Timer scans, QPACK, routing, and cryptography were not leading server samples.
+`kevent` and scheduler samples show normal waits/wakeups, but no lock hotspot
+larger than packet I/O was found. A 2,000,000-request eight-worker run declined
+to 43.1k requests/s with worse tails; client time was 46.97 s real, 168.03 s
+user, 15.86 s system, 156.7 MB maximum RSS, and 588,945 involuntary context
+switches, reinforcing client/process scheduling and long-run connection
+lifecycle pressure.
+
+## Rejected experiments
+
+- A direct QPACK static-name scan passed exhaustive checks but measured
+  13.606k, 12.530k, and 13.533k requests/s against the 13.768k one-worker
+  baseline, with no latency gain. Reverted.
+- Lazy staging of flow/ACK candidates only when affected frames appeared
+  passed all 42 QUIC tests but measured 13.099k, 13.383k, and 13.314k. Typical
+  packets carried ACK work, so the branch did not avoid the dominant copy.
+  Reverted.
+- Increasing workers beyond eight and repeatedly opening new 128-connection
+  generations worsened handshake latency and throughput. Those runs are useful
+  saturation evidence, not accepted tuning changes.
+
+## Correctness qualification
+
+Commands and final results:
+
+```sh
+./scripts/test.sh
+./scripts/http2-test.sh qualification
+FLYOLOGY_QUIC_TRACE=false ./scripts/test-http3-interop.sh all
+FLYOLOGY_QUIC_TRACE=false ./scripts/test-http3-h3spec.sh
+FLYOLOGY_QUIC_TRACE=false \
+FLYOLOGY_HTTP3_STRESS_PEAK_CONCURRENCY=128 \
+FLYOLOGY_HTTP3_CLIENT_STRESS_WORKERS=64 \
+FLYOLOGY_HTTP3_CLIENT_STRESS_REQUESTS=16 \
+FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
+  ./scripts/test-http3-stress.sh
+```
+
+- Full repository behavioral suite: pass, including all 42 QUIC checks.
+- H2: Go, Node, and nghttpd peers passed in native and lightweight models;
+  fault campaign and bounded soak passed; h2spec 146/146 passed.
+- H3: aioquic and quic-go passed in both Ada client and Ada server roles.
+- h3spec 0.1.13: 49/49 passed.
+- Bounded H3 stress: hostile UDP and 64 malformed cases passed; server load
+  passed through 128 connections and 128-way concurrency; Ada client passed
+  1,024/1,024 requests. One preceding identical run had one 60-second aioquic
+  handshake timeout at the 64-connection phase; a fresh-server rerun passed
+  all phases and the isolated timeout is retained here rather than hidden.
+
+## Remaining bottlenecks
+
+- Minimize or batch one-datagram-at-a-time output and cache safe source/local
+  endpoint metadata in Flyology core; reproduce upstream before changing it.
+- Investigate delayed retirement of old H3 connection generations and long-run
+  throughput decay with a lifecycle-focused diagnostic build.
+- Reduce multi-process client scheduling and packet receive overhead before
+  treating 59k as a server ceiling.
+- Repeat on a quiescent, thermally controlled machine and on Linux before
+  making cross-platform claims.

--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -258,6 +258,24 @@ lifecycle pressure.
   completed streams are released immediately, so the common path reuses the
   first free transport entry; retaining a cursor would keep more bounded
   request state live without evidence of scan pressure.
+- Replacing response-validation and QPACK-encoding string results with
+  variable-bound slice renames measured 25.644k and 21.295k requests/s versus
+  a fresh-server baseline median of 28.484k. Tail latency also worsened. The
+  generated variable-slice path was more expensive than the compiler's
+  existing scalarized string-result path. Reverted.
+- Copying only meaningful HTTP/3 field bytes across the public/internal QPACK
+  boundary stalled one load run and measured 23.428k on a clean repeat. Fixed
+  bounded-record assignment was cheaper than the added variable-length work.
+  Reverted.
+- Removing redundant-looking QPACK decoder buffer and record clears measured
+  28.219k, 28.281k, and 28.443k requests/s (28.281k median, -0.7%). Reverted.
+- Additive indexed name/value accessors avoided returning a complete bounded
+  field record but measured 26.241k and 26.486k requests/s. Cross-package
+  string-result overhead outweighed the saved copy. The API addition was
+  removed.
+- Collapsing four high-level request-header searches into one positional pass
+  measured 28.588k, 26.826k, and 29.309k requests/s (28.588k median, +0.36%).
+  The result was inside noise with worse variance, so it was reverted.
 
 ## Correctness qualification
 

--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -99,12 +99,16 @@ Latency values are milliseconds. All requests succeeded.
 | H3, 1 Python worker, baseline | 13,768 | 10.320 | 18.111 | 19.454 | 16 connections x 16 streams |
 | H3, 1 server loop saturated, baseline | 25,725 | 36.64 | — | — | 4 workers, 64 connections x 16 streams |
 | H3, 1 server loop, ACK candidate | 26,827 | 35.25 | — | — | same; +4.3% rate, -3.8% p50 |
+| H3, 1 loop, pre-QPACK median | 27,310 | 32.8 | — | — | 4 workers, 64 connections x 16 streams |
+| H3, 1 loop, QPACK median | **30,097** | 29.6 | — | — | same; +10.2% rate, about -10% p50 |
 | H1, 16 loops, baseline median | 98,299 | 0.459 | 1.700 | 3.285 | 64 connections |
 | H2, 16 loops, baseline median | 32,035 | 1.946 | 2.552 | 2.795 | 4 connections x 16 streams |
 | H3, 16 loops, baseline | 54,123 | — | — | — | 8 workers, 128 connections x 16 streams |
-| H3, 16 loops, final | **58,935** | 24.896 | 51.082 | 78.762 | 8 workers, 128 connections x 16 streams; reuse 6,250x |
+| H3, 16 loops, pre-QPACK best | **58,935** | 24.896 | 51.082 | 78.762 | 8 workers, 128 connections x 16 streams; reuse 6,250x |
+| H3, 16 loops, QPACK median | 57,222 | 26.617 | 46.145 | 65.833 | same; neutral within run noise |
 
-The final H3 wall time was 13.574 s for 800,000 requests. Handshake latency was
+The pre-QPACK 58.9k H3 run took 13.574 s for 800,000 requests. Handshake
+latency was
 55.118 ms mean, 54.984 ms p50, 58.172 ms p95, and 97.680 ms max. The final H1
 and H2 spot checks after the long qualification session were 79,340 and 29,091
 requests/s respectively; both were below their earlier controlled medians, so
@@ -115,9 +119,27 @@ The original approximately 13.9k H3 result is reproducible, but it measures a
 single aioquic process: the Python client was about 98.5% of one core while the
 server was about 66% of one core. Multiprocess load exposes server capacity.
 With 16 positively probed Flyology loops, sustained H3 crossed 50k and peaked
-in the final clean run at 58.9k. Scaling saturated around 8 client workers:
+in a clean run at 58.9k. Scaling saturated around 8 client workers:
 16 workers regressed to about 42k because handshake/process/packet pressure
 grew faster than useful server work.
+
+### H3 client concurrency
+
+The one-loop stream sweep held the client at four Python processes and 64
+total QUIC connections. Maximum in-flight request concurrency is therefore
+`connections x streams`:
+
+| Streams/connection | Maximum in flight | Requests/s | p50 (ms) |
+| ---: | ---: | ---: | ---: |
+| 1 | 64 | 15,231 | 4.271 |
+| 4 | 256 | 19,824 | — |
+| 8 | 512 | 23,482 | — |
+| 16 | 1,024 | 24,804 | — |
+
+This is why a one-loop result can be either about 15k or 25k without a server
+change: 64 in-flight requests do not saturate the same path as 1,024. The
+16-loop final campaign used eight Python processes, 128 total connections,
+and 16 streams per connection, for a maximum of 2,048 in-flight requests.
 
 ### Size sensitivity
 
@@ -157,7 +179,22 @@ builds were excluded from all reported rates.
    call. Caching verified local endpoint data and packet batching are plausible
    upstream work. This crate was not changed to work around Flyology core.
 
-2. **ACK processing copied large retransmission tables per packet.** The
+2. **QPACK response encoding repeatedly constructed static-table names.** At
+   one-loop server saturation, the encoder's exact lookup called the static
+   table `Name` function for up to 99 entries per response header. Returning
+   unconstrained strings drove secondary-stack allocation and lightweight-task
+   lookup work. A direct name matcher plus one combined exact/name pass keeps
+   the canonical table API and wire representation unchanged. Three controlled
+   200,000-request medians improved from 27,310 to 30,097 requests/s (+10.2%).
+   A 1,000,000-request pair improved from 29,436 to 32,646 requests/s (+10.9%).
+   In comparable active samples, secondary-stack allocation samples fell from
+   125 to 42, scheduler current-task samples from 392 to 231, and static `Name`
+   disappeared. Differing sample totals make those counts mechanism evidence,
+   not exact time percentages. Three 16-loop repetitions were 57.22k, 57.38k,
+   and 55.65k, neutral relative to the previous 58.94k best once client and
+   packet I/O dominate.
+
+3. **ACK processing copied large retransmission tables per packet.** The
    application-space packet transaction copied a roughly 72 KiB
    retransmittable table plus packet-frame table before applying ACK events.
    The accepted change stages only the bounded packet-event resolution log,
@@ -166,7 +203,7 @@ builds were excluded from all reported rates.
    25,725 to 26,827 requests/s (+4.3%); 16-loop results were neutral within
    noise, so no multi-loop gain is attributed to this change.
 
-3. **The Ada H3 client allocated a large event object twice per request.** A
+4. **The Ada H3 client allocated a large event object twice per request.** A
    pooled connection now retains one event object and frees it with the
    transport. In a 640,000-request, 64-connection optimized Ada-client run,
    rate improved from 31,543 to 35,284 requests/s (+11.9%) and mean latency
@@ -177,7 +214,7 @@ builds were excluded from all reported rates.
    totals differed, so counts support the allocation mechanism rather than an
    exact percentage claim.
 
-4. **Eager per-connection request header slots inflated server memory.** Eight
+5. **Eager per-connection request header slots inflated server memory.** Eight
    bounded slots embedded full header blocks even when unused. Header blocks
    are now allocated on first slot use, retained for the connection, and freed
    during cleanup. At 64 H3 connections peak physical memory fell from 309.9
@@ -185,12 +222,14 @@ builds were excluded from all reported rates.
    MB (about 22%). Throughput remained in the 50k+ band. This is a capacity
    improvement, not a claimed request-rate win.
 
-5. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
+6. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
    13k even against 16 loops. Four workers sustained about 50k; eight reached
    54-59k. The benchmark now records workers explicitly so “single client” is
    not confused with “single Flyology loop.”
 
-Timer scans, QPACK, routing, and cryptography were not leading server samples.
+Timer scans, routing, and cryptography were not leading server samples. QPACK
+was material only in the saturated one-loop profile; it was small in the
+16-loop packet-I/O-dominated profile.
 `kevent` and scheduler samples show normal waits/wakeups, but no lock hotspot
 larger than packet I/O was found. A 2,000,000-request eight-worker run declined
 to 43.1k requests/s with worse tails; client time was 46.97 s real, 168.03 s
@@ -210,6 +249,15 @@ lifecycle pressure.
 - Increasing workers beyond eight and repeatedly opening new 128-connection
   generations worsened handshake latency and throughput. Those runs are useful
   saturation evidence, not accepted tuning changes.
+- Raising the default bidirectional-stream flow-credit refill threshold from
+  one-half to three-quarters measured 25.742k, 25.809k, and 26.387k requests/s
+  versus a reverse-order baseline median of 27.310k (-5.5%). Reverted.
+- Adding direct static-table value matching after the accepted QPACK name
+  matcher measured a 29.752k median versus 30.097k (-1.1%). Reverted.
+- A round-robin HTTP/3 request-slot polling cursor was rejected before code:
+  completed streams are released immediately, so the common path reuses the
+  first free transport entry; retaining a cursor would keep more bounded
+  request state live without evidence of scan pressure.
 
 ## Correctness qualification
 
@@ -232,7 +280,9 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
 - H2: Go, Node, and nghttpd peers passed in native and lightweight models;
   fault campaign and bounded soak passed; h2spec 146/146 passed.
 - H3: aioquic and quic-go passed in both Ada client and Ada server roles.
-- h3spec 0.1.13: 49/49 passed.
+- h3spec 0.1.13: a first run passed all HTTP/3 and QPACK cases but was 48/49
+  because one randomized QUIC Handshake reserved-bit case did not observe its
+  expected exception; an immediate fresh-server rerun passed 49/49.
 - Bounded H3 stress: hostile UDP and 64 malformed cases passed; server load
   passed through 128 connections and 128-way concurrency; Ada client passed
   1,024/1,024 requests. One preceding identical run had one 60-second aioquic
@@ -242,7 +292,12 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
 ## Remaining bottlenecks
 
 - Minimize or batch one-datagram-at-a-time output and cache safe source/local
-  endpoint metadata in Flyology core; reproduce upstream before changing it.
+  endpoint metadata in Flyology core. The minimal upstream profile is an
+  optimized 16-loop server, tracing off, eight aioquic processes, 128 QUIC
+  connections and 16 streams each: the send stack configures descriptor/socket
+  state, obtains the local endpoint for source-selected datagrams, then issues
+  one `sendmsg`. `fcntl`, `setsockopt`, and `getsockname` all remain visible
+  beside `sendmsg`. This repository deliberately does not modify Flyology core.
 - Investigate delayed retirement of old H3 connection generations and long-run
   throughput decay with a lifecycle-focused diagnostic build.
 - Reduce multi-process client scheduling and packet receive overhead before

--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -96,6 +96,7 @@ Latency values are milliseconds. All requests succeeded.
 | --- | ---: | ---: | ---: | ---: | --- |
 | H1, 1 loop, baseline | 34,784 | 0.431 | 0.540 | 0.737 | 16 connections, keep-alive |
 | H2, 1 loop, baseline | 19,783 | 3.17 | 4.09 | 4.54 | 4 connections x 16 streams |
+| H2, 1 loop, reusable handlers median | **29,002** | 1.929 | 3.198 | 6.005 | same; +49.2% against fresh 19,444 median |
 | H3, 1 Python worker, baseline | 13,768 | 10.320 | 18.111 | 19.454 | 16 connections x 16 streams |
 | H3, 1 server loop saturated, baseline | 25,725 | 36.64 | — | — | 4 workers, 64 connections x 16 streams |
 | H3, 1 server loop, ACK candidate | 26,827 | 35.25 | — | — | same; +4.3% rate, -3.8% p50 |
@@ -103,6 +104,7 @@ Latency values are milliseconds. All requests succeeded.
 | H3, 1 loop, QPACK median | **30,097** | 29.6 | — | — | same; +10.2% rate, about -10% p50 |
 | H1, 16 loops, baseline median | 98,299 | 0.459 | 1.700 | 3.285 | 64 connections |
 | H2, 16 loops, baseline median | 32,035 | 1.946 | 2.552 | 2.795 | 4 connections x 16 streams |
+| H2, 16 loops, reusable handlers median | **89,856** | 0.533 | 0.987 | 5.762 | same; +180.5% |
 | H3, 16 loops, baseline | 54,123 | — | — | — | 8 workers, 128 connections x 16 streams |
 | H3, 16 loops, pre-QPACK best | **58,935** | 24.896 | 51.082 | 78.762 | 8 workers, 128 connections x 16 streams; reuse 6,250x |
 | H3, 16 loops, QPACK median | 57,222 | 26.617 | 46.145 | 65.833 | same; neutral within run noise |
@@ -122,6 +124,44 @@ With 16 positively probed Flyology loops, sustained H3 crossed 50k and peaked
 in a clean run at 58.9k. Scaling saturated around 8 client workers:
 16 workers regressed to about 42k because handshake/process/packet pressure
 grew faster than useful server work.
+
+### H2 handler-task profile and scaling
+
+The maintained H2 load command uses four reused TLS connections and up to 16
+concurrent streams on each connection, for 64 maximum in-flight requests:
+
+```sh
+oha -n 200000 -c 4 -p 16 --http-version 2 --insecure --no-tui --json \
+  https://127.0.0.1:18443/hello/test
+```
+
+On a fresh one-loop server before handler reuse, three runs were 19.444k,
+20.077k, and 18.773k requests/s (19.444k median). After reuse, the same command
+measured 27.892k, 32.250k, and 29.002k (29.002k median, +49.2%). A 30-second
+candidate run sustained 31.032k and validated 930,965 responses. With a clean
+16-loop rebuild and a runtime probe of 16, three runs were 89.856k, 91.088k,
+and 78.060k (89.856k median), versus the earlier 32.035k baseline. The short
+16-loop trials show larger run-order tails, so the median is useful local
+evidence rather than a portable capacity claim.
+
+The before profile used:
+
+```sh
+oha -z 30s -c 4 -p 16 --http-version 2 --insecure --no-tui --json \
+  https://127.0.0.1:18443/hello/test
+sample SERVER_PID 8 -file /tmp/flyology-h2-one-loop-20260809.sample.txt
+```
+
+Per-request task activation and destruction dominated HPACK and TLS: leading
+top-of-stack counts included `mprotect` 570, scheduler current-task 399,
+task-local storage lookup 310, `munmap` 266, `madvise` 221, context trampoline
+219, context creation 169, `close` 152, `pipe` 117, and `mmap` 99. The corrected
+candidate sample used the same command and duration. Context creation,
+destruction, mapping, protection, and task activation/finalization disappeared
+from the leading list. The next visible work was TLS/socket `write` 674,
+scheduler current-task 644, task-local lookup 456, `fcntl` 314, `read` 271,
+`memcmp` 254, and HPACK static lookup 253. Differing sample totals make the
+counts mechanism evidence, not percentages.
 
 ### H3 client concurrency
 
@@ -168,7 +208,17 @@ rate drop as the useful size signal, not a cross-run H1 throughput conclusion.
 macOS `sample` was used for low-drag server and client sampling. Trace-enabled
 builds were excluded from all reported rates.
 
-1. **Packet output and descriptor/source-address work dominate the H3
+1. **HTTP/2 created and destroyed a lightweight handler task per request.**
+   Stream slots were already bounded to 32 per connection and protected by an
+   explicit completion/continuation-pin state. Each connection now creates a
+   handler lazily per used slot, rendezvouses it for later requests assigned to
+   that slot, frees the per-request backend only when the existing state says
+   it is safe, and shuts workers down deterministically with the connection.
+   One-loop median throughput improved 49.2%; 16-loop median throughput
+   improved 180.5%. The task/context mapping hot path disappeared. Full tests
+   and the complete H2 qualification, including h2spec 146/146, passed.
+
+2. **Packet output and descriptor/source-address work dominate the H3
    server.** In the active 16-loop server sample the leading stacks included
    `sendmsg` (56,142 samples), `kevent` (7,759), `memmove` (4,822), `fcntl`
    (3,052), `memset` (1,684), `setsockopt` (1,364), scheduler current-fiber
@@ -179,7 +229,7 @@ builds were excluded from all reported rates.
    call. Caching verified local endpoint data and packet batching are plausible
    upstream work. This crate was not changed to work around Flyology core.
 
-2. **QPACK response encoding repeatedly constructed static-table names.** At
+3. **QPACK response encoding repeatedly constructed static-table names.** At
    one-loop server saturation, the encoder's exact lookup called the static
    table `Name` function for up to 99 entries per response header. Returning
    unconstrained strings drove secondary-stack allocation and lightweight-task
@@ -194,7 +244,7 @@ builds were excluded from all reported rates.
    and 55.65k, neutral relative to the previous 58.94k best once client and
    packet I/O dominate.
 
-3. **ACK processing copied large retransmission tables per packet.** The
+4. **ACK processing copied large retransmission tables per packet.** The
    application-space packet transaction copied a roughly 72 KiB
    retransmittable table plus packet-frame table before applying ACK events.
    The accepted change stages only the bounded packet-event resolution log,
@@ -203,7 +253,7 @@ builds were excluded from all reported rates.
    25,725 to 26,827 requests/s (+4.3%); 16-loop results were neutral within
    noise, so no multi-loop gain is attributed to this change.
 
-4. **The Ada H3 client allocated a large event object twice per request.** A
+5. **The Ada H3 client allocated a large event object twice per request.** A
    pooled connection now retains one event object and frees it with the
    transport. In a 640,000-request, 64-connection optimized Ada-client run,
    rate improved from 31,543 to 35,284 requests/s (+11.9%) and mean latency
@@ -214,7 +264,7 @@ builds were excluded from all reported rates.
    totals differed, so counts support the allocation mechanism rather than an
    exact percentage claim.
 
-5. **Eager per-connection request header slots inflated server memory.** Eight
+6. **Eager per-connection request header slots inflated server memory.** Eight
    bounded slots embedded full header blocks even when unused. Header blocks
    are now allocated on first slot use, retained for the connection, and freed
    during cleanup. At 64 H3 connections peak physical memory fell from 309.9
@@ -222,7 +272,7 @@ builds were excluded from all reported rates.
    MB (about 22%). Throughput remained in the 50k+ band. This is a capacity
    improvement, not a claimed request-rate win.
 
-6. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
+7. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
    13k even against 16 loops. Four workers sustained about 50k; eight reached
    54-59k. The benchmark now records workers explicitly so “single client” is
    not confused with “single Flyology loop.”
@@ -276,6 +326,11 @@ lifecycle pressure.
 - Collapsing four high-level request-header searches into one positional pass
   measured 28.588k, 26.826k, and 29.309k requests/s (28.588k median, +0.36%).
   The result was inside noise with worse variance, so it was reverted.
+- Caching a validated and QPACK-encoded HTTP/3 response field section per
+  connection for exact repeated headers used strict byte matching and bounded
+  itself to eight fields and 1,024 input bytes. It measured 27.250k and
+  27.947k requests/s versus a fresh 28.484k baseline median. The lookup and
+  retained state cost more than encoding the small response; reverted.
 
 ## Correctness qualification
 
@@ -296,7 +351,8 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
 
 - Full repository behavioral suite: pass, including all 42 QUIC checks.
 - H2: Go, Node, and nghttpd peers passed in native and lightweight models;
-  fault campaign and bounded soak passed; h2spec 146/146 passed.
+  fault campaign and bounded soak passed; h2spec 146/146 passed. The full H2
+  qualification was repeated after the reusable-handler change.
 - H3: aioquic and quic-go passed in both Ada client and Ada server roles.
 - h3spec 0.1.13: a first run passed all HTTP/3 and QPACK cases but was 48/49
   because one randomized QUIC Handshake reserved-bit case did not observe its
@@ -320,5 +376,8 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
   throughput decay with a lifecycle-focused diagnostic build.
 - Reduce multi-process client scheduling and packet receive overhead before
   treating 59k as a server ceiling.
+- The post-reuse H2 profile is now led by TLS/socket calls, scheduler/task-local
+  lookup, byte comparison, and HPACK static lookup. Separate those costs with
+  concurrency sweeps before attempting another H2 change.
 - Repeat on a quiescent, thermally controlled machine and on Linux before
   making cross-platform claims.

--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -97,6 +97,7 @@ Latency values are milliseconds. All requests succeeded.
 | H1, 1 loop, baseline | 34,784 | 0.431 | 0.540 | 0.737 | 16 connections, keep-alive |
 | H2, 1 loop, baseline | 19,783 | 3.17 | 4.09 | 4.54 | 4 connections x 16 streams |
 | H2, 1 loop, reusable handlers median | **29,002** | 1.929 | 3.198 | 6.005 | same; +49.2% against fresh 19,444 median |
+| H2, 1 loop, direct HPACK match median | **39,187** | 1.637 | 1.710 | 1.891 | same; +35.1% over reusable handlers |
 | H3, 1 Python worker, baseline | 13,768 | 10.320 | 18.111 | 19.454 | 16 connections x 16 streams |
 | H3, 1 server loop saturated, baseline | 25,725 | 36.64 | — | — | 4 workers, 64 connections x 16 streams |
 | H3, 1 server loop, ACK candidate | 26,827 | 35.25 | — | — | same; +4.3% rate, -3.8% p50 |
@@ -105,6 +106,7 @@ Latency values are milliseconds. All requests succeeded.
 | H1, 16 loops, baseline median | 98,299 | 0.459 | 1.700 | 3.285 | 64 connections |
 | H2, 16 loops, baseline median | 32,035 | 1.946 | 2.552 | 2.795 | 4 connections x 16 streams |
 | H2, 16 loops, reusable handlers median | **89,856** | 0.533 | 0.987 | 5.762 | same; +180.5% |
+| H2, 16 loops, direct HPACK match median | 90,237 | 0.540 | 0.855 | 3.927 | same; +0.4%, neutral |
 | H3, 16 loops, baseline | 54,123 | — | — | — | 8 workers, 128 connections x 16 streams |
 | H3, 16 loops, pre-QPACK best | **58,935** | 24.896 | 51.082 | 78.762 | 8 workers, 128 connections x 16 streams; reuse 6,250x |
 | H3, 16 loops, QPACK median | 57,222 | 26.617 | 46.145 | 65.833 | same; neutral within run noise |
@@ -163,6 +165,29 @@ scheduler current-task 644, task-local lookup 456, `fcntl` 314, `read` 271,
 `memcmp` 254, and HPACK static lookup 253. Differing sample totals make the
 counts mechanism evidence, not percentages.
 
+The next profile-led change combined the encoder's exact and name-only HPACK
+static-table searches and matched canonical names directly. One-loop trials
+were 38.942k, 39.187k, and 39.453k requests/s (39.187k median, +35.1% over
+reusable handlers alone). A 30-second run sustained 39.116k with 1,173,561
+validated responses. Static lookup fell from 253 to 135 samples even though
+sampled throughput increased by about 26%. At 16 loops, three trials were
+90.629k, 89.036k, and 90.237k (90.237k median, +0.4%); the change is neutral
+once other work limits throughput.
+
+The post-change 16-loop connection sweep held streams per connection at 16
+and sent 100,000 validated requests per point:
+
+| Connections | Maximum in flight | Requests/s | p50 | p95 | p99 |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 16 | 48,816 | 0.306 | 0.373 | 0.430 |
+| 2 | 32 | 71,480 | 0.390 | 0.527 | 0.607 |
+| 4 | 64 | 95,758 | 0.502 | 0.708 | 1.820 |
+| 8 | 128 | 99,342 | 0.801 | 3.528 | 10.144 |
+| 16 | 256 | 96,980 | 0.725 | 8.204 | 46.515 |
+
+Throughput saturates around 128 in flight. Doubling concurrency beyond that
+reduces rate and sharply worsens tail latency.
+
 ### H3 client concurrency
 
 The one-loop stream sweep held the client at four Python processes and 64
@@ -218,7 +243,16 @@ builds were excluded from all reported rates.
    improved 180.5%. The task/context mapping hot path disappeared. Full tests
    and the complete H2 qualification, including h2spec 146/146, passed.
 
-2. **Packet output and descriptor/source-address work dominate the H3
+2. **HPACK response encoding scanned the static table twice per field.** The
+   exact-value and name-only searches each constructed up to 61 unconstrained
+   static-name string results. A direct canonical-name matcher now collects
+   both indexes in one pass while preserving every RFC table index and encoded
+   representation. One-loop median throughput improved from 29.002k to
+   39.187k requests/s (+35.1%); the 16-loop result was neutral after saturation.
+   The independent 500-case HPACK and 1,000-case Huffman differential suites,
+   full repository tests, and complete H2 qualification passed.
+
+3. **Packet output and descriptor/source-address work dominate the H3
    server.** In the active 16-loop server sample the leading stacks included
    `sendmsg` (56,142 samples), `kevent` (7,759), `memmove` (4,822), `fcntl`
    (3,052), `memset` (1,684), `setsockopt` (1,364), scheduler current-fiber
@@ -229,7 +263,7 @@ builds were excluded from all reported rates.
    call. Caching verified local endpoint data and packet batching are plausible
    upstream work. This crate was not changed to work around Flyology core.
 
-3. **QPACK response encoding repeatedly constructed static-table names.** At
+4. **QPACK response encoding repeatedly constructed static-table names.** At
    one-loop server saturation, the encoder's exact lookup called the static
    table `Name` function for up to 99 entries per response header. Returning
    unconstrained strings drove secondary-stack allocation and lightweight-task
@@ -244,7 +278,7 @@ builds were excluded from all reported rates.
    and 55.65k, neutral relative to the previous 58.94k best once client and
    packet I/O dominate.
 
-4. **ACK processing copied large retransmission tables per packet.** The
+5. **ACK processing copied large retransmission tables per packet.** The
    application-space packet transaction copied a roughly 72 KiB
    retransmittable table plus packet-frame table before applying ACK events.
    The accepted change stages only the bounded packet-event resolution log,
@@ -253,7 +287,7 @@ builds were excluded from all reported rates.
    25,725 to 26,827 requests/s (+4.3%); 16-loop results were neutral within
    noise, so no multi-loop gain is attributed to this change.
 
-5. **The Ada H3 client allocated a large event object twice per request.** A
+6. **The Ada H3 client allocated a large event object twice per request.** A
    pooled connection now retains one event object and frees it with the
    transport. In a 640,000-request, 64-connection optimized Ada-client run,
    rate improved from 31,543 to 35,284 requests/s (+11.9%) and mean latency
@@ -264,7 +298,7 @@ builds were excluded from all reported rates.
    totals differed, so counts support the allocation mechanism rather than an
    exact percentage claim.
 
-6. **Eager per-connection request header slots inflated server memory.** Eight
+7. **Eager per-connection request header slots inflated server memory.** Eight
    bounded slots embedded full header blocks even when unused. Header blocks
    are now allocated on first slot use, retained for the connection, and freed
    during cleanup. At 64 H3 connections peak physical memory fell from 309.9
@@ -272,7 +306,7 @@ builds were excluded from all reported rates.
    MB (about 22%). Throughput remained in the 50k+ band. This is a capacity
    improvement, not a claimed request-rate win.
 
-7. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
+8. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
    13k even against 16 loops. Four workers sustained about 50k; eight reached
    54-59k. The benchmark now records workers explicitly so “single client” is
    not confused with “single Flyology loop.”
@@ -352,7 +386,8 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
 - Full repository behavioral suite: pass, including all 42 QUIC checks.
 - H2: Go, Node, and nghttpd peers passed in native and lightweight models;
   fault campaign and bounded soak passed; h2spec 146/146 passed. The full H2
-  qualification was repeated after the reusable-handler change.
+  qualification was repeated after both accepted H2 changes. The HPACK and
+  Huffman differential suites passed 500 and 1,000 cases respectively.
 - H3: aioquic and quic-go passed in both Ada client and Ada server roles.
 - h3spec 0.1.13: a first run passed all HTTP/3 and QPACK cases but was 48/49
   because one randomized QUIC Handshake reserved-bit case did not observe its
@@ -376,8 +411,9 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
   throughput decay with a lifecycle-focused diagnostic build.
 - Reduce multi-process client scheduling and packet receive overhead before
   treating 59k as a server ceiling.
-- The post-reuse H2 profile is now led by TLS/socket calls, scheduler/task-local
-  lookup, byte comparison, and HPACK static lookup. Separate those costs with
-  concurrency sweeps before attempting another H2 change.
+- The post-HPACK H2 profile is led by TLS/socket calls, scheduler/task-local
+  lookup, byte comparison, and remaining bounded header construction. The
+  16-loop sweep saturates around 128 in flight, where client/TLS/socket work
+  limits another codec-only gain.
 - Repeat on a quiescent, thermally controlled machine and on Linux before
   making cross-platform claims.

--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -9,7 +9,11 @@ all materially affect the results.
 - Baseline: `main` at `8b09b0f4830683d6d76c4e31ffa5dd31a2386988`.
 - Working branch: `codex/http-stack-performance`.
 - Flyology: Alire `0.1.0-dev` at
-  `3808aabcb33d75b06a6a9472eb2342094a66d018`.
+  `1acfd59312ea36a8c0d2e2112cf242a66c78a4ae`, resolved from the project
+  index after [Flyology PR #31](https://github.com/flyology-ada/flyology/pull/31)
+  and [alire-index PR #4](https://github.com/flyology-ada/alire-index/pull/4)
+  were merged. Their merge commits were `1acfd59312ea36a8c0d2e2112cf242a66c78a4ae`
+  and `dd5c12ded8ccb3fd754732842203150acb51d65e` respectively.
 - Machine: MacBook Pro `Mac15,9`, Apple M3 Max, 16 cores (12 performance,
   4 efficiency), 48 GB RAM.
 - OS: macOS 26.5.2, Darwin 25.5.0, arm64.
@@ -20,39 +24,62 @@ all materially affect the results.
 - Build: release switches (`-O3`, inlining), assertions and validity checks
   retained by the showcase project, `FLYOLOGY_QUIC_TRACE=false`.
 
+Accepted implementation commits from the `8b09b0f` baseline are:
+
+```text
+65269d4  transactional ACK event staging
+9f5a157  lazy H3 request-header slots
+27c5408  retained Ada H3 client event storage
+e7cf51d  allocation-free QPACK static-name matching
+5d8414c  reusable H2 handler tasks
+7041891  direct HPACK static matching
+44450d4  retained H2 stream wake sources
+3e80047  compact H3 request slots
+6a73671  bounded common QPACK lookup ranges
+a6485e1  QUIC key-update send-key synchronization
+2a2612e  compiled multiprocess aioquic benchmark path
+05db017  bounded transactional H3 response packet batching
+3432181  one timeout context per validated aioquic batch
+```
+
+Notebook-only commits between those implementation slices preserve the raw
+campaign history in Git. No branch from this worktree was pushed and no HTTP
+repository pull request was opened.
+
 ## Runtime preparation and fail-closed checks
 
 Every performance and standalone H3 qualification/stress binary used an
 explicit Flyology lightweight RTS. No H3 performance harness was built or run
 with GNAT's default RTS. The one-loop and 16-loop roots were
-`build/perf-rts-l1` and `build/perf-rts-l16`.
+`build/perf-rts-l1-1acfd593` and `build/perf-rts-l16-1acfd593`.
 
 Representative 16-loop preparation and clean build:
 
 ```sh
 alr update
 alr with flyology=0.1.0-dev
+flyology_root=$(./scripts/resolve-flyology-root.sh)
 
-FLYOLOGY_RTS_DIR="$PWD/build/perf-rts-l16" \
+FLYOLOGY_RTS_DIR="$PWD/build/perf-rts-l16-1acfd593" \
 FLYOLOGY_DEFAULT=lightweight \
 FLYOLOGY_LOOP_POOL_SIZE=16 \
-  /path/to/resolved/flyology/scripts/prepare-rts.sh
+  "$flyology_root/scripts/prepare-rts.sh"
 
-test -f build/perf-rts-l16/.flyology-rts-root
+test -f build/perf-rts-l16-1acfd593/.flyology-rts-root
 grep -q 'Flyology prepared RTS version' \
-  build/perf-rts-l16/.flyology-rts-root
+  build/perf-rts-l16-1acfd593/.flyology-rts-root
 grep -q 'Lightweight : constant Boolean := True;' \
-  build/perf-rts-l16/adainclude/s-fldeex.ads
+  build/perf-rts-l16-1acfd593/adainclude/s-fldeex.ads
 
 ./showcases/prepare-alire.sh release
 cd showcases
-FLYOLOGY_RTS_DIR=../build/perf-rts-l16 \
+FLYOLOGY_RTS_DIR=../build/perf-rts-l16-1acfd593 \
   alr exec -- env -u GPR_CONFIG gprclean -r -q -P showcases.gpr
-FLYOLOGY_RTS_DIR=../build/perf-rts-l16 \
+FLYOLOGY_RTS_DIR=../build/perf-rts-l16-1acfd593 \
 FLYOLOGY_SHOWCASE_PROFILE=release \
 FLYOLOGY_QUIC_TRACE=false \
   alr exec -- env -u GPR_CONFIG gprbuild \
-    --RTS=../build/perf-rts-l16 -p -P showcases.gpr \
+    --RTS=../build/perf-rts-l16-1acfd593 -p -P showcases.gpr \
     http3_application_server.adb http_benchmark_runtime_probe.adb
 ./bin/http_benchmark_runtime_probe
 ```
@@ -75,22 +102,23 @@ oha -n 200000 -c 4 -p 16 --http-version 2 --insecure --no-tui --json \
   https://127.0.0.1:18443/hello/test
 build/oracle/aioquic/bin/python showcases/http3_benchmark.py \
   --port 18443 --path /hello/test --requests 800000 \
-  --workers 8 --connections 128 --streams 16 --timeout 20
+  --workers 8 --connections 8 --streams 16 --timeout 20
 ```
 
 The H3 fixture keeps connections open, validates every status/body, separates
 handshake and request latency, reports connection reuse, and uses multiple
-processes when one Python event loop would be the limiting component. A fresh
-server was used for each high-connection trial. Reusing one server across
-successive 128-new-connection trials degraded from 53.9k to 41.7k to 35.4k
-requests/s while median handshake latency rose from 69 to 200 ms; this is a
-connection-retirement/lifecycle pressure signal, not a steady-state result.
+processes when one Python event loop would be the limiting component. The
+final topology uses eight total persistent connections, one per worker, and
+16 concurrent streams per connection: 128 maximum requests in flight and
+100,000 validated requests per connection. Earlier 128-connection trials are
+retained below as lifecycle and saturation evidence, not the final operating
+point.
 
 ## Baselines and final measurements
 
 The baseline table uses medians of three controlled trials where available.
-The last H3 rows are fresh-server measurements of the final source, taken
-before the final qualification campaign. Latency values are milliseconds. All
+The final H3 median uses fresh servers; the strict spot check was repeated
+after the full qualification campaign. Latency values are milliseconds. All
 requests succeeded.
 
 | Configuration | Requests/s | p50 | p95 | p99 | Concurrency and reuse |
@@ -107,6 +135,8 @@ requests succeeded.
 | H3, 1 loop, QPACK median | **30,097** | 29.6 | — | — | same; +10.2% rate, about -10% p50 |
 | H3, 1 loop, compact request slots | **31,713** | about 29.8 | — | — | same; +5.6% against fresh 30,019 median |
 | H3, 1 loop, bounded common QPACK lookup | **32,819** | 28.802 | — | — | same; +3.5% over compact slots, +9.3% over fresh 30,019 median |
+| H3, 1 loop, final comparable topology | **42,733** | 20.761 | 21.832 | 22.480 | 64 connections x 16 streams; +30.2% over 32,819 |
+| H3, 1 loop, final low-connection topology | **47,013** | 1.114 | 1.418 | 1.650 | 4 persistent connections x 16 streams; 64 in flight |
 | H1, 16 loops, baseline median | 98,299 | 0.459 | 1.700 | 3.285 | 64 connections |
 | H2, 16 loops, baseline median | 32,035 | 1.946 | 2.552 | 2.795 | 4 connections x 16 streams |
 | H2, 16 loops, reusable handlers median | **89,856** | 0.533 | 0.987 | 5.762 | same; +180.5% |
@@ -117,24 +147,37 @@ requests succeeded.
 | H3, 16 loops, QPACK median | 57,222 | 26.617 | 46.145 | 65.833 | same; neutral within run noise |
 | H3, 16 loops, compact request slots median | 57,578 | — | — | — | same; neutral, best 61,596 |
 | H3, 16 loops, final bounded lookup median | 54,390 | 26.982 | 54.148 | 71.293 | same; neutral-to-uncertain in the 16-loop run band |
+| H3, 16 loops, response packet batching | 125,915 | — | — | — | 8 persistent connections x 16 streams; 128 in flight |
+| H3, 16 loops, final median | **143,709** | 0.673 | 0.858 | 0.969 | same; 100,000 requests/connection |
+| H3, 16 loops, post-qualification spot | **146,562** | 0.653 | 0.807 | 0.894 | same; 800,000/800,000 validated |
+| H1, 16 loops, post-qualification spot | 79,856 | 0.746 | 1.446 | 2.519 | 64 persistent connections |
+| H2, 16 loops, post-qualification spot | **148,167** | 0.337 | 0.573 | 3.180 | 4 connections x 16 streams |
 
-The pre-QPACK 58.9k H3 run took 13.574 s for 800,000 requests. Handshake
-latency was
-55.118 ms mean, 54.984 ms p50, 58.172 ms p95, and 97.680 ms max. The final H1
-and H2 spot checks after the long qualification session were 79,340 and 29,091
-requests/s respectively; both were below their earlier controlled medians, so
-they are recorded as thermal/order-sensitive spot checks rather than
-regressions. Their success rates were 100%.
+The pre-QPACK 58.9k H3 run took 13.574 s for 800,000 requests. Its 128
+connections and 2,048 in-flight requests generated far more client and
+connection-lifecycle work than the final eight-connection topology. The final
+H3 median is 97.5% of the retained 147.435k H2 median. The strict
+post-qualification spot checks put H3 at 98.9% of the matching 148.167k H2
+spot check. This is local parity for the short route on this M3 Max, not a
+portable claim that the protocols have equal cost.
+
+The three final fresh-server H3 runs, in requests/s with p50/p95/p99
+milliseconds, were `141545.3377 (0.6767/0.8746/1.0106)`, `145327.4412
+(0.6652/0.8325/0.9346)`, and `143708.9714 (0.6733/0.8578/0.9693)`. The strict
+post-qualification run was `146562.4085 (0.6531/0.8072/0.8935)`, completed
+800,000 validated responses in 5.458 s, reused each of eight connections
+100,000 times, and had a 22.088 ms median handshake. The adjacent oha H2 spot
+check was 148166.7055 requests/s; H1 was 79856.4328 requests/s.
 
 The original approximately 13.9k H3 result is reproducible, but it measures a
 single aioquic process: the Python client was about 98.5% of one core while the
 server was about 66% of one core. Multiprocess load exposes server capacity.
-With 16 positively probed Flyology loops, sustained H3 crossed 50k and peaked
-in a clean run at 58.9k. Scaling saturated around 8 client workers:
-16 workers regressed to about 42k because handshake/process/packet pressure
-grew faster than useful server work.
+With 16 positively probed Flyology loops, sustained H3 first crossed 50k with
+many connections, reached 125.9k after response packet batching, then reached
+a 143.7k median after removing per-event timeout-task overhead from the
+maintained Python oracle. Eight client workers remained the local optimum.
 
-The final one-loop campaign used this exact client command against a fresh
+The pre-coalescing one-loop campaign used this client command against a fresh
 server for each trial:
 
 ```sh
@@ -144,9 +187,19 @@ build/oracle/aioquic/bin/python showcases/http3_benchmark.py \
 ```
 
 That is 1,024 maximum in-flight requests, 6,250 requests per connection, and
-64 reused QUIC connections. The corresponding 16-loop command used 800,000
+64 reused QUIC connections. The earlier 16-loop command used 800,000
 requests, eight workers, 128 connections, and 16 streams, for 2,048 maximum
-in flight and the same 6,250x connection reuse.
+in flight and the same 6,250x connection reuse. The final topology sweep
+instead found eight connections x 16 streams to be substantially faster.
+
+The final source was rebuilt cleanly with
+`build/perf-rts-l1-1acfd593`, and the runtime probe printed `1`. A comparable
+200,000-request run at four workers, 64 connections, and 16 streams measured
+42.733k requests/s, +30.2% over the 32.819k pre-coalescing median. Reducing
+that topology to four persistent connections x 16 streams measured 47.013k
+requests/s with p50/p95/p99 of 1.114/1.418/1.650 ms. Both commands were the
+final command above with `--requests 200000 --workers 4`, changing
+`--connections` between 64 and 4.
 
 ### H2 handler-task profile and scaling
 
@@ -263,10 +316,27 @@ total QUIC connections. Maximum in-flight request concurrency is therefore
 | 8 | 512 | 23,482 | — |
 | 16 | 1,024 | 24,804 | — |
 
-This is why a one-loop result can be either about 15k or 25k without a server
-change: 64 in-flight requests do not saturate the same path as 1,024. The
-16-loop final campaign used eight Python processes, 128 total connections,
-and 16 streams per connection, for a maximum of 2,048 in-flight requests.
+This historical sweep is why a pre-coalescing one-loop result could be either
+about 15k or 25k without a server change: 64 in-flight requests did not
+saturate the same path as 1,024. With response batching, four connections x
+16 streams instead reached 47.013k at only 64 in flight. The
+earlier 16-loop campaign used eight Python processes, 128 total connections,
+and 16 streams per connection, for 2,048 in flight. After packet batching,
+the final campaign used eight processes, eight total persistent connections,
+and 16 streams per connection, for 128 in flight.
+
+The final topology sweep held the server and eight persistent connections
+constant after response batching:
+
+| Connections x streams | Maximum in flight | Requests/s | p50 | p99 |
+| ---: | ---: | ---: | ---: | ---: |
+| 8 x 8 | 64 | 89,748 | — | — |
+| 8 x 16 | 128 | **125,915** | — | — |
+| 8 x 32 | 256 | 128,146 | 1.210 | 4.020 |
+
+Sixteen streams supplied most of the useful scaling. Doubling to 32 added
+only 1.8% while materially worsening latency, so 128 in flight was retained
+as the local operating point.
 
 ### Size sensitivity
 
@@ -276,15 +346,15 @@ or protocol behavior. A 1,024-byte case used:
 
 ```sh
 build/oracle/aioquic/bin/python showcases/http3_benchmark.py \
-  --port 18443 --response-bytes 1024 --requests 200000 \
-  --workers 8 --connections 128 --streams 16 --timeout 20
+  --port 18443 --response-bytes 1024 --requests 50000 \
+  --workers 8 --connections 8 --streams 16 --timeout 20
 ```
 
 | Protocol, 16 loops | Bytes | Requests/s | p50 | p95 | p99 |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | H1 | 1,024 | 86,548 | 0.620 | 1.432 | 3.101 |
 | H2 | 1,024 | 25,054 | 2.546 | 2.858 | 3.004 |
-| H3 | 1,024 | 33,746 | 28.916 | 73.220 | 179.143 |
+| H3, final fallback | 1,024 | 28,409 | 2.263 | 3.871 | 4.639 |
 
 H1's larger-body rate exceeded its immediately preceding 10-byte spot check,
 which confirms material run-order/noise on this laptop; use the latency and H3
@@ -324,18 +394,46 @@ builds were excluded from all reported rates.
    and `fcntl` disappeared from the leading post-change sample. Full repository
    tests and the complete H2 qualification passed again.
 
-4. **Packet output and descriptor/source-address work dominate the H3
-   server.** In the active 16-loop server sample the leading stacks included
-   `sendmsg` (56,142 samples), `kevent` (7,759), `memmove` (4,822), `fcntl`
-   (3,052), `memset` (1,684), `setsockopt` (1,364), scheduler current-fiber
-   work (850), `recvmsg` (715), and `getsockname` (681). QPACK field-name work
-   was only 533 samples and crypto was sparse. Routing and response construction
-   did not dominate. Flyology's native `flyology_socket_send_datagram` calls
-   `getsockname` for every source-selected datagram and emits one `sendmsg` per
-   call. Caching verified local endpoint data and packet batching are plausible
-   upstream work. This crate was not changed to work around Flyology core.
+4. **The Flyology UDP send path repeated socket setup and endpoint discovery.**
+   In the active 16-loop server sample the leading stacks included `sendmsg`
+   (56,142 samples), `fcntl` (3,052), `setsockopt` (1,364), and `getsockname`
+   (681); crypto and QPACK were sparse. The separately reviewed Flyology PR
+   #31 removed repeated work in the task-aware datagram path and added portable
+   `SO_REUSEPORT` support without changing this HTTP crate. Its maintained UDP
+   benchmark median improved from 34,373 to 38,512 datagrams/s (+12.0%). The
+   exact Flyology commit was then published through alire-index PR #4 and used
+   to prepare both explicit lightweight RTS roots above.
 
-5. **QPACK response encoding repeatedly constructed static-table names.** At
+5. **One small H3 response consumed one QUIC packet and one `sendmsg`.** The
+   unified server now prepares complete bounded responses and transactionally
+   combines up to eight independent STREAM frames into one protected 1-RTT
+   packet. Flow-control reservations, sent-packet accounting, recovery data,
+   final sizes, and request release commit only after the complete batch is
+   accepted. Oversize batches fall back to individual response packets, so
+   1,024-byte responses preserve the previous path. At eight connections x
+   eight streams, rate rose from the 73--74k band to 85.459k and 89.748k.
+   With eight connections x 16 streams it reached 125.915k. In comparable
+   active samples, `sendmsg` fell from 8,353 to 732 observations, roughly the
+   expected eight-response aggregation effect; differing sample totals make
+   this mechanism evidence rather than an exact percentage. The post-change
+   sample was led by waits, then `memmove` 1,503, `sendmsg` 732, `memset` 592,
+   flow reservation 115, and `recvmsg` 80. Routing, QPACK, timers, and crypto
+   were not the limiting stacks.
+
+6. **The maintained aioquic oracle created and cancelled a timeout task for
+   every received H3 event.** A single `asyncio.timeout` now bounds each
+   validated request batch while the inner loop awaits the queue directly.
+   This preserves the same timeout, status, body, and completion checks. Three
+   fresh 800,000-request trials at eight workers, eight connections, and 16
+   streams measured 141.545k, 145.327k, and 143.709k requests/s (143.709k
+   median). A representative before run consumed 33.44 s client user CPU over
+   6.36 s real; a representative after run consumed 30.25 s user CPU over
+   5.96 s real. System CPU and context-switch counts did not improve
+   consistently, so no broader CPU reduction is claimed. This experiment
+   demonstrated that the earlier 125.9k result still included material oracle
+   overhead.
+
+7. **QPACK response encoding repeatedly constructed static-table names.** At
    one-loop server saturation, the encoder's exact lookup called the static
    table `Name` function for up to 99 entries per response header. Returning
    unconstrained strings drove secondary-stack allocation and lightweight-task
@@ -350,7 +448,7 @@ builds were excluded from all reported rates.
    and 55.65k, neutral relative to the previous 58.94k best once client and
    packet I/O dominate.
 
-6. **ACK processing copied large retransmission tables per packet.** The
+8. **ACK processing copied large retransmission tables per packet.** The
    application-space packet transaction copied a roughly 72 KiB
    retransmittable table plus packet-frame table before applying ACK events.
    The accepted change stages only the bounded packet-event resolution log,
@@ -359,7 +457,7 @@ builds were excluded from all reported rates.
    25,725 to 26,827 requests/s (+4.3%); 16-loop results were neutral within
    noise, so no multi-loop gain is attributed to this change.
 
-7. **The Ada H3 client allocated a large event object twice per request.** A
+9. **The Ada H3 client allocated a large event object twice per request.** A
    pooled connection now retains one event object and frees it with the
    transport. In a 640,000-request, 64-connection optimized Ada-client run,
    rate improved from 31,543 to 35,284 requests/s (+11.9%) and mean latency
@@ -370,7 +468,7 @@ builds were excluded from all reported rates.
    totals differed, so counts support the allocation mechanism rather than an
    exact percentage claim.
 
-8. **Eager per-connection request header slots inflated server memory.** Eight
+10. **Eager per-connection request header slots inflated server memory.** Eight
    bounded slots embedded full header blocks even when unused. Header blocks
    are now allocated on first slot use, retained for the connection, and freed
    during cleanup. At 64 H3 connections peak physical memory fell from 309.9
@@ -378,7 +476,7 @@ builds were excluded from all reported rates.
    MB (about 22%). Throughput remained in the 50k+ band. This is a capacity
    improvement, not a claimed request-rate win.
 
-9. **Materializing a second full H3 header block per active request was still
+11. **Materializing a second full H3 header block per active request was still
    expensive.** A fresh optimized one-loop baseline at `e6272f4` measured
    30.019k requests/s. The server adapter now writes decoded method, target,
    authority, and ordinary headers directly into the unified request retained
@@ -391,7 +489,7 @@ builds were excluded from all reported rates.
    `memmove` samples fell from 2,242 to 1,960 despite higher throughput. The
    16-loop median was 57.578k, neutral in the existing run band.
 
-10. **Common response fields still searched irrelevant QPACK ranges.** The
+12. **Common response fields still searched irrelevant QPACK ranges.** The
     prior accepted QPACK matcher removed secondary-stack-heavy name
     construction, but `:status`, `content-type`, and `content-length` still
     walked entries that cannot match those names. Restricting exact lookup to
@@ -404,10 +502,19 @@ builds were excluded from all reported rates.
     the preceding compact-slot median but within the broad 47.5--61.6k
     multi-loop band. No 16-loop gain is claimed.
 
-11. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
+13. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
    13k even against 16 loops. Four workers sustained about 50k; eight reached
-   54-59k. The benchmark now records workers explicitly so “single client” is
-   not confused with “single Flyology loop.”
+   54-59k before packet batching and over 140k afterward. The benchmark now
+   records workers explicitly so “single client” is not confused with “single
+   Flyology loop.”
+
+14. **Connections and in-flight streams have distinct costs.** The old
+   128-connection topology required 2,048 in-flight requests to reach 54--59k
+   and accumulated retirement pressure across generations. With response
+   batching, eight persistent connections x 16 streams reached 125.915k before
+   the oracle fix and the 143.709k final median afterward. Eight x 32 reached
+   128.146k before the oracle fix, only 1.8% above eight x 16 while p50/p99
+   rose to 1.210/4.020 ms. More concurrency was not free capacity.
 
 Timer scans, routing, and cryptography were not leading server samples. QPACK
 was material only in the saturated one-loop profile; it was small in the
@@ -478,6 +585,29 @@ lifecycle pressure.
   measured 33.130k, 33.130k, and 32.946k requests/s (33.130k median), +0.95%.
   This was also reverted rather than trading easier initialization reasoning
   for a sub-one-percent result.
+- Replacing transactional flow-control candidate state with repeated no-copy
+  preflight scans passed the batching test but regressed an exact 800,000
+  request pair from 91.272k to 82.948k requests/s. The bounded candidate copy
+  was restored.
+- Preparing directly into the pending response slot removed one 1,100-byte
+  record copy. Three fresh baseline trials had an 86.535k median and three
+  candidate trials an 87.349k median (+0.94%) with wide overlap. The more
+  complicated calling convention was reverted.
+- Raising the response batch cap from eight to 16 measured 126.595k at eight
+  connections x 16 streams, only +0.54% with a worse median latency. The cap
+  returned to eight. Raising streams to 32 reached 128.146k, only +1.8% over
+  the 16-stream point while p50/p99 rose to 1.210/4.020 ms; no code or default
+  was changed for that operating point.
+- Replacing the aioquic driver's fixed per-connection batches with rolling
+  stream replenishment did not expose hidden server capacity. Against fresh
+  otherwise identical one-listener servers, with 400,000 requests, eight
+  workers, eight persistent connections, and eight streams, the maintained
+  batch driver measured 70.362k requests/s. Replenishing each completed stream
+  immediately measured 62.640k (-11.0%); refilling half of the window at once
+  measured 64.634k (-8.1%). The eager variants also raised median response
+  latency from 0.565 to 0.865--0.745 ms. aioquic coalesces each fixed request
+  batch before transmitting it; eager refill traded the batch barrier for more
+  client packet/oracle overhead. Both variants were reverted.
 
 ## Correctness qualification
 
@@ -485,6 +615,8 @@ Commands and final results:
 
 ```sh
 ./scripts/test.sh
+./scripts/prove.sh
+./scripts/docs.sh
 ./scripts/http2-test.sh qualification
 FLYOLOGY_QUIC_TRACE=false ./scripts/test-http3-interop.sh all
 FLYOLOGY_QUIC_TRACE=false ./scripts/test-http3-h3spec.sh
@@ -497,43 +629,48 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
 ```
 
 - Full repository behavioral suite: pass after the final source changes,
-  including all 42 QUIC checks. The SPARK campaign proved all 2,928 checks.
+  including all 43 QUIC checks and 56 behavioral checks. The new standalone
+  batch smoke test validates two streams in one packet and verifies that an
+  aggregate connection-credit failure leaves all flow state uncommitted. The
+  SPARK campaign passed, and GNATdoc generated `docs/api/index.html`.
 - H2: Go, Node, and nghttpd peers passed in native and lightweight models;
   fault campaign and bounded soak passed; h2spec 146/146 passed. The full H2
   qualification was repeated after the final H3 changes as a cross-protocol
   guard. The HPACK and Huffman differential suites passed 500 and 1,000 cases
   respectively.
 - H3: aioquic and quic-go passed in both Ada client and Ada server roles.
-- h3spec 0.1.13: a first run passed all HTTP/3 and QPACK cases but was 48/49
-  because one randomized QUIC Handshake reserved-bit case did not observe its
-  expected exception; an immediate fresh-server rerun passed 49/49.
-- Bounded H3 stress: hostile UDP and 64 malformed cases passed; server load
-  passed through 128 connections and 128-way concurrency; Ada client passed
-  1,024/1,024 requests. One preceding identical run had one 60-second aioquic
-  handshake timeout at the 64-connection phase; a fresh-server rerun passed
-  all phases and the isolated timeout is retained here rather than hidden.
+- h3spec 0.1.13: 49/49 examples passed.
+- Bounded H3 stress: hostile UDP and 64 malformed cases passed; churn passed
+  at 16, 32, 64, and 128 connections; server load passed at 128-way
+  concurrency; the Ada client passed 1,024/1,024 requests.
 
 ## Remaining bottlenecks
 
-- Minimize or batch one-datagram-at-a-time output and cache safe source/local
-  endpoint metadata in Flyology core. The minimal upstream profile is an
-  optimized 16-loop server, tracing off, eight aioquic processes, 128 QUIC
-  connections and 16 streams each: the send stack configures descriptor/socket
-  state, obtains the local endpoint for source-selected datagrams, then issues
-  one `sendmsg`. `fcntl`, `setsockopt`, and `getsockname` all remain visible
-  beside `sendmsg`. This repository deliberately does not modify Flyology core.
-- The final one-loop profile is likewise led by `memmove`, `sendmsg`,
-  `memset`, `fcntl`, scheduler work, and receive-flow-control bookkeeping.
-  The largest remaining copy roots are Flyology QUIC's transactional stream
-  frame processing (357 and 276 samples in the captured active stack), not
-  routing or QPACK. This is a minimal upstream finding: reproduce with the
-  one-loop command above, an explicit prepared lightweight RTS, and tracing
-  disabled; sample `http3_application_server` while the 400,000-request run is
-  active. Do not move those transaction semantics into this HTTP crate.
+- The short-response path is now close to H2 locally, but a response whose
+  encoded HEADERS plus DATA cannot share the 1,100-byte aggregate falls back to
+  individual packets. The validated 1,024-byte case measured 28.409k requests/s.
+  General packet segmentation/coalescing across larger responses is the next
+  material protocol-path opportunity; it must preserve congestion, recovery,
+  final-size, and retransmission accounting.
+- The post-batching profile is led by bounded record copies and packet I/O once
+  waits are excluded. Transactional flow state and the prepared response each
+  have fixed-size copies. Controlled no-copy/direct-slot variants were neutral
+  or slower, so further work needs a different representation with evidence,
+  not removal of transaction semantics.
+- Flyology now exposes portable `SO_REUSEPORT`, but this server still uses one
+  UDP listener with multiple Flyology loops. Naively giving each loop a reused
+  QUIC socket would allow the kernel to route later packets for one connection
+  to a different owner. Listener sharding therefore needs a connection-ID-aware
+  dispatch design and its own interop tests; the benchmark does not justify
+  weakening connection ownership.
 - Investigate delayed retirement of old H3 connection generations and long-run
-  throughput decay with a lifecycle-focused diagnostic build.
-- Reduce multi-process client scheduling and packet receive overhead before
-  treating 59k as a server ceiling.
+  throughput decay with a lifecycle-focused diagnostic build. The final
+  eight-connection topology avoids making that pressure part of the throughput
+  number but does not erase the earlier observation.
+- Isolate client and server on separate machines before interpreting remaining
+  CPU headroom. In co-located runs the Python oracle consumed several cores;
+  the `asyncio.timeout` change proved that oracle overhead can materially cap
+  the apparent server result.
 - The post-wake-source H2 profile is led by TLS/socket calls,
   scheduler/task-local lookup, byte comparison, and remaining bounded header
   construction. One loop reached a 44.8k median and 16 loops a 147.4k median

--- a/docs/http-stack-performance-2026-08-09.md
+++ b/docs/http-stack-performance-2026-08-09.md
@@ -89,8 +89,9 @@ connection-retirement/lifecycle pressure signal, not a steady-state result.
 ## Baselines and final measurements
 
 The baseline table uses medians of three controlled trials where available.
-The final H3 row is the last clean 16-loop post-change run after qualification.
-Latency values are milliseconds. All requests succeeded.
+The last H3 rows are fresh-server measurements of the final source, taken
+before the final qualification campaign. Latency values are milliseconds. All
+requests succeeded.
 
 | Configuration | Requests/s | p50 | p95 | p99 | Concurrency and reuse |
 | --- | ---: | ---: | ---: | ---: | --- |
@@ -104,6 +105,8 @@ Latency values are milliseconds. All requests succeeded.
 | H3, 1 server loop, ACK candidate | 26,827 | 35.25 | — | — | same; +4.3% rate, -3.8% p50 |
 | H3, 1 loop, pre-QPACK median | 27,310 | 32.8 | — | — | 4 workers, 64 connections x 16 streams |
 | H3, 1 loop, QPACK median | **30,097** | 29.6 | — | — | same; +10.2% rate, about -10% p50 |
+| H3, 1 loop, compact request slots | **31,713** | about 29.8 | — | — | same; +5.6% against fresh 30,019 median |
+| H3, 1 loop, bounded common QPACK lookup | **32,819** | 28.802 | — | — | same; +3.5% over compact slots, +9.3% over fresh 30,019 median |
 | H1, 16 loops, baseline median | 98,299 | 0.459 | 1.700 | 3.285 | 64 connections |
 | H2, 16 loops, baseline median | 32,035 | 1.946 | 2.552 | 2.795 | 4 connections x 16 streams |
 | H2, 16 loops, reusable handlers median | **89,856** | 0.533 | 0.987 | 5.762 | same; +180.5% |
@@ -112,6 +115,8 @@ Latency values are milliseconds. All requests succeeded.
 | H3, 16 loops, baseline | 54,123 | — | — | — | 8 workers, 128 connections x 16 streams |
 | H3, 16 loops, pre-QPACK best | **58,935** | 24.896 | 51.082 | 78.762 | 8 workers, 128 connections x 16 streams; reuse 6,250x |
 | H3, 16 loops, QPACK median | 57,222 | 26.617 | 46.145 | 65.833 | same; neutral within run noise |
+| H3, 16 loops, compact request slots median | 57,578 | — | — | — | same; neutral, best 61,596 |
+| H3, 16 loops, final bounded lookup median | 54,390 | 26.982 | 54.148 | 71.293 | same; neutral-to-uncertain in the 16-loop run band |
 
 The pre-QPACK 58.9k H3 run took 13.574 s for 800,000 requests. Handshake
 latency was
@@ -128,6 +133,20 @@ With 16 positively probed Flyology loops, sustained H3 crossed 50k and peaked
 in a clean run at 58.9k. Scaling saturated around 8 client workers:
 16 workers regressed to about 42k because handshake/process/packet pressure
 grew faster than useful server work.
+
+The final one-loop campaign used this exact client command against a fresh
+server for each trial:
+
+```sh
+build/oracle/aioquic/bin/python showcases/http3_benchmark.py \
+  --port 18443 --path /hello/test --requests 400000 \
+  --workers 4 --connections 64 --streams 16 --timeout 20
+```
+
+That is 1,024 maximum in-flight requests, 6,250 requests per connection, and
+64 reused QUIC connections. The corresponding 16-loop command used 800,000
+requests, eight workers, 128 connections, and 16 streams, for 2,048 maximum
+in flight and the same 6,250x connection reuse.
 
 ### H2 handler-task profile and scaling
 
@@ -359,7 +378,33 @@ builds were excluded from all reported rates.
    MB (about 22%). Throughput remained in the 50k+ band. This is a capacity
    improvement, not a claimed request-rate win.
 
-9. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
+9. **Materializing a second full H3 header block per active request was still
+   expensive.** A fresh optimized one-loop baseline at `e6272f4` measured
+   30.019k requests/s. The server adapter now writes decoded method, target,
+   authority, and ordinary headers directly into the unified request retained
+   by each bounded slot instead of retaining a separate, roughly 139 KiB
+   public H3 header block and copying it at dispatch. Three trials at
+   `3e80047` measured a 31.713k median (+5.6%), with p50 consistently about
+   29.6--29.8 ms instead of about 30.8--31.9 ms. A 1,000,000-request run
+   reached 32.123k with p50/p95/p99 of 30.257/32.995/33.689 ms. In comparable
+   server samples, active physical footprint fell from 247.8 to 189.1 MB and
+   `memmove` samples fell from 2,242 to 1,960 despite higher throughput. The
+   16-loop median was 57.578k, neutral in the existing run band.
+
+10. **Common response fields still searched irrelevant QPACK ranges.** The
+    prior accepted QPACK matcher removed secondary-stack-heavy name
+    construction, but `:status`, `content-type`, and `content-length` still
+    walked entries that cannot match those names. Restricting exact lookup to
+    their RFC 9204 static-table ranges while preserving the generic fallback
+    raised the one-loop median from 31.713k to 32.819k (+3.5%); the three
+    trials were 31.974k, 33.068k, and 32.819k. A 1,000,000-request run measured
+    32.678k with p50/p95/p99 of 29.606/31.968/44.142 ms. Comparable profile
+    samples in `QPACK_Static_Table.Find` fell from 227 to 23, about 90%. The
+    16-loop trials were 58.074k, 54.390k, and 53.994k (54.390k median), below
+    the preceding compact-slot median but within the broad 47.5--61.6k
+    multi-loop band. No 16-loop gain is claimed.
+
+11. **Single-process aioquic is an oracle bottleneck.** One worker stayed near
    13k even against 16 loops. Four workers sustained about 50k; eight reached
    54-59k. The benchmark now records workers explicitly so “single client” is
    not confused with “single Flyology loop.”
@@ -425,6 +470,14 @@ lifecycle pressure.
   --connections 64 --streams 16 --timeout 20`. P50/p95/p99 latency was
   effectively unchanged. The extra ownership machinery had no material
   benefit, so it was reverted.
+- Moving one redundant public `QUIC.Datagram` clear to the uninitialized error
+  path measured 33.058k, 33.039k, and 32.966k requests/s (33.039k median), only
+  +0.67% over the final QPACK baseline. It was reverted as non-material.
+- Leaving the internal 1,109-byte combined HEADERS/DATA staging array
+  uninitialized, after proving the transmitted slice is fully assigned,
+  measured 33.130k, 33.130k, and 32.946k requests/s (33.130k median), +0.95%.
+  This was also reverted rather than trading easier initialization reasoning
+  for a sub-one-percent result.
 
 ## Correctness qualification
 
@@ -443,11 +496,13 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
   ./scripts/test-http3-stress.sh
 ```
 
-- Full repository behavioral suite: pass, including all 42 QUIC checks.
+- Full repository behavioral suite: pass after the final source changes,
+  including all 42 QUIC checks. The SPARK campaign proved all 2,928 checks.
 - H2: Go, Node, and nghttpd peers passed in native and lightweight models;
   fault campaign and bounded soak passed; h2spec 146/146 passed. The full H2
-  qualification was repeated after all three accepted H2 changes. The HPACK and
-  Huffman differential suites passed 500 and 1,000 cases respectively.
+  qualification was repeated after the final H3 changes as a cross-protocol
+  guard. The HPACK and Huffman differential suites passed 500 and 1,000 cases
+  respectively.
 - H3: aioquic and quic-go passed in both Ada client and Ada server roles.
 - h3spec 0.1.13: a first run passed all HTTP/3 and QPACK cases but was 48/49
   because one randomized QUIC Handshake reserved-bit case did not observe its
@@ -467,6 +522,14 @@ FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE=16 \
   state, obtains the local endpoint for source-selected datagrams, then issues
   one `sendmsg`. `fcntl`, `setsockopt`, and `getsockname` all remain visible
   beside `sendmsg`. This repository deliberately does not modify Flyology core.
+- The final one-loop profile is likewise led by `memmove`, `sendmsg`,
+  `memset`, `fcntl`, scheduler work, and receive-flow-control bookkeeping.
+  The largest remaining copy roots are Flyology QUIC's transactional stream
+  frame processing (357 and 276 samples in the captured active stack), not
+  routing or QPACK. This is a minimal upstream finding: reproduce with the
+  one-loop command above, an explicit prepared lightweight RTS, and tracing
+  disabled; sample `http3_application_server` while the 400,000-request run is
+  active. Do not move those transaction semantics into this HTTP crate.
 - Investigate delayed retirement of old H3 connection generations and long-run
   throughput decay with a lifecycle-focused diagnostic build.
 - Reduce multi-process client scheduling and packet receive overhead before

--- a/flyology_quic/scripts/test.sh
+++ b/flyology_quic/scripts/test.sh
@@ -52,6 +52,7 @@ for test in \
   flyology-quic-ack_frame_policy-smoke \
   flyology-quic-ack_range_policy-smoke \
   flyology-quic-application_connection-smoke \
+  flyology-quic-application_space-batch_smoke \
   flyology-quic-application_space-smoke \
   flyology-quic-application_frame_policy-smoke \
   flyology-quic-connection_state_policy-smoke \

--- a/flyology_quic/src/flyology-quic-application_connection.adb
+++ b/flyology_quic/src/flyology-quic-application_connection.adb
@@ -146,9 +146,23 @@ package body Flyology.QUIC.Application_Connection is
               One_RTT_Receiver.Received
                 | One_RTT_Receiver.Invalid_Reserved_Bits
               and then
-                Candidate.Key_Phase /= Item.Receiving_Key_Phase
+               Candidate.Key_Phase /= Item.Receiving_Key_Phase
             then
                if Candidate.Status = One_RTT_Receiver.Received then
+                  if Item.Sending_Key_Phase /= Candidate.Key_Phase then
+                     declare
+                        Next_Sending : TLS_Key_Schedule.QUIC_Traffic_Keys;
+                     begin
+                        --  The next packet can ACK Candidate, so RFC 9001
+                        --  requires the responder's corresponding send phase.
+                        TLS_Key_Schedule.Update_QUIC_Keys
+                          (Item.Backend, Item.Sending, Next_Sending);
+                        TLS_Key_Schedule.Clear (Item.Sending);
+                        Item.Sending := Next_Sending;
+                        TLS_Key_Schedule.Clear (Next_Sending);
+                        Item.Sending_Key_Phase := Candidate.Key_Phase;
+                     end;
+                  end if;
                   Item.Previous_Receiving := Item.Receiving;
                   Item.Has_Previous_Receiving := True;
                   Item.Receiving := Item.Next_Receiving;

--- a/flyology_quic/src/flyology-quic-application_space.adb
+++ b/flyology_quic/src/flyology-quic-application_space.adb
@@ -1053,10 +1053,10 @@ package body Flyology.QUIC.Application_Space is
       Local_Uni_Opened : constant Stream_ID_Policy.Stream_Count :=
         Stream_ID_Policy.Opened_Count
           (Item.Allocator, Stream_ID_Policy.Unidirectional);
-      --  The stream table dominates connection-state size, so validate every
-      --  frame before changing it and reserve a full table transaction for
-      --  the uncommon packet that changes multiple streams. The smaller
-      --  policy tables remain staged until all packet effects succeed.
+      --  Validate every frame before changing the stream table. Policy state
+      --  remains staged until all packet effects succeed. Retransmission
+      --  payloads are much larger than the sent-packet ledger, so retain only
+      --  the bounded ACK resolutions and apply them at commit.
       Candidate_Streams : Stream_Table_Policy.Stream_Table
         renames Item.Streams;
       Candidate_Receive : Receive_Flow_Control_Policy.State :=
@@ -1064,10 +1064,8 @@ package body Flyology.QUIC.Application_Space is
       Candidate_Flow : Flow_Control_Policy.State := Item.Flow;
       Candidate_Sent : Sent_Packet_Policy.Ledger := Item.Sent;
       Candidate_Recovery : Recovery_Policy.State := Item.Recovery;
-      Candidate_Retransmittable : Retransmittable_Table
-        := Item.Retransmittable;
-      Candidate_Packet_Frames : Packet_Frame_Table
-        := Item.Packet_Frames;
+      Pending_Resolutions : Sent_Packet_Policy.Packet_Event_Array;
+      Pending_Resolution_Count : Sent_Packet_Policy.Sent_Count := 0;
       Candidate_Peer_Bidi : Varint_Policy.Value_Type := Item.Peer_Bidi;
       Candidate_Peer_Uni : Varint_Policy.Value_Type := Item.Peer_Uni;
       Active_Stream_Frame_Count : Natural := 0;
@@ -1277,11 +1275,12 @@ package body Flyology.QUIC.Application_Space is
             Sampled := False;
             ACKed_Ack_Eliciting := False;
             for Index in 1 .. Applied.Count loop
-               Resolve_Retransmittable_Frame
-                 (Candidate_Retransmittable, Candidate_Packet_Frames,
-                  Applied.Events (Index).Packet.Number,
-                  Applied.Events (Index).Kind =
-                    Sent_Packet_Policy.Acknowledged);
+               pragma Assert
+                 (Pending_Resolution_Count <
+                    Sent_Packet_Policy.Max_Sent_Packets);
+               Pending_Resolution_Count := Pending_Resolution_Count + 1;
+               Pending_Resolutions (Pending_Resolution_Count) :=
+                 Applied.Events (Index);
                if Applied.Events (Index).Kind =
                  Sent_Packet_Policy.Acknowledged
                  and then Applied.Events (Index).Packet.ACK_Eliciting
@@ -1369,12 +1368,17 @@ package body Flyology.QUIC.Application_Space is
          return;
       end if;
 
+      for Index in 1 .. Pending_Resolution_Count loop
+         Resolve_Retransmittable_Frame
+           (Item.Retransmittable, Item.Packet_Frames,
+            Pending_Resolutions (Index).Packet.Number,
+            Pending_Resolutions (Index).Kind =
+              Sent_Packet_Policy.Acknowledged);
+      end loop;
       Item.Receive_Flow := Candidate_Receive;
       Item.Flow := Candidate_Flow;
       Item.Sent := Candidate_Sent;
       Item.Recovery := Candidate_Recovery;
-      Item.Retransmittable := Candidate_Retransmittable;
-      Item.Packet_Frames := Candidate_Packet_Frames;
       Item.Peer_Bidi := Candidate_Peer_Bidi;
       Item.Peer_Uni := Candidate_Peer_Uni;
       Result.Status := Processed;

--- a/flyology_quic/src/flyology-quic-application_space.adb
+++ b/flyology_quic/src/flyology-quic-application_space.adb
@@ -526,6 +526,156 @@ package body Flyology.QUIC.Application_Space is
       Result.Status := Sent;
    end Build_Stream_Packet;
 
+   procedure Build_Stream_Batch_Packet
+     (Item        : in out State;
+      Fragments   : Stream_Fragment_Array;
+      Data        : Ada.Streams.Stream_Element_Array;
+      Now         : Timestamp;
+      Packet      : out Ada.Streams.Stream_Element_Array;
+      Result      : out Send_Result;
+      Include_ACK : Boolean := False)
+   is
+      Frame          : Stream_Frame_Policy.Encode_Result;
+      ACK_Frame      : ACK_Frame_Policy.Encode_Result;
+      Plaintext      : Ada.Streams.Stream_Element_Array
+        (1 .. Max_Retransmittable_Length) := (others => 0);
+      Plaintext_Length : Natural range 0 .. Max_Retransmittable_Length := 0;
+      Data_Offset    : Natural := 0;
+      Built          : Application_Connection.Build_Result;
+      Record_Status  : Sent_Packet_Policy.Record_Status;
+      Account_Status : Recovery_Policy.Send_Status;
+      Flow_Status    : Flow_Control_Policy.Reserve_Status;
+      Candidate_Flow : Flow_Control_Policy.State := Item.Flow;
+      Sent_Packet    : Sent_Packet_Policy.Sent_Packet;
+   begin
+      Packet := (others => 0);
+      Result := (others => <>);
+      if Sent_Packet_Policy.Retained (Item.Sent) =
+        Sent_Packet_Policy.Max_Sent_Packets
+        or else Free_Retransmittable_Frame (Item) = 0
+        or else Free_Packet_Frame_Mapping (Item) = 0
+      then
+         Result.Status := Recovery_Capacity_Exceeded;
+         return;
+      elsif not Recovery_Policy.Can_Send
+        (Item.Recovery,
+         Sent_Packet_Policy.Packet_Byte_Count (Max_Datagram_Length))
+      then
+         Result.Status := Congestion_Blocked;
+         return;
+      end if;
+
+      ACK_Frame := (others => <>);
+      if Include_ACK then
+         ACK_Frame := Application_Connection.Encode_ACK
+           (Item.Packets, ACK_Delay => 0);
+      end if;
+      if ACK_Frame.Status = ACK_Frame_Policy.Encoded then
+         Plaintext
+           (1 .. Ada.Streams.Stream_Element_Offset (ACK_Frame.Length)) :=
+             ACK_Frame.Data
+               (1 .. Ada.Streams.Stream_Element_Offset (ACK_Frame.Length));
+         Plaintext_Length := ACK_Frame.Length;
+         Result.ACK_Included := True;
+      end if;
+
+      for Fragment of Fragments loop
+         declare
+            First : Ada.Streams.Stream_Element_Offset;
+            Last  : Ada.Streams.Stream_Element_Offset;
+         begin
+            if not Stream_Was_Opened (Item, Fragment.ID) then
+               Result.Status := Stream_Not_Sendable;
+               return;
+            elsif Fragment.Length > Data'Length - Data_Offset then
+               Result.Status := Internal_State_Error;
+               return;
+            end if;
+
+            Flow_Control_Policy.Reserve_Send
+              (Candidate_Flow, Fragment.ID, Fragment.Offset, Fragment.Length,
+               Fragment.Fin, Flow_Status);
+            if Flow_Status /= Flow_Control_Policy.Reserved then
+               Result.Status := Send_Status_For (Flow_Status);
+               return;
+            end if;
+
+            First := Data'First
+              + Ada.Streams.Stream_Element_Offset (Data_Offset);
+            Last := First
+              + Ada.Streams.Stream_Element_Offset (Fragment.Length) - 1;
+            Frame := Stream_Frame_Policy.Encode
+              (Fragment.ID, Fragment.Offset, Fragment.Fin,
+               Data (First .. Last));
+            if Frame.Status /= Stream_Frame_Policy.Encoded then
+               Result.Status := Stream_Range_Too_Large;
+               return;
+            elsif Frame.Length >
+              Max_Retransmittable_Length - Plaintext_Length
+            then
+               Result.Status := Packet_Too_Large;
+               return;
+            end if;
+            Plaintext
+              (Ada.Streams.Stream_Element_Offset (Plaintext_Length + 1)
+                 .. Ada.Streams.Stream_Element_Offset
+                      (Plaintext_Length + Frame.Length)) :=
+                Frame.Data
+                  (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length));
+            Plaintext_Length := Plaintext_Length + Frame.Length;
+            Data_Offset := Data_Offset + Fragment.Length;
+         end;
+      end loop;
+      if Data_Offset /= Data'Length then
+         Result.Status := Internal_State_Error;
+         return;
+      end if;
+
+      Application_Connection.Build_One_RTT
+        (Item.Packets,
+         Plaintext
+           (1 .. Ada.Streams.Stream_Element_Offset (Plaintext_Length)),
+         Packet, Built);
+      Result.Number := Built.Number;
+      if Built.Status /= Application_Connection.Built then
+         Result.Status := Send_Status_For (Built.Status);
+         return;
+      elsif Built.Packet_Length > Max_Datagram_Length then
+         Result.Status := Packet_Too_Large;
+         return;
+      end if;
+
+      Item.Flow := Candidate_Flow;
+      Result.Packet_Length := Built.Packet_Length;
+      Sent_Packet :=
+        (Number        => Built.Number,
+         Sent_At       => Now,
+         Bytes         => Sent_Packet_Policy.Packet_Byte_Count
+           (Built.Packet_Length),
+         ACK_Eliciting => True,
+         In_Flight     => True);
+      Sent_Packet_Policy.Record_Sent
+        (Item.Sent, Sent_Packet, Record_Status);
+      if Record_Status /= Sent_Packet_Policy.Recorded then
+         Result.Status := Internal_State_Error;
+         return;
+      end if;
+      Recovery_Policy.On_Packet_Sent
+        (Item.Recovery, Sent_Packet, Permit_Probe => False,
+         Status => Account_Status);
+      if Account_Status /= Recovery_Policy.Accounted then
+         Result.Status := Internal_State_Error;
+         return;
+      end if;
+      Item.Has_Latest_ACK_Eliciting := True;
+      Item.Latest_ACK_Eliciting := Now;
+      Retain_New_Frame
+        (Item, Built.Number,
+         Plaintext
+           (1 .. Ada.Streams.Stream_Element_Offset (Plaintext_Length)));
+      Result.Status := Sent;
+   end Build_Stream_Batch_Packet;
+
    procedure Build_Tracked_Frame_Packet
      (Item         : in out State;
       Plaintext    : Ada.Streams.Stream_Element_Array;

--- a/flyology_quic/src/flyology-quic-application_space.ads
+++ b/flyology_quic/src/flyology-quic-application_space.ads
@@ -85,6 +85,16 @@ private package Flyology.QUIC.Application_Space is
       ACK_Included  : Boolean := False;
    end record;
 
+   Max_Stream_Fragments : constant Positive := 8;
+   type Stream_Fragment is record
+      ID     : Varint_Policy.Value_Type := 0;
+      Offset : Varint_Policy.Value_Type := 0;
+      Length : Natural range 0 .. Max_Stream_Payload := 0;
+      Fin    : Boolean := False;
+   end record;
+   type Stream_Fragment_Array is
+     array (Positive range <>) of Stream_Fragment;
+
    procedure Build_Stream_Packet
      (Item      : in out State;
       Stream_ID : Varint_Policy.Value_Type;
@@ -97,6 +107,20 @@ private package Flyology.QUIC.Application_Space is
       Include_ACK : Boolean := False)
    with
      Pre => Is_Initialized (Item)
+       and then Data'Length <= Max_Stream_Payload
+       and then Packet'Length >= Max_Datagram_Length;
+
+   procedure Build_Stream_Batch_Packet
+     (Item        : in out State;
+      Fragments   : Stream_Fragment_Array;
+      Data        : Ada.Streams.Stream_Element_Array;
+      Now         : Timestamp;
+      Packet      : out Ada.Streams.Stream_Element_Array;
+      Result      : out Send_Result;
+      Include_ACK : Boolean := False)
+   with
+     Pre => Is_Initialized (Item)
+       and then Fragments'Length in 1 .. Max_Stream_Fragments
        and then Data'Length <= Max_Stream_Payload
        and then Packet'Length >= Max_Datagram_Length;
 

--- a/flyology_quic/src/flyology-quic-connection_driver.adb
+++ b/flyology_quic/src/flyology-quic-connection_driver.adb
@@ -162,6 +162,28 @@ package body Flyology.QUIC.Connection_Driver is
       end if;
    end Build_Stream_Datagram_With_ACK;
 
+   procedure Build_Stream_Batch_Datagram_With_ACK
+     (Item         : in out Connection;
+      Fragments    : Application_Space.Stream_Fragment_Array;
+      Data         : Ada.Streams.Stream_Element_Array;
+      Now          : Application_Space.Timestamp;
+      Packet       : out Datagram;
+      Status       : out Application_Space.Send_Status;
+      ACK_Included : out Boolean)
+   is
+      Built : Application_Space.Send_Result;
+   begin
+      Packet := (others => <>);
+      Application_Space.Build_Stream_Batch_Packet
+        (Item.Application, Fragments, Data, Now, Packet.Data, Built,
+         Include_ACK => True);
+      Status := Built.Status;
+      ACK_Included := Built.ACK_Included;
+      if Built.Status = Application_Space.Sent then
+         Packet.Length := Built.Packet_Length;
+      end if;
+   end Build_Stream_Batch_Datagram_With_ACK;
+
    procedure Build_Stream_Abort_Datagram
      (Item              : in out Connection;
       Stream_ID         : Varint_Policy.Value_Type;

--- a/flyology_quic/src/flyology-quic-connection_driver.ads
+++ b/flyology_quic/src/flyology-quic-connection_driver.ads
@@ -187,6 +187,18 @@ private package Flyology.QUIC.Connection_Driver is
    with Pre => Is_Connected (Item)
      and then Data'Length <= Application_Space.Max_Stream_Payload;
 
+   procedure Build_Stream_Batch_Datagram_With_ACK
+     (Item         : in out Connection;
+      Fragments    : Application_Space.Stream_Fragment_Array;
+      Data         : Ada.Streams.Stream_Element_Array;
+      Now          : Application_Space.Timestamp;
+      Packet       : out Datagram;
+      Status       : out Application_Space.Send_Status;
+      ACK_Included : out Boolean)
+   with Pre => Is_Connected (Item)
+     and then Fragments'Length in 1 .. Application_Space.Max_Stream_Fragments
+     and then Data'Length <= Application_Space.Max_Stream_Payload;
+
    procedure Build_Stream_Abort_Datagram
      (Item              : in out Connection;
       Stream_ID         : Varint_Policy.Value_Type;

--- a/flyology_quic/src/flyology-quic-connections.adb
+++ b/flyology_quic/src/flyology-quic-connections.adb
@@ -100,6 +100,22 @@ package body Flyology.QUIC.Connections is
            "the QUIC cryptographic provider could not generate randomness";
    end Random_Connection_ID;
 
+   function Total_Length
+     (Fragments : Stream_Fragment_Array) return Natural
+   is
+      Result : Natural := 0;
+   begin
+      for Fragment of Fragments loop
+         if Fragment.Length > Max_Stream_Payload -
+           Natural'Min (Result, Max_Stream_Payload)
+         then
+            return Max_Stream_Payload + 1;
+         end if;
+         Result := Result + Fragment.Length;
+      end loop;
+      return Result;
+   end Total_Length;
+
    function Inspect_Datagram_Header
      (Data : Ada.Streams.Stream_Element_Array;
       Short_Header_Destination_Length : Positive := 8)
@@ -550,6 +566,35 @@ package body Flyology.QUIC.Connections is
       Copy (Internal_Packet, Packet);
       Status := Public_Status (Internal_Status);
    end Build_Stream_Datagram_With_ACK;
+
+   procedure Build_Stream_Batch_Datagram_With_ACK
+     (Item         : in out Connection;
+      Fragments    : Stream_Fragment_Array;
+      Data         : Ada.Streams.Stream_Element_Array;
+      Now          : Timestamp;
+      Packet       : out Datagram;
+      Status       : out Send_Status;
+      ACK_Included : out Boolean)
+   is
+      Internal_Fragments : Application_Space.Stream_Fragment_Array
+        (Fragments'Range);
+      Internal_Packet : Connection_Driver.Datagram;
+      Internal_Status : Application_Space.Send_Status;
+   begin
+      for Index in Fragments'Range loop
+         Internal_Fragments (Index) :=
+           (ID     => Fragments (Index).ID,
+            Offset => Fragments (Index).Offset,
+            Length => Fragments (Index).Length,
+            Fin    => Fragments (Index).Fin);
+      end loop;
+      Connection_Driver.Build_Stream_Batch_Datagram_With_ACK
+        (Impl (Item).Driver, Internal_Fragments, Data,
+         Application_Space.Timestamp (Now), Internal_Packet, Internal_Status,
+         ACK_Included);
+      Copy (Internal_Packet, Packet);
+      Status := Public_Status (Internal_Status);
+   end Build_Stream_Batch_Datagram_With_ACK;
 
    procedure Build_Stream_Abort_Datagram
      (Item              : in out Connection;

--- a/flyology_quic/src/flyology-quic-connections.ads
+++ b/flyology_quic/src/flyology-quic-connections.ads
@@ -19,6 +19,10 @@ package Flyology.QUIC.Connections is
    Max_Output_Datagrams : constant := 20;
    --  Largest stream payload carried by one generated datagram.
    Max_Stream_Payload : constant := 1_100;
+   --  Largest number of independent STREAM frames combined in one generated
+   --  1-RTT packet. The aggregate encoded packet remains bounded by
+   --  Max_Datagram_Length.
+   Max_Stream_Fragments : constant Positive := 8;
    --  Lifetime stream accounting retained by one bounded QUIC connection.
    --  Large byte reassembly buffers remain separately bounded to 32 active
    --  streams and are recycled after protocol completion.
@@ -125,6 +129,28 @@ package Flyology.QUIC.Connections is
       Items : Datagram_Array;
       Count : Natural range 0 .. Max_Output_Datagrams := 0;
    end record;
+
+   --  Description of one slice in the aggregate Data argument supplied to
+   --  Build_Stream_Batch_Datagram_With_ACK.
+   --  @field ID QUIC stream identifier
+   --  @field Offset Absolute stream offset of the slice
+   --  @field Length Number of aggregate Data octets belonging to this stream
+   --  @field Fin Whether the slice sets the stream final size
+   type Stream_Fragment is record
+      ID     : Stream_ID := 0;
+      Offset : Stream_Offset := 0;
+      Length : Natural range 0 .. Max_Stream_Payload := 0;
+      Fin    : Boolean := False;
+   end record;
+
+   --  Bounded descriptions for STREAM frames combined into one packet.
+   type Stream_Fragment_Array is
+     array (Positive range <>) of Stream_Fragment;
+
+   --  Return the aggregate payload length described by Fragments, capped one
+   --  past Max_Stream_Payload so callers can validate without overflow.
+   function Total_Length
+     (Fragments : Stream_Fragment_Array) return Natural;
 
    --  Externally visible connection phase.
    --  @enum Uninitialized No endpoint configuration has been supplied
@@ -485,6 +511,31 @@ package Flyology.QUIC.Connections is
       Status       : out Send_Status;
       ACK_Included : out Boolean)
    with Pre => Is_Connected (Item)
+     and then Data'Length <= Max_Stream_Payload;
+
+   --  Build one protected packet containing STREAM frames for several
+   --  independent streams and include the current application ACK when it
+   --  fits. All stream-flow reservations commit together only when Status is
+   --  Sent. Packet_Too_Large leaves every stream unsent so callers can fall
+   --  back to individual packets.
+   --  @param Item Connected endpoint
+   --  @param Fragments Ordered stream slice descriptions
+   --  @param Data Concatenated slice payloads in Fragments order
+   --  @param Now Monotonic microsecond timestamp for recovery accounting
+   --  @param Packet Datagram to transmit when Status is Sent
+   --  @param Status Build outcome
+   --  @param ACK_Included Whether the datagram carries an ACK frame
+   procedure Build_Stream_Batch_Datagram_With_ACK
+     (Item         : in out Connection;
+      Fragments    : Stream_Fragment_Array;
+      Data         : Ada.Streams.Stream_Element_Array;
+      Now          : Timestamp;
+      Packet       : out Datagram;
+      Status       : out Send_Status;
+      ACK_Included : out Boolean)
+   with Pre => Is_Connected (Item)
+     and then Fragments'Length in 1 .. Max_Stream_Fragments
+     and then Total_Length (Fragments) = Data'Length
      and then Data'Length <= Max_Stream_Payload;
 
    --  Build one protected cancellation packet for both directions of a

--- a/flyology_quic/tests/flyology_quic_tests.gpr
+++ b/flyology_quic/tests/flyology_quic_tests.gpr
@@ -9,6 +9,7 @@ project Flyology_QUIC_Tests is
      ("flyology-quic-ack_frame_policy-smoke.adb",
       "flyology-quic-ack_range_policy-smoke.adb",
       "flyology-quic-application_connection-smoke.adb",
+      "flyology-quic-application_space-batch_smoke.adb",
       "flyology-quic-application_space-smoke.adb",
       "flyology-quic-application_frame_policy-smoke.adb",
       "flyology-quic-connection_state_policy-smoke.adb",

--- a/flyology_quic/tests/src/flyology-quic-application_connection-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-application_connection-smoke.adb
@@ -78,11 +78,14 @@ begin
 
       declare
          Backend : Crypto_OpenSSL.Provider;
-         Next_Keys, Next_Next_Keys : TLS_Key_Schedule.QUIC_Traffic_Keys;
+         Next_Keys, Next_Next_Keys, Third_Keys :
+           TLS_Key_Schedule.QUIC_Traffic_Keys;
          Old_Packet, Updated_Packet :
            Ada.Streams.Stream_Element_Array (1 .. 64);
          Old_Built : Build_Result;
          Updated : One_RTT_Sender.Send_Result;
+         Response_Packet : Ada.Streams.Stream_Element_Array (1 .. 64);
+         Response_Built : Build_Result;
       begin
          Crypto_OpenSSL.Initialize_Provider (Backend);
          Build_One_RTT (Client, Plaintext, Old_Packet, Old_Built);
@@ -102,6 +105,20 @@ begin
             Updated_Packet
               (1 .. Ada.Streams.Stream_Element_Offset
                       (Updated.Packet_Length)),
+            Decoded, Processed_Packet);
+         pragma Assert
+           (Processed_Packet.Status = Processed
+            and then Processed_Packet.Packet.Key_Phase);
+         Build_One_RTT
+           (Server, Plaintext, Response_Packet, Response_Built);
+         pragma Assert
+           (Response_Built.Status = Built
+            and then Server.Sending_Key_Phase);
+         Process_One_RTT
+           (Client,
+            Response_Packet
+              (1 .. Ada.Streams.Stream_Element_Offset
+                      (Response_Built.Packet_Length)),
             Decoded, Processed_Packet);
          pragma Assert
            (Processed_Packet.Status = Processed
@@ -135,6 +152,62 @@ begin
          pragma Assert
            (Processed_Packet.Status = Processed
             and then not Processed_Packet.Packet.Key_Phase);
+         Build_One_RTT
+           (Server, Plaintext, Response_Packet, Response_Built);
+         pragma Assert
+           (Response_Built.Status = Built
+            and then not Server.Sending_Key_Phase);
+         Process_One_RTT
+           (Client,
+            Response_Packet
+              (1 .. Ada.Streams.Stream_Element_Offset
+                      (Response_Built.Packet_Length)),
+            Decoded, Processed_Packet);
+         pragma Assert
+           (Processed_Packet.Status = Processed
+            and then not Processed_Packet.Packet.Key_Phase);
+
+         declare
+            Next_Server_Sending : TLS_Key_Schedule.QUIC_Traffic_Keys;
+         begin
+            TLS_Key_Schedule.Update_QUIC_Keys
+              (Backend, Server.Sending, Next_Server_Sending);
+            TLS_Key_Schedule.Clear (Server.Sending);
+            Server.Sending := Next_Server_Sending;
+            TLS_Key_Schedule.Clear (Next_Server_Sending);
+            Server.Sending_Key_Phase := True;
+         end;
+         TLS_Key_Schedule.Update_QUIC_Keys
+           (Backend, Next_Next_Keys, Third_Keys);
+         One_RTT_Sender.Send
+           (Backend, Third_Keys.Key, Third_Keys.IV, Third_Keys.HP,
+            Server_ID, 4, 1, Key_Phase => True, Spin => False,
+            Plaintext => Plaintext, Packet => Updated_Packet,
+            Result => Updated);
+         pragma Assert (Updated.Status = One_RTT_Sender.Sent);
+         Process_One_RTT
+           (Server,
+            Updated_Packet
+              (1 .. Ada.Streams.Stream_Element_Offset
+                      (Updated.Packet_Length)),
+            Decoded, Processed_Packet);
+         pragma Assert
+           (Processed_Packet.Status = Processed
+            and then Processed_Packet.Packet.Key_Phase);
+         Build_One_RTT
+           (Server, Plaintext, Response_Packet, Response_Built);
+         pragma Assert
+           (Response_Built.Status = Built
+            and then Server.Sending_Key_Phase);
+         Process_One_RTT
+           (Client,
+            Response_Packet
+              (1 .. Ada.Streams.Stream_Element_Offset
+                      (Response_Built.Packet_Length)),
+            Decoded, Processed_Packet);
+         pragma Assert
+           (Processed_Packet.Status = Processed
+            and then Processed_Packet.Packet.Key_Phase);
       end;
 
       declare

--- a/flyology_quic/tests/src/flyology-quic-application_space-batch_smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-application_space-batch_smoke.adb
@@ -1,0 +1,130 @@
+procedure Flyology.QUIC.Application_Space.Batch_Smoke is
+   use type Ada.Streams.Stream_Element;
+   use type Stream_ID_Policy.Open_Status;
+   use type Timestamp;
+
+   function ID
+     (Data : Ada.Streams.Stream_Element_Array)
+      return Long_Header_Policy.Connection_ID
+   is
+      Result : Long_Header_Policy.Connection_ID;
+   begin
+      Result.Length := Natural (Data'Length);
+      Result.Data (1 .. Data'Length) := Data;
+      return Result;
+   end ID;
+
+   Client_Keys : constant TLS_Key_Schedule.QUIC_Traffic_Keys :=
+     (Traffic => (others => 16#01#),
+      Key => (others => 16#11#), IV => (others => 16#22#),
+      HP => (others => 16#33#));
+   Server_Keys : constant TLS_Key_Schedule.QUIC_Traffic_Keys :=
+     (Traffic => (others => 16#02#),
+      Key => (others => 16#44#), IV => (others => 16#55#),
+      HP => (others => 16#66#));
+   Client_ID : constant Long_Header_Policy.Connection_ID :=
+     ID ((16#AA#, 16#BB#, 16#CC#, 16#DD#));
+   Server_ID : constant Long_Header_Policy.Connection_ID :=
+     ID ((16#10#, 16#20#, 16#30#, 16#40#));
+
+   Client_Parameters : Transport_Parameter_Policy.Transport_Parameters;
+   Server_Parameters : Transport_Parameter_Policy.Transport_Parameters;
+   Client : State;
+   Server : State;
+   Packet : Ada.Streams.Stream_Element_Array (1 .. Max_Datagram_Length);
+   Sent : Send_Result;
+   Received : Process_Result;
+   Opened_ID : Varint_Policy.Value_Type;
+   Opened : Open_Status;
+   Fragments : constant Stream_Fragment_Array :=
+     (1 => (ID => 0, Offset => 0, Length => 1, Fin => True),
+      2 => (ID => 4, Offset => 0, Length => 1, Fin => True));
+   Over_Credit : constant Stream_Fragment_Array :=
+     (1 => (ID => 0, Offset => 0, Length => 2, Fin => True),
+      2 => (ID => 4, Offset => 0, Length => 1, Fin => True));
+
+   procedure Open_And_Deliver_Request
+     (Expected_ID : Varint_Policy.Value_Type;
+      Value       : Ada.Streams.Stream_Element;
+      Now         : Timestamp)
+   is
+   begin
+      Open_Stream
+        (Client, Stream_ID_Policy.Bidirectional, Opened_ID, Opened);
+      pragma Assert
+        (Opened = Stream_ID_Policy.Opened and then Opened_ID = Expected_ID);
+      Build_Stream_Packet
+        (Client, Opened_ID, Offset => 0, Fin => True,
+         Data => (1 => Value), Now => Now, Packet => Packet, Result => Sent);
+      pragma Assert (Sent.Status = Application_Space.Sent);
+      Process_Packet
+        (Server,
+         Packet
+           (1 .. Ada.Streams.Stream_Element_Offset (Sent.Packet_Length)),
+         Now => Now + 1, ACK_Delay_Exponent => 3,
+         Maximum_ACK_Delay => 25_000, Handshake_Confirmed => True,
+         Result => Received);
+      pragma Assert (Received.Status = Processed);
+   end Open_And_Deliver_Request;
+begin
+   Client_Parameters.Initial_Max_Data := (Present => True, Value => 2);
+   Client_Parameters.Initial_Max_Stream_Data_Bidi_Local :=
+     (Present => True, Value => 2);
+   Client_Parameters.Initial_Max_Stream_Data_Bidi_Remote :=
+     (Present => True, Value => 2);
+   Client_Parameters.Initial_Max_Stream_Data_Uni :=
+     (Present => True, Value => 2);
+   Client_Parameters.Initial_Max_Streams_Bidi :=
+     (Present => True, Value => 2);
+   Client_Parameters.Initial_Max_Streams_Uni :=
+     (Present => True, Value => 1);
+
+   Server_Parameters.Initial_Max_Data := (Present => True, Value => 100);
+   Server_Parameters.Initial_Max_Stream_Data_Bidi_Local :=
+     (Present => True, Value => 100);
+   Server_Parameters.Initial_Max_Stream_Data_Bidi_Remote :=
+     (Present => True, Value => 100);
+   Server_Parameters.Initial_Max_Stream_Data_Uni :=
+     (Present => True, Value => 100);
+   Server_Parameters.Initial_Max_Streams_Bidi :=
+     (Present => True, Value => 4);
+   Server_Parameters.Initial_Max_Streams_Uni :=
+     (Present => True, Value => 4);
+
+   Initialize
+     (Client, Client_Keys, Server_Keys, Server_ID, Client_ID,
+      Stream_ID_Policy.Client, Client_Parameters, Server_Parameters);
+   Initialize
+     (Server, Server_Keys, Client_Keys, Client_ID, Server_ID,
+      Stream_ID_Policy.Server, Server_Parameters, Client_Parameters);
+   Open_And_Deliver_Request (0, 16#A0#, 700);
+   Open_And_Deliver_Request (4, 16#A4#, 702);
+
+   Build_Stream_Batch_Packet
+     (Server, Over_Credit, (16#B0#, 16#B1#, 16#B4#),
+      Now => 704, Packet => Packet, Result => Sent);
+   pragma Assert
+     (Sent.Status = Connection_Flow_Blocked
+      and then Committed_Data (Server) = 0);
+
+   Build_Stream_Batch_Packet
+     (Server, Fragments, (16#C0#, 16#C4#),
+      Now => 705, Packet => Packet, Result => Sent);
+   pragma Assert
+     (Sent.Status = Application_Space.Sent
+      and then Committed_Data (Server) = 2);
+   Process_Packet
+     (Client,
+      Packet (1 .. Ada.Streams.Stream_Element_Offset (Sent.Packet_Length)),
+      Now => 706, ACK_Delay_Exponent => 3,
+      Maximum_ACK_Delay => 25_000, Handshake_Confirmed => True,
+      Result => Received);
+   pragma Assert
+     (Received.Status = Processed
+      and then Has_Stream (Client, 0)
+      and then Has_Stream (Client, 4)
+      and then Available_Length (Client, 0) = 1
+      and then Available_Length (Client, 4) = 1
+      and then Stream_Element (Client, 0, 0) = 16#C0#
+      and then Stream_Element (Client, 4, 0) = 16#C4#);
+end Flyology.QUIC.Application_Space.Batch_Smoke;

--- a/flyology_quic/tests/src/flyology-quic-application_space-batch_smoke.ads
+++ b/flyology_quic/tests/src/flyology-quic-application_space-batch_smoke.ads
@@ -1,0 +1,1 @@
+private procedure Flyology.QUIC.Application_Space.Batch_Smoke;

--- a/scripts/test-http3-h3spec.sh
+++ b/scripts/test-http3-h3spec.sh
@@ -13,9 +13,20 @@ prepare_qualification_rts () {
 
   "$alr" exec -- env \
     FLYOLOGY_RTS_DIR="$qualification_rts" \
-    FLYOLOGY_DEFAULT=native \
+    FLYOLOGY_DEFAULT=lightweight \
     FLYOLOGY_LOOP_POOL_SIZE=1 \
     "$flyology_root/scripts/prepare-rts.sh" >/dev/null
+
+  if [ ! -f "$qualification_rts/.flyology-rts-root" ] \
+    || ! grep -q 'Flyology prepared RTS version' \
+      "$qualification_rts/.flyology-rts-root" \
+    || ! grep -q 'Lightweight : constant Boolean := True;' \
+      "$qualification_rts/adainclude/s-fldeex.ads"
+  then
+    printf '%s\n' \
+      'HTTP/3 qualification RTS is not a prepared Flyology lightweight RTS' >&2
+    exit 2
+  fi
 }
 
 if [ -z "$h3spec" ]; then

--- a/scripts/test-http3-interop.sh
+++ b/scripts/test-http3-interop.sh
@@ -26,9 +26,20 @@ prepare_qualification_rts () {
 
   "$alr" exec -- env \
     FLYOLOGY_RTS_DIR="$qualification_rts" \
-    FLYOLOGY_DEFAULT=native \
+    FLYOLOGY_DEFAULT=lightweight \
     FLYOLOGY_LOOP_POOL_SIZE=1 \
     "$flyology_root/scripts/prepare-rts.sh" >/dev/null
+
+  if [ ! -f "$qualification_rts/.flyology-rts-root" ] \
+    || ! grep -q 'Flyology prepared RTS version' \
+      "$qualification_rts/.flyology-rts-root" \
+    || ! grep -q 'Lightweight : constant Boolean := True;' \
+      "$qualification_rts/adainclude/s-fldeex.ads"
+  then
+    printf '%s\n' \
+      'HTTP/3 qualification RTS is not a prepared Flyology lightweight RTS' >&2
+    exit 2
+  fi
 }
 
 prepare_aioquic () {

--- a/scripts/test-http3-stress.sh
+++ b/scripts/test-http3-stress.sh
@@ -51,12 +51,14 @@ prepare_stress_rts () {
     FLYOLOGY_LOOP_POOL_SIZE="$loop_pool_size" \
     "$flyology_root/scripts/prepare-rts.sh" >/dev/null
 
-  default_execution="$stress_rts/adainclude/s-fldeex.ads"
-  if ! grep -q 'Lightweight : constant Boolean := True;' \
-      "$default_execution"
+  if [ ! -f "$stress_rts/.flyology-rts-root" ] \
+    || ! grep -q 'Flyology prepared RTS version' \
+      "$stress_rts/.flyology-rts-root" \
+    || ! grep -q 'Lightweight : constant Boolean := True;' \
+      "$stress_rts/adainclude/s-fldeex.ads"
   then
     printf '%s\n' \
-      'HTTP/3 stress RTS is not configured for lightweight tasks' >&2
+      'HTTP/3 stress RTS is not a prepared Flyology lightweight RTS' >&2
     exit 2
   fi
 }

--- a/showcases/http3_benchmark.py
+++ b/showcases/http3_benchmark.py
@@ -74,25 +74,26 @@ async def request_batch(
 
     ended = set()
     latencies = []
-    while len(ended) != count:
-        event = await asyncio.wait_for(protocol.events.get(), timeout=timeout)
-        if isinstance(event, ConnectionTerminated):
-            raise RuntimeError(
-                f"connection closed early: code={event.error_code} "
-                f"ended={len(ended)}/{count}"
-            )
-        if isinstance(event, HeadersReceived) and event.stream_id in started:
-            for name, value in event.headers:
-                if name == b":status":
-                    statuses[event.stream_id] = value
-            if event.stream_ended:
-                ended.add(event.stream_id)
-                latencies.append(time.perf_counter() - started[event.stream_id])
-        elif isinstance(event, DataReceived) and event.stream_id in started:
-            bodies[event.stream_id].extend(event.data)
-            if event.stream_ended:
-                ended.add(event.stream_id)
-                latencies.append(time.perf_counter() - started[event.stream_id])
+    async with asyncio.timeout(timeout):
+        while len(ended) != count:
+            event = await protocol.events.get()
+            if isinstance(event, ConnectionTerminated):
+                raise RuntimeError(
+                    f"connection closed early: code={event.error_code} "
+                    f"ended={len(ended)}/{count}"
+                )
+            if isinstance(event, HeadersReceived) and event.stream_id in started:
+                for name, value in event.headers:
+                    if name == b":status":
+                        statuses[event.stream_id] = value
+                if event.stream_ended:
+                    ended.add(event.stream_id)
+                    latencies.append(time.perf_counter() - started[event.stream_id])
+            elif isinstance(event, DataReceived) and event.stream_id in started:
+                bodies[event.stream_id].extend(event.data)
+                if event.stream_ended:
+                    ended.add(event.stream_id)
+                    latencies.append(time.perf_counter() - started[event.stream_id])
 
     for stream_id in started:
         if (

--- a/showcases/http3_benchmark.py
+++ b/showcases/http3_benchmark.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Repeatable aioquic load driver for the unified Flyology HTTP route.
+
+This is a benchmark fixture, not an interoperability oracle.  It keeps QUIC
+connections open, issues requests in bounded stream batches, and reports the
+handshake and request latency distributions separately.
+"""
+
+import argparse
+import asyncio
+import concurrent.futures
+import json
+import math
+import ssl
+import statistics
+import time
+
+from aioquic.asyncio import QuicConnectionProtocol, connect
+from aioquic.h3.connection import H3_ALPN, H3Connection
+from aioquic.h3.events import DataReceived, HeadersReceived
+from aioquic.quic.configuration import QuicConfiguration
+from aioquic.quic.events import ConnectionTerminated, ProtocolNegotiated, QuicEvent
+from aioquic.tls import CipherSuite
+
+
+class BenchmarkProtocol(QuicConnectionProtocol):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.http = None
+        self.events = asyncio.Queue()
+
+    def quic_event_received(self, event: QuicEvent) -> None:
+        if isinstance(event, ProtocolNegotiated):
+            self.http = H3Connection(self._quic)
+        if isinstance(event, ConnectionTerminated):
+            self.events.put_nowait(event)
+        if self.http is not None:
+            for item in self.http.handle_event(event):
+                self.events.put_nowait(item)
+
+
+def configuration() -> QuicConfiguration:
+    return QuicConfiguration(
+        alpn_protocols=H3_ALPN,
+        cipher_suites=[CipherSuite.AES_128_GCM_SHA256],
+        is_client=True,
+        max_datagram_size=1200,
+        server_name="localhost",
+        verify_mode=ssl.CERT_NONE,
+    )
+
+
+async def request_batch(
+    protocol, path: str, expected_body: bytes, count: int, timeout: float
+):
+    started = {}
+    bodies = {}
+    statuses = {}
+    for _ in range(count):
+        stream_id = protocol._quic.get_next_available_stream_id()
+        started[stream_id] = time.perf_counter()
+        bodies[stream_id] = bytearray()
+        protocol.http.send_headers(
+            stream_id,
+            [
+                (b":method", b"GET"),
+                (b":scheme", b"https"),
+                (b":authority", b"localhost"),
+                (b":path", path.encode("ascii")),
+            ],
+            end_stream=True,
+        )
+    protocol.transmit()
+
+    ended = set()
+    latencies = []
+    while len(ended) != count:
+        event = await asyncio.wait_for(protocol.events.get(), timeout=timeout)
+        if isinstance(event, ConnectionTerminated):
+            raise RuntimeError(
+                f"connection closed early: code={event.error_code} "
+                f"ended={len(ended)}/{count}"
+            )
+        if isinstance(event, HeadersReceived) and event.stream_id in started:
+            for name, value in event.headers:
+                if name == b":status":
+                    statuses[event.stream_id] = value
+            if event.stream_ended:
+                ended.add(event.stream_id)
+                latencies.append(time.perf_counter() - started[event.stream_id])
+        elif isinstance(event, DataReceived) and event.stream_id in started:
+            bodies[event.stream_id].extend(event.data)
+            if event.stream_ended:
+                ended.add(event.stream_id)
+                latencies.append(time.perf_counter() - started[event.stream_id])
+
+    for stream_id in started:
+        if (
+            statuses.get(stream_id) != b"200"
+            or bytes(bodies[stream_id]) != expected_body
+        ):
+            raise RuntimeError(
+                f"bad response stream={stream_id} status={statuses.get(stream_id)!r} "
+                f"body={bytes(bodies[stream_id])!r}"
+            )
+    return latencies
+
+
+async def run_connection(
+    port: int,
+    path: str,
+    expected_body: bytes,
+    requests: int,
+    streams: int,
+    timeout: float,
+):
+    connected_at = time.perf_counter()
+    async with connect(
+        "127.0.0.1",
+        port,
+        configuration=configuration(),
+        create_protocol=BenchmarkProtocol,
+    ) as protocol:
+        await asyncio.wait_for(protocol.wait_connected(), timeout=timeout)
+        handshake = time.perf_counter() - connected_at
+        latencies = []
+        remaining = requests
+        while remaining:
+            count = min(streams, remaining)
+            latencies.extend(
+                await request_batch(
+                    protocol, path, expected_body, count, timeout
+                )
+            )
+            remaining -= count
+    return handshake, latencies
+
+
+def percentile(values, fraction: float) -> float:
+    if not values:
+        return 0.0
+    return values[min(len(values) - 1, math.ceil(len(values) * fraction) - 1)]
+
+
+async def run_worker(
+    port, path, expected_body, requests, connections, streams, timeout
+):
+    per_connection = [requests // connections] * connections
+    for index in range(requests % connections):
+        per_connection[index] += 1
+    results = await asyncio.gather(
+        *(
+            run_connection(
+                port,
+                path,
+                expected_body,
+                count,
+                streams,
+                timeout,
+            )
+            for count in per_connection
+            if count
+        )
+    )
+    return results
+
+
+def run_worker_process(parameters):
+    return asyncio.run(run_worker(*parameters))
+
+
+def distribute(total: int, workers: int):
+    values = [total // workers] * workers
+    for index in range(total % workers):
+        values[index] += 1
+    return values
+
+
+def benchmark(arguments):
+    if arguments.response_bytes is None:
+        path = arguments.path
+        expected_body = b"hello test"
+    else:
+        if arguments.response_bytes < len(b"hello "):
+            raise ValueError("response bytes cannot be smaller than 6")
+        name = "x" * (arguments.response_bytes - len(b"hello "))
+        path = "/hello/" + name
+        expected_body = ("hello " + name).encode("ascii")
+
+    request_counts = distribute(arguments.requests, arguments.workers)
+    connection_counts = distribute(arguments.connections, arguments.workers)
+    parameters = [
+        (
+            arguments.port,
+            path,
+            expected_body,
+            request_counts[index],
+            connection_counts[index],
+            arguments.streams,
+            arguments.timeout,
+        )
+        for index in range(arguments.workers)
+    ]
+
+    started = time.perf_counter()
+    if arguments.workers == 1:
+        worker_results = [run_worker_process(parameters[0])]
+    else:
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=arguments.workers
+        ) as executor:
+            worker_results = list(executor.map(run_worker_process, parameters))
+    wall = time.perf_counter() - started
+    results = [result for worker in worker_results for result in worker]
+    handshakes = sorted(handshake for handshake, _ in results)
+    latencies = sorted(value for _, group in results for value in group)
+    summary = {
+        "protocol": "h3",
+        "requests": arguments.requests,
+        "workers": arguments.workers,
+        "connections": len(results),
+        "streams": arguments.streams,
+        "connection_reuse": arguments.requests / len(results),
+        "wall_s": wall,
+        "requests_per_s": len(latencies) / wall,
+        "response_bytes": len(expected_body),
+        "latency_ms": {
+            "mean": statistics.fmean(latencies) * 1000,
+            "p50": percentile(latencies, 0.50) * 1000,
+            "p95": percentile(latencies, 0.95) * 1000,
+            "p99": percentile(latencies, 0.99) * 1000,
+            "max": latencies[-1] * 1000,
+        },
+        "handshake_ms": {
+            "mean": statistics.fmean(handshakes) * 1000,
+            "p50": percentile(handshakes, 0.50) * 1000,
+            "p95": percentile(handshakes, 0.95) * 1000,
+            "max": handshakes[-1] * 1000,
+        },
+    }
+    print(json.dumps(summary, sort_keys=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=18443)
+    parser.add_argument("--path", default="/hello/test")
+    parser.add_argument("--response-bytes", type=int)
+    parser.add_argument("--requests", type=int, default=10000)
+    parser.add_argument("--connections", type=int, default=16)
+    parser.add_argument("--streams", type=int, default=1)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    arguments = parser.parse_args()
+    if (
+        arguments.requests < 1
+        or arguments.connections < 1
+        or arguments.streams < 1
+        or arguments.workers < 1
+    ):
+        parser.error("requests, connections, streams, and workers must be positive")
+    if arguments.workers > min(arguments.requests, arguments.connections):
+        parser.error("workers cannot exceed requests or connections")
+    benchmark(arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/showcases/http3_client_benchmark.gpr
+++ b/showcases/http3_client_benchmark.gpr
@@ -1,0 +1,23 @@
+with "../flyology_http.gpr";
+with "config/flyology_http_showcases_config.gpr";
+
+project HTTP3_Client_Benchmark is
+   for Languages use ("Ada", "C");
+   for Runtime ("Ada") use external ("FLYOLOGY_RTS_DIR", "../build/rts");
+   for Source_Dirs use ("../tests");
+   for Object_Dir use "obj/http3-client-benchmark";
+   for Exec_Dir use "bin";
+   for Main use
+     ("http3_client_stress_probe.adb",
+      "http3_h3spec_server.adb",
+      "http3_stress_runtime_probe.adb");
+   for Create_Missing_Dirs use "True";
+
+   package Compiler is
+      for Default_Switches ("Ada") use
+        Flyology_HTTP_Showcases_Config.Ada_Compiler_Switches
+        & ("-gnat2022", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ",
+           "-gnateDFLYOLOGY_CONNECTION_TEST_HOOKS=False");
+      for Default_Switches ("C") use ("-O2", "-Wall", "-Wextra");
+   end Compiler;
+end HTTP3_Client_Benchmark;

--- a/src/flyology-http-client-http_3_internals.adb
+++ b/src/flyology-http-client-http_3_internals.adb
@@ -4,10 +4,6 @@ separate (Flyology.HTTP.Client)
 package body HTTP_3_Internals is
    use Ada.Streams;
 
-   type Event_Access is access H3.Event;
-   procedure Free_Event is new Ada.Unchecked_Deallocation
-     (H3.Event, Event_Access);
-
    ALPN : constant Stream_Element_Array := Byte_Array ("h3");
    Request_Chunk_Size : constant Positive := 1_024;
    Maximum_Retained_Request : constant Natural := 16_384;
@@ -311,7 +307,7 @@ package body HTTP_3_Internals is
       Stream    : QUIC.Stream_ID;
       Packet    : QUIC.Datagram;
       Status    : H3.Operation_Status;
-      Event_Value : Event_Access := new H3.Event;
+      Event_Value : HTTP_3_Event_Access;
 
       procedure Add (Name, Field_Value : String) is
       begin
@@ -331,6 +327,10 @@ package body HTTP_3_Internals is
             Packet => Output, Status => Result);
       end Send_Head;
    begin
+      if Data.Connection.HTTP_3_Event = null then
+         Data.Connection.HTTP_3_Event := new H3.Event;
+      end if;
+      Event_Value := Data.Connection.HTTP_3_Event;
       if Value.Expect_Continue then
          raise Constraint_Error with
            "HTTP/3 Expect: 100-continue is not yet supported";
@@ -478,7 +478,6 @@ package body HTTP_3_Internals is
                   Data.Status_Value := Status_Code (Code);
                   Data.Protocol_Value := HTTP_3_Protocol;
                   Data.Saw_Response_Bytes := True;
-                  Free_Event (Event_Value);
                   return;
                end if;
             elsif Event.Stream = Stream
@@ -492,10 +491,6 @@ package body HTTP_3_Internals is
             end if;
          end;
       end loop;
-   exception
-      when others =>
-         Free_Event (Event_Value);
-         raise;
    end Execute_Request;
 
    procedure Copy_Pending
@@ -540,7 +535,8 @@ package body HTTP_3_Internals is
       Finished : out Boolean;
       Token    : access Flyology.Cancellation.Token)
    is
-      Event_Value : Event_Access := new H3.Event;
+      Event_Value : constant HTTP_3_Event_Access :=
+        Item.Data.Connection.HTTP_3_Event;
       Event  : H3.Event renames Event_Value.all;
       Status : H3.Operation_Status;
    begin
@@ -548,7 +544,6 @@ package body HTTP_3_Internals is
       Finished := False;
       if Flyology.Bytes.Length (Item.Data.HTTP_3_Pending) > 0 then
          Copy_Pending (Item.Data.all, Data, Last);
-         Free_Event (Event_Value);
          return;
       end if;
       loop
@@ -573,7 +568,6 @@ package body HTTP_3_Internals is
                  (Item.Data.HTTP_3_Pending,
                   Event.Data (1 .. Stream_Element_Offset (Event.Data_Length)));
                Copy_Pending (Item.Data.all, Data, Last);
-               Free_Event (Event_Value);
                return;
             end if;
          elsif Event.Stream = Item.Data.HTTP_3_Stream
@@ -600,7 +594,6 @@ package body HTTP_3_Internals is
             Release_Lease
               (Item.Data.all, Is_Usable (Item.Data.Connection));
             Finished := True;
-            Free_Event (Event_Value);
             return;
          elsif Event.Stream = Item.Data.HTTP_3_Stream
            and then Event.Kind = H3.Stream_Reset
@@ -609,9 +602,5 @@ package body HTTP_3_Internals is
             raise Protocol_Error with "HTTP/3 response stream was reset";
          end if;
       end loop;
-   exception
-      when others =>
-         Free_Event (Event_Value);
-         raise;
    end Read_Response_Body;
 end HTTP_3_Internals;

--- a/src/flyology-http-client.adb
+++ b/src/flyology-http-client.adb
@@ -66,6 +66,10 @@ package body Flyology.HTTP.Client is
    --  storage is recycled inside the bounded concurrent-stream profile.
    HTTP_3_Requests_Per_Connection : constant Positive := 100_000;
 
+   type HTTP_3_Event_Access is access H3.Event;
+   procedure Free_HTTP_3_Event is new Ada.Unchecked_Deallocation
+     (H3.Event, HTTP_3_Event_Access);
+
    type Pooled_Connection is limited record
       Channel  : aliased Connections.Connection;
       UDP      : aliased Sockets.Socket_Type;
@@ -75,6 +79,7 @@ package body Flyology.HTTP.Client is
       HTTP_3         : H3.Session;
       HTTP_3_Epoch   : Ada.Real_Time.Time := Ada.Real_Time.Time_First;
       HTTP_3_Goaway  : Boolean := False;
+      HTTP_3_Event   : HTTP_3_Event_Access := null;
    end record;
    type Pooled_Connection_Access is access Pooled_Connection;
 
@@ -430,6 +435,9 @@ package body Flyology.HTTP.Client is
       end;
       if Connection.HTTP_2 /= null then
          H2_Connections.Destroy (Connection.HTTP_2);
+      end if;
+      if Connection.HTTP_3_Event /= null then
+         Free_HTTP_3_Event (Connection.HTTP_3_Event);
       end if;
       Free_Connection (Connection);
    end Dispose_Connection;

--- a/src/flyology-http-http_2_hpack.adb
+++ b/src/flyology-http-http_2_hpack.adb
@@ -686,18 +686,85 @@ package body Flyology.HTTP.HTTP_2_HPACK is
       Flyology.Bytes.Append_Byte_String (Item.Data, Value);
    end Encode_String;
 
-   function Static_Index
-     (Name : String; Value : String; Exact : Boolean) return Natural is
+   function Matches_Static_Name
+     (Index : Positive; Name : String) return Boolean
+   is
+     (case Index is
+        when 1 => Name = ":authority",
+        when 2 | 3 => Name = ":method",
+        when 4 | 5 => Name = ":path",
+        when 6 | 7 => Name = ":scheme",
+        when 8 .. 14 => Name = ":status",
+        when 15 => Name = "accept-charset",
+        when 16 => Name = "accept-encoding",
+        when 17 => Name = "accept-language",
+        when 18 => Name = "accept-ranges",
+        when 19 => Name = "accept",
+        when 20 => Name = "access-control-allow-origin",
+        when 21 => Name = "age",
+        when 22 => Name = "allow",
+        when 23 => Name = "authorization",
+        when 24 => Name = "cache-control",
+        when 25 => Name = "content-disposition",
+        when 26 => Name = "content-encoding",
+        when 27 => Name = "content-language",
+        when 28 => Name = "content-length",
+        when 29 => Name = "content-location",
+        when 30 => Name = "content-range",
+        when 31 => Name = "content-type",
+        when 32 => Name = "cookie",
+        when 33 => Name = "date",
+        when 34 => Name = "etag",
+        when 35 => Name = "expect",
+        when 36 => Name = "expires",
+        when 37 => Name = "from",
+        when 38 => Name = "host",
+        when 39 => Name = "if-match",
+        when 40 => Name = "if-modified-since",
+        when 41 => Name = "if-none-match",
+        when 42 => Name = "if-range",
+        when 43 => Name = "if-unmodified-since",
+        when 44 => Name = "last-modified",
+        when 45 => Name = "link",
+        when 46 => Name = "location",
+        when 47 => Name = "max-forwards",
+        when 48 => Name = "proxy-authenticate",
+        when 49 => Name = "proxy-authorization",
+        when 50 => Name = "range",
+        when 51 => Name = "referer",
+        when 52 => Name = "refresh",
+        when 53 => Name = "retry-after",
+        when 54 => Name = "server",
+        when 55 => Name = "set-cookie",
+        when 56 => Name = "strict-transport-security",
+        when 57 => Name = "transfer-encoding",
+        when 58 => Name = "user-agent",
+        when 59 => Name = "vary",
+        when 60 => Name = "via",
+        when 61 => Name = "www-authenticate",
+        when others => False);
+
+   procedure Static_Indexes
+     (Name  : String;
+      Value : String;
+      Exact : out Natural;
+      Named : out Natural)
+   is
    begin
+      Exact := 0;
+      Named := 0;
       for Index in 1 .. Static_Count loop
-         if Static_Name (Index) = Name
-           and then (not Exact or else Static_Value (Index) = Value)
-         then
-            return Index;
+         if Matches_Static_Name (Index, Name) then
+            if Named = 0 then
+               Named := Index;
+            end if;
+            if Static_Value (Index) = Value then
+               Exact := Index;
+               return;
+            end if;
          end if;
       end loop;
-      return 0;
-   end Static_Index;
+   end Static_Indexes;
 
    procedure Clear (Item : in out Builder) is
    begin
@@ -716,9 +783,10 @@ package body Flyology.HTTP.HTTP_2_HPACK is
       Never_Indexed : Boolean := False)
    is
       Lower : constant String := Ada.Characters.Handling.To_Lower (Name);
-      Exact : constant Natural := Static_Index (Lower, Value, True);
-      Named : constant Natural := Static_Index (Lower, "", False);
+      Exact : Natural;
+      Named : Natural;
    begin
+      Static_Indexes (Lower, Value, Exact, Named);
       if Name = "" or else Name /= Lower then
          raise Constraint_Error with "HTTP/2 field names must be lowercase";
       elsif Exact > 0 and then not Never_Indexed then

--- a/src/flyology-http-http_3.adb
+++ b/src/flyology-http-http_3.adb
@@ -13,6 +13,7 @@ package body Flyology.HTTP.HTTP_3 is
    package Internal_Settings renames
      Flyology.HTTP.HTTP_3_Settings_Policy;
    use type Internal.Event_Kind;
+   use type Internal.Operation_Status;
 
    type Session_Impl is limited record
       Value      : Internal.Connection;
@@ -369,6 +370,81 @@ package body Flyology.HTTP.HTTP_3 is
          Now, Packet, Result, ACK_Included);
       Status := Public_Status (Result);
    end Send_Response;
+
+   procedure Prepare_Response
+     (Item      : in out Session;
+      Transport : QUIC.Connection;
+      Stream    : QUIC.Stream_ID;
+      Headers   : Header_Block;
+      Data      : Ada.Streams.Stream_Element_Array;
+      Output    : out Prepared_Response;
+      Status    : out Operation_Status)
+   is
+      Result : Internal.Operation_Status;
+      Value  : Internal.Prepared_Response;
+   begin
+      Output := (others => <>);
+      if not Is_Initialized (Item) then
+         Status := Uninitialized;
+         return;
+      end if;
+      To_Internal_Into (Headers, Impl (Item).Send_Headers);
+      Internal.Prepare_Response
+        (Impl (Item).Value, Transport, Stream, Impl (Item).Send_Headers, Data,
+         Value, Result);
+      Status := Public_Status (Result);
+      if Result = Internal.Succeeded then
+         Output :=
+           (Ready              => Value.Ready,
+            Stream             => Value.Stream,
+            Data               => Value.Data,
+            Length             => Value.Length,
+            Response_Code      => Value.Response_Code,
+            Has_Content_Length => Value.Has_Content_Length,
+            Content_Length     => Value.Content_Length,
+            Body_Length        => Value.Body_Length);
+      end if;
+   end Prepare_Response;
+
+   procedure Send_Prepared_Responses
+     (Item         : in out Session;
+      Transport    : in out QUIC.Connection;
+      Responses    : in out Prepared_Response_Array;
+      Now          : QUIC.Timestamp;
+      Packet       : out QUIC.Datagram;
+      Status       : out Operation_Status;
+      ACK_Included : out Boolean)
+   is
+      Values : Internal.Prepared_Response_Array (Responses'Range);
+      Result : Internal.Operation_Status;
+   begin
+      Packet := (others => <>);
+      ACK_Included := False;
+      if not Is_Initialized (Item) then
+         Status := Uninitialized;
+         return;
+      end if;
+      for Index in Responses'Range loop
+         Values (Index) :=
+           (Ready              => Responses (Index).Ready,
+            Stream             => Responses (Index).Stream,
+            Data               => Responses (Index).Data,
+            Length             => Responses (Index).Length,
+            Response_Code      => Responses (Index).Response_Code,
+            Has_Content_Length => Responses (Index).Has_Content_Length,
+            Content_Length     => Responses (Index).Content_Length,
+            Body_Length        => Responses (Index).Body_Length);
+      end loop;
+      Internal.Build_Prepared_Responses
+        (Impl (Item).Value, Transport, Values, Now, Packet, Result,
+         ACK_Included);
+      Status := Public_Status (Result);
+      if Result = Internal.Succeeded then
+         for Response of Responses loop
+            Response := (others => <>);
+         end loop;
+      end if;
+   end Send_Prepared_Responses;
 
    procedure Send_Data
      (Item      : in out Session;

--- a/src/flyology-http-http_3.ads
+++ b/src/flyology-http-http_3.ads
@@ -336,6 +336,54 @@ package Flyology.HTTP.HTTP_3 is
       Status    : out Operation_Status;
       ACK_Included : out Boolean);
 
+   --  Maximum complete responses combined into one QUIC packet.
+   Max_Prepared_Responses : constant Positive := 8;
+
+   --  One validated and encoded complete response awaiting transport commit.
+   type Prepared_Response is private;
+   --  Bounded collection of complete responses awaiting one transport commit.
+   type Prepared_Response_Array is
+     array (Positive range <>) of Prepared_Response;
+
+   --  Validate and encode a complete response without consuming QUIC packet
+   --  or congestion credit. The bounded result can later be committed alone
+   --  or with other streams by Send_Prepared_Responses.
+   --  @param Item Initialized HTTP/3 session
+   --  @param Transport Connected QUIC transport used for validation
+   --  @param Stream Request stream receiving the response
+   --  @param Headers Response header fields
+   --  @param Data Complete response body
+   --  @param Output Prepared response when Status is Success
+   --  @param Status Preparation outcome
+   procedure Prepare_Response
+     (Item      : in out Session;
+      Transport : QUIC.Connection;
+      Stream    : QUIC.Stream_ID;
+      Headers   : Header_Block;
+      Data      : Ada.Streams.Stream_Element_Array;
+      Output    : out Prepared_Response;
+      Status    : out Operation_Status);
+
+   --  Commit one or more prepared responses in a single protected QUIC
+   --  packet. Frame_Too_Large leaves every response uncommitted so callers
+   --  can retry smaller groups or use Send_Response.
+   --  @param Item Initialized HTTP/3 session
+   --  @param Transport Connected QUIC transport to update transactionally
+   --  @param Responses Prepared responses to commit
+   --  @param Now Monotonic microsecond timestamp for recovery accounting
+   --  @param Packet Datagram to transmit when Status is Success
+   --  @param Status Commit outcome
+   --  @param ACK_Included Whether the datagram carries an ACK frame
+   procedure Send_Prepared_Responses
+     (Item         : in out Session;
+      Transport    : in out QUIC.Connection;
+      Responses    : in out Prepared_Response_Array;
+      Now          : QUIC.Timestamp;
+      Packet       : out QUIC.Datagram;
+      Status       : out Operation_Status;
+      ACK_Included : out Boolean)
+   with Pre => Responses'Length in 1 .. Max_Prepared_Responses;
+
    --  Encode and protect one DATA frame.
    --  @param Item Initialized HTTP/3 session
    --  @param Transport Connected QUIC connection
@@ -401,6 +449,18 @@ private
 
    type Session is new Ada.Finalization.Limited_Controlled with record
       Backend : System.Address := System.Null_Address;
+   end record;
+
+   type Prepared_Response is record
+      Ready              : Boolean := False;
+      Stream             : QUIC.Stream_ID := 0;
+      Data               : Ada.Streams.Stream_Element_Array
+        (1 .. QUIC.Max_Stream_Payload) := (others => 0);
+      Length             : Natural range 0 .. QUIC.Max_Stream_Payload := 0;
+      Response_Code      : Natural range 0 .. 599 := 0;
+      Has_Content_Length : Boolean := False;
+      Content_Length     : QUIC.Stream_Offset := 0;
+      Body_Length        : QUIC.Stream_Offset := 0;
    end record;
 
    --  @exclude

--- a/src/flyology-http-http_3_connection.adb
+++ b/src/flyology-http-http_3_connection.adb
@@ -829,6 +829,125 @@ package body Flyology.HTTP.HTTP_3_Connection is
       end if;
    end Build_Headers;
 
+   procedure Prepare_Response
+     (Item      : in out Connection;
+      Transport : QUIC.Connection;
+      Stream    : QUIC.Stream_ID;
+      Headers   : QPACK_Field_Section_Policy.Header_Block;
+      Data      : Ada.Streams.Stream_Element_Array;
+      Output    : out Prepared_Response;
+      Status    : out Operation_Status)
+   is
+      Slot        : Optional_Slot;
+      Validation  : HTTP_3_Header_Policy.Validation_Result;
+      Head_Update : HTTP_3_Message_Policy.Response_Update;
+      Data_Update : HTTP_3_Message_Policy.Response_Update;
+      Encoded     : QPACK_Field_Section_Policy.Encode_Result;
+      Head_Frame  : HTTP_3_Frame_Policy.Encode_Result;
+      Data_Frame  : HTTP_3_Frame_Policy.Encode_Result;
+      Length      : Natural;
+      Peer        : HTTP_3_Settings_Policy.Settings;
+   begin
+      Output := (others => <>);
+      if not QUIC.Is_Connected (Transport) then
+         Status := Not_Connected;
+         return;
+      elsif Item.Local_Role /= Server then
+         Status := Wrong_Role;
+         return;
+      elsif Data'Length > HTTP_3_Frame_Policy.Max_Payload_Length then
+         Status := Frame_Too_Large;
+         return;
+      end if;
+
+      if Has_Peer_Settings (Item) then
+         Peer := Peer_Settings (Item);
+         if Peer.Has_Max_Field_Size
+           and then HTTP_3_Settings_Policy.Varint_Policy.Value_Type
+             (QPACK_Field_Section_Policy.Field_Section_Size (Headers)) >
+               Peer.Max_Field_Size
+         then
+            Status := Peer_Field_Section_Too_Large;
+            return;
+         end if;
+      end if;
+
+      Validation := HTTP_3_Header_Policy.Validate_Response (Headers);
+      if Validation.Status /= HTTP_3_Header_Policy.Valid then
+         Status := Header_Error;
+         return;
+      elsif Validation.Is_Interim then
+         Status := Message_Error;
+         return;
+      end if;
+      Encoded := QPACK_Field_Section_Policy.Encode (Headers);
+      if Encoded.Status /= QPACK_Field_Section_Policy.Encoded then
+         Status := QPACK_Decompression_Failed;
+         return;
+      end if;
+      Head_Frame := HTTP_3_Frame_Policy.Encode
+        (HTTP_3_Frame_Policy.Headers_Frame,
+         Encoded.Data
+           (1 .. Ada.Streams.Stream_Element_Offset (Encoded.Length)));
+      Data_Frame := HTTP_3_Frame_Policy.Encode
+        (HTTP_3_Frame_Policy.Data_Frame, Data);
+      Length := Head_Frame.Length + Data_Frame.Length;
+      if Length > QUIC.Max_Stream_Payload then
+         Status := Frame_Too_Large;
+         return;
+      end if;
+
+      Find_Or_Add_Message (Item, Transport, Stream, Slot, Status);
+      if Status /= Succeeded or else Item.Sending (Slot).Finished then
+         if Status = Succeeded then
+            Status := Frame_Unexpected;
+         end if;
+         return;
+      elsif Item.Sending (Slot).Kind /= Response_Message then
+         Status := Frame_Unexpected;
+         return;
+      end if;
+      Head_Update := HTTP_3_Message_Policy.On_Response_Frame
+        (Item.Sending (Slot).Response,
+         HTTP_3_Frame_Policy.Headers_Frame,
+         HTTP_3_Message_Policy.Final_Response_Headers,
+         Response_Code => Validation.Response_Code,
+         Has_Content_Length => Validation.Has_Content_Length,
+         Content_Length => Validation.Content_Length);
+      if Head_Update.Status /= HTTP_3_Message_Policy.Accepted then
+         Status := Message_Error;
+         return;
+      end if;
+      Data_Update := HTTP_3_Message_Policy.On_Response_Frame
+        (Head_Update.State, HTTP_3_Frame_Policy.Data_Frame,
+         Data_Length => QUIC.Stream_Offset (Data'Length));
+      if Data_Update.Status /= HTTP_3_Message_Policy.Accepted
+        or else HTTP_3_Message_Policy.Finish_Response (Data_Update.State) /=
+          HTTP_3_Message_Policy.Message_Complete
+      then
+         Status := Message_Error;
+         return;
+      end if;
+
+      Output.Stream := Stream;
+      Output.Length := Length;
+      Output.Data
+        (1 .. Ada.Streams.Stream_Element_Offset (Head_Frame.Length)) :=
+          Head_Frame.Data
+            (1 .. Ada.Streams.Stream_Element_Offset (Head_Frame.Length));
+      Output.Data
+        (Ada.Streams.Stream_Element_Offset (Head_Frame.Length + 1)
+           .. Ada.Streams.Stream_Element_Offset (Length)) :=
+          Data_Frame.Data
+            (1 .. Ada.Streams.Stream_Element_Offset (Data_Frame.Length));
+      Output.Response_Code := Validation.Response_Code;
+      Output.Has_Content_Length := Validation.Has_Content_Length;
+      Output.Content_Length := Validation.Content_Length;
+      Output.Body_Length := QUIC.Stream_Offset (Data'Length);
+      Output.Ready := True;
+      Status := Succeeded;
+   end Prepare_Response;
+
    procedure Build_Response
      (Item      : in out Connection;
       Transport : in out QUIC.Connection;
@@ -957,6 +1076,132 @@ package body Flyology.HTTP.HTTP_3_Connection is
          Item.Send_Count := Item.Send_Count - 1;
       end if;
    end Build_Response;
+
+   procedure Build_Prepared_Responses
+     (Item         : in out Connection;
+      Transport    : in out QUIC.Connection;
+      Responses    : Prepared_Response_Array;
+      Now          : QUIC.Timestamp;
+      Packet       : out QUIC.Datagram;
+      Status       : out Operation_Status;
+      ACK_Included : out Boolean)
+   is
+      Fragments : QUIC.Stream_Fragment_Array (Responses'Range);
+      Combined  : Ada.Streams.Stream_Element_Array
+        (1 .. QUIC.Max_Stream_Payload) := (others => 0);
+      Length    : Natural := 0;
+      Slot      : Optional_Slot;
+      Head_Update : HTTP_3_Message_Policy.Response_Update;
+      Data_Update : HTTP_3_Message_Policy.Response_Update;
+      Sent      : QUIC.Send_Status;
+
+      procedure Validate (Response : Prepared_Response) is
+      begin
+         if not Response.Ready then
+            Status := Frame_Unexpected;
+            return;
+         end if;
+         Slot := Find_Send (Item, Response.Stream);
+         if Slot = 0
+           or else Item.Sending (Slot).Finished
+           or else Item.Sending (Slot).Kind /= Response_Message
+         then
+            Status := Frame_Unexpected;
+            return;
+         end if;
+         Head_Update := HTTP_3_Message_Policy.On_Response_Frame
+           (Item.Sending (Slot).Response,
+            HTTP_3_Frame_Policy.Headers_Frame,
+            HTTP_3_Message_Policy.Final_Response_Headers,
+            Response_Code => Response.Response_Code,
+            Has_Content_Length => Response.Has_Content_Length,
+            Content_Length => Response.Content_Length);
+         Data_Update := HTTP_3_Message_Policy.On_Response_Frame
+           (Head_Update.State, HTTP_3_Frame_Policy.Data_Frame,
+            Data_Length => Response.Body_Length);
+         if Head_Update.Status /= HTTP_3_Message_Policy.Accepted
+           or else Data_Update.Status /= HTTP_3_Message_Policy.Accepted
+           or else HTTP_3_Message_Policy.Finish_Response (Data_Update.State) /=
+             HTTP_3_Message_Policy.Message_Complete
+         then
+            Status := Message_Error;
+         end if;
+      end Validate;
+   begin
+      Packet := (others => <>);
+      ACK_Included := False;
+      if not QUIC.Is_Connected (Transport) then
+         Status := Not_Connected;
+         return;
+      elsif Item.Local_Role /= Server then
+         Status := Wrong_Role;
+         return;
+      elsif Responses'Length not in 1 .. Max_Prepared_Responses then
+         Status := Frame_Too_Large;
+         return;
+      end if;
+
+      Status := Succeeded;
+      for Index in Responses'Range loop
+         Validate (Responses (Index));
+         exit when Status /= Succeeded;
+         for Prior in Responses'First .. Index - 1 loop
+            if Responses (Prior).Stream = Responses (Index).Stream then
+               Status := Frame_Unexpected;
+            end if;
+         end loop;
+         exit when Status /= Succeeded;
+         if Responses (Index).Length > QUIC.Max_Stream_Payload - Length then
+            Status := Frame_Too_Large;
+            return;
+         end if;
+         Slot := Find_Send (Item, Responses (Index).Stream);
+         Fragments (Index) :=
+           (ID     => Responses (Index).Stream,
+            Offset => Item.Sending (Slot).Offset,
+            Length => Responses (Index).Length,
+            Fin    => True);
+         Combined
+           (Ada.Streams.Stream_Element_Offset (Length + 1)
+              .. Ada.Streams.Stream_Element_Offset
+                   (Length + Responses (Index).Length)) :=
+             Responses (Index).Data
+               (1 .. Ada.Streams.Stream_Element_Offset
+                    (Responses (Index).Length));
+         Length := Length + Responses (Index).Length;
+      end loop;
+      if Status /= Succeeded then
+         return;
+      end if;
+
+      if Responses'Length = 1 then
+         QUIC.Build_Stream_Datagram_With_ACK
+           (Transport, Fragments (Responses'First).ID,
+            Fragments (Responses'First).Offset, Fin => True,
+            Data => Combined (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+            Now => Now, Packet => Packet, Status => Sent,
+            ACK_Included => ACK_Included);
+      else
+         QUIC.Build_Stream_Batch_Datagram_With_ACK
+           (Transport, Fragments,
+            Combined (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+            Now, Packet, Sent, ACK_Included);
+      end if;
+      if Sent = QUIC.Packet_Too_Large then
+         Status := Frame_Too_Large;
+         return;
+      end if;
+      Status := Send_Status_For (Sent);
+      if Status /= Succeeded then
+         return;
+      end if;
+
+      for Response of Responses loop
+         Slot := Find_Send (Item, Response.Stream);
+         Item.Sending (Slot) := (others => <>);
+         Item.Send_Count := Item.Send_Count - 1;
+      end loop;
+   end Build_Prepared_Responses;
 
    procedure Build_Data
      (Item      : in out Connection;

--- a/src/flyology-http-http_3_connection.ads
+++ b/src/flyology-http-http_3_connection.ads
@@ -146,6 +146,39 @@ private package Flyology.HTTP.HTTP_3_Connection is
       Status    : out Operation_Status;
       ACK_Included : out Boolean);
 
+   Max_Prepared_Responses : constant Positive := 8;
+   type Prepared_Response is record
+      Ready              : Boolean := False;
+      Stream             : QUIC.Stream_ID := 0;
+      Data               : Ada.Streams.Stream_Element_Array
+        (1 .. QUIC.Max_Stream_Payload) := (others => 0);
+      Length             : Natural range 0 .. QUIC.Max_Stream_Payload := 0;
+      Response_Code      : Natural range 0 .. 599 := 0;
+      Has_Content_Length : Boolean := False;
+      Content_Length     : QUIC.Stream_Offset := 0;
+      Body_Length        : QUIC.Stream_Offset := 0;
+   end record;
+   type Prepared_Response_Array is
+     array (Positive range <>) of Prepared_Response;
+
+   procedure Prepare_Response
+     (Item      : in out Connection;
+      Transport : QUIC.Connection;
+      Stream    : QUIC.Stream_ID;
+      Headers   : QPACK_Field_Section_Policy.Header_Block;
+      Data      : Ada.Streams.Stream_Element_Array;
+      Output    : out Prepared_Response;
+      Status    : out Operation_Status);
+
+   procedure Build_Prepared_Responses
+     (Item         : in out Connection;
+      Transport    : in out QUIC.Connection;
+      Responses    : Prepared_Response_Array;
+      Now          : QUIC.Timestamp;
+      Packet       : out QUIC.Datagram;
+      Status       : out Operation_Status;
+      ACK_Included : out Boolean);
+
    procedure Build_Data
      (Item      : in out Connection;
       Transport : in out QUIC.Connection;

--- a/src/flyology-http-qpack_field_section_policy.adb
+++ b/src/flyology-http-qpack_field_section_policy.adb
@@ -445,7 +445,8 @@ is
             Name_Text  : constant String := Field_Name (Item);
             Value_Text : constant String := Field_Value (Item);
          begin
-            Exact := QPACK_Static_Table.Find_Exact (Name_Text, Value_Text);
+            QPACK_Static_Table.Find
+              (Name_Text, Value_Text, Exact, Named);
             if Exact.Found then
                pragma Assert
                  ((Ada.Streams.Stream_Element'(16#C0#)
@@ -453,7 +454,6 @@ is
                Append_Integer
                  (QPACK_Integer_Policy.Value_Type (Exact.Index), 6, 16#C0#);
             else
-               Named := QPACK_Static_Table.Find_Name (Name_Text);
                if Named.Found then
                   pragma Assert
                     ((Ada.Streams.Stream_Element'(16#50#)

--- a/src/flyology-http-qpack_static_table.adb
+++ b/src/flyology-http-qpack_static_table.adb
@@ -147,24 +147,103 @@ is
          when 97 => "deny",
          when 98 => "sameorigin");
 
+   function Matches_Name
+     (Index : Static_Index; Field_Name : String) return Boolean
+   is
+     (case Index is
+         when 0 => Field_Name = ":authority",
+         when 1 => Field_Name = ":path",
+         when 2 => Field_Name = "age",
+         when 3 => Field_Name = "content-disposition",
+         when 4 => Field_Name = "content-length",
+         when 5 => Field_Name = "cookie",
+         when 6 => Field_Name = "date",
+         when 7 => Field_Name = "etag",
+         when 8 => Field_Name = "if-modified-since",
+         when 9 => Field_Name = "if-none-match",
+         when 10 => Field_Name = "last-modified",
+         when 11 => Field_Name = "link",
+         when 12 => Field_Name = "location",
+         when 13 => Field_Name = "referer",
+         when 14 => Field_Name = "set-cookie",
+         when 15 .. 21 => Field_Name = ":method",
+         when 22 .. 23 => Field_Name = ":scheme",
+         when 24 .. 28 => Field_Name = ":status",
+         when 29 .. 30 => Field_Name = "accept",
+         when 31 => Field_Name = "accept-encoding",
+         when 32 => Field_Name = "accept-ranges",
+         when 33 .. 34 => Field_Name = "access-control-allow-headers",
+         when 35 => Field_Name = "access-control-allow-origin",
+         when 36 .. 41 => Field_Name = "cache-control",
+         when 42 .. 43 => Field_Name = "content-encoding",
+         when 44 .. 54 => Field_Name = "content-type",
+         when 55 => Field_Name = "range",
+         when 56 .. 58 => Field_Name = "strict-transport-security",
+         when 59 .. 60 => Field_Name = "vary",
+         when 61 => Field_Name = "x-content-type-options",
+         when 62 => Field_Name = "x-xss-protection",
+         when 63 .. 71 => Field_Name = ":status",
+         when 72 => Field_Name = "accept-language",
+         when 73 .. 74 => Field_Name = "access-control-allow-credentials",
+         when 75 => Field_Name = "access-control-allow-headers",
+         when 76 .. 78 => Field_Name = "access-control-allow-methods",
+         when 79 => Field_Name = "access-control-expose-headers",
+         when 80 => Field_Name = "access-control-request-headers",
+         when 81 .. 82 => Field_Name = "access-control-request-method",
+         when 83 => Field_Name = "alt-svc",
+         when 84 => Field_Name = "authorization",
+         when 85 => Field_Name = "content-security-policy",
+         when 86 => Field_Name = "early-data",
+         when 87 => Field_Name = "expect-ct",
+         when 88 => Field_Name = "forwarded",
+         when 89 => Field_Name = "if-range",
+         when 90 => Field_Name = "origin",
+         when 91 => Field_Name = "purpose",
+         when 92 => Field_Name = "server",
+         when 93 => Field_Name = "timing-allow-origin",
+         when 94 => Field_Name = "upgrade-insecure-requests",
+         when 95 => Field_Name = "user-agent",
+         when 96 => Field_Name = "x-forwarded-for",
+         when 97 .. 98 => Field_Name = "x-frame-options");
+
+   procedure Find
+     (Field_Name  : String;
+      Field_Value : String;
+      Exact       : out Lookup_Result;
+      Named       : out Lookup_Result)
+   is
+   begin
+      Exact := (others => <>);
+      Named := (others => <>);
+      for Index in Static_Index loop
+         if Matches_Name (Index, Field_Name) then
+            if not Named.Found then
+               Named := (Found => True, Index => Index);
+            end if;
+            if Value (Index) = Field_Value then
+               Exact := (Found => True, Index => Index);
+               return;
+            end if;
+         end if;
+      end loop;
+   end Find;
+
    function Find_Exact
      (Field_Name  : String;
       Field_Value : String) return Lookup_Result
    is
+      Exact : Lookup_Result;
+      Named : Lookup_Result;
    begin
-      for Index in Static_Index loop
-         if Name (Index) = Field_Name and then Value (Index) = Field_Value then
-            return (Found => True, Index => Index);
-         end if;
-      end loop;
-      return (others => <>);
+      Find (Field_Name, Field_Value, Exact, Named);
+      return Exact;
    end Find_Exact;
 
    function Find_Name (Field_Name : String) return Lookup_Result
    is
    begin
       for Index in Static_Index loop
-         if Name (Index) = Field_Name then
+         if Matches_Name (Index, Field_Name) then
             return (Found => True, Index => Index);
          end if;
       end loop;

--- a/src/flyology-http-qpack_static_table.adb
+++ b/src/flyology-http-qpack_static_table.adb
@@ -215,6 +215,37 @@ is
    begin
       Exact := (others => <>);
       Named := (others => <>);
+      if Field_Name = ":status" then
+         Named := (Found => True, Index => 24);
+         for Index in Static_Index range 24 .. 28 loop
+            if Value (Index) = Field_Value then
+               Exact := (Found => True, Index => Index);
+               return;
+            end if;
+         end loop;
+         for Index in Static_Index range 63 .. 71 loop
+            if Value (Index) = Field_Value then
+               Exact := (Found => True, Index => Index);
+               return;
+            end if;
+         end loop;
+         return;
+      elsif Field_Name = "content-length" then
+         Named := (Found => True, Index => 4);
+         if Field_Value = "0" then
+            Exact := Named;
+         end if;
+         return;
+      elsif Field_Name = "content-type" then
+         Named := (Found => True, Index => 44);
+         for Index in Static_Index range 44 .. 54 loop
+            if Value (Index) = Field_Value then
+               Exact := (Found => True, Index => Index);
+               return;
+            end if;
+         end loop;
+         return;
+      end if;
       for Index in Static_Index loop
          if Matches_Name (Index, Field_Name) then
             if not Named.Found then

--- a/src/flyology-http-qpack_static_table.ads
+++ b/src/flyology-http-qpack_static_table.ads
@@ -27,4 +27,11 @@ is
 
    function Find_Name (Field_Name : String) return Lookup_Result
    with Global => null;
+
+   procedure Find
+     (Field_Name  : String;
+      Field_Value : String;
+      Exact       : out Lookup_Result;
+      Named       : out Lookup_Result)
+   with Global => null;
 end Flyology.HTTP.QPACK_Static_Table;

--- a/src/flyology-http-server-http_2.adb
+++ b/src/flyology-http-server-http_2.adb
@@ -1905,6 +1905,8 @@ package body Flyology.HTTP.Server.HTTP_2 is
 
       task type Handler_Task (Slot : Positive) is
          pragma Task_Info (Flyology.Lightweight_Task);
+         entry Run;
+         entry Shutdown;
       end Handler_Task;
       type Handler_Access is access Handler_Task;
       type Handler_Array is array
@@ -1912,37 +1914,50 @@ package body Flyology.HTTP.Server.HTTP_2 is
       Handlers : Handler_Array := (others => null);
 
       task body Handler_Task is
-         Backend : Stream_Backend renames Backends_By_Slot (Slot).all;
-         X : Applications.Exchange := Applications.Internals.Create
-           (Backend.Request_Value, Backend'Access, Peer,
-            Backend.Token'Access, Backend.Deadline, Scheme);
       begin
-         begin
-            Handle (Context, X);
-            if X.Response = Applications.Not_Started then
-               X.No_Content;
-            elsif X.Response in
-              Applications.Streaming_Response | Applications.Streaming_SSE |
-              Applications.Upgraded | Applications.Failed
-            then
-               X.Mark_Failed;
-            end if;
-         exception
-            when others =>
-               if not X.Wire_Response_Started then
-                  begin
-                     X.Problem
-                       (500, "internal-server-error",
-                        "Internal server error");
-                  exception
-                     when others => X.Mark_Failed;
-                  end;
-               else
-                  X.Mark_Failed;
-               end if;
-         end;
-         State.Streams.Handler_Finished (Slot);
-         Drivers.Signal (State.Outbound);
+         loop
+            select
+               accept Run;
+            or
+               accept Shutdown;
+               exit;
+            end select;
+            declare
+               Backend : Stream_Backend renames
+                 Backends_By_Slot (Slot).all;
+               X : Applications.Exchange := Applications.Internals.Create
+                 (Backend.Request_Value, Backend'Access, Peer,
+                  Backend.Token'Access, Backend.Deadline, Scheme);
+            begin
+               begin
+                  Handle (Context, X);
+                  if X.Response = Applications.Not_Started then
+                     X.No_Content;
+                  elsif X.Response in
+                    Applications.Streaming_Response |
+                    Applications.Streaming_SSE |
+                    Applications.Upgraded | Applications.Failed
+                  then
+                     X.Mark_Failed;
+                  end if;
+               exception
+                  when others =>
+                     if not X.Wire_Response_Started then
+                        begin
+                           X.Problem
+                             (500, "internal-server-error",
+                              "Internal server error");
+                        exception
+                           when others => X.Mark_Failed;
+                        end;
+                     else
+                        X.Mark_Failed;
+                     end if;
+               end;
+            end;
+            State.Streams.Handler_Finished (Slot);
+            Drivers.Signal (State.Outbound);
+         end loop;
       end Handler_Task;
 
       procedure Free_Handler is new Ada.Unchecked_Deallocation
@@ -1953,10 +1968,10 @@ package body Flyology.HTTP.Server.HTTP_2 is
       procedure Reap is
       begin
          for Slot in Handlers'Range loop
-            if Handlers (Slot) /= null and then Handlers (Slot).all'Terminated
+            if Handlers (Slot) /= null
+              and then Backends_By_Slot (Slot) /= null
               and then State.Streams.Can_Reap (Slot)
             then
-               Free_Handler (Handlers (Slot));
                Free_Backend (Backends_By_Slot (Slot));
                State.Streams.Release_Stream (Slot);
             end if;
@@ -1997,7 +2012,10 @@ package body Flyology.HTTP.Server.HTTP_2 is
                "Host: " & Authority & CRLF);
          end if;
          Backends_By_Slot (Slot) := Backend;
-         Handlers (Slot) := new Handler_Task (Slot);
+         if Handlers (Slot) = null then
+            Handlers (Slot) := new Handler_Task (Slot);
+         end if;
+         Handlers (Slot).Run;
       end Start_Handler;
 
       Output : Stream_Element_Array
@@ -2571,9 +2589,9 @@ package body Flyology.HTTP.Server.HTTP_2 is
       end loop;
       for Slot in Handlers'Range loop
          if Handlers (Slot) /= null then
-            --  Dynamic Ada tasks must terminate before their task object and
-            --  backend are deallocated. A handler may still be unwinding
-            --  application code after connection cancellation reaches it.
+            --  Shutdown queues behind any handler still unwinding application
+            --  code after connection cancellation reaches it.
+            Handlers (Slot).Shutdown;
             while not Handlers (Slot).all'Terminated loop
                delay 0.001;
             end loop;

--- a/src/flyology-http-server-http_2.adb
+++ b/src/flyology-http-server-http_2.adb
@@ -1303,8 +1303,12 @@ package body Flyology.HTTP.Server.HTTP_2 is
          Streams (Slot).Receive_Window :=
            Policy.Window_Size (Settings.Advertised_Initial_Window_Size);
          Streams (Slot).Pending_Receive_Credit := 0;
-         if Flyology.Wake_Sources.Descriptor (Streams (Slot).Wake) >= 0 then
-            Flyology.Wake_Sources.Release (Streams (Slot).Wake);
+         --  Keep the bounded per-slot descriptor generation across stream
+         --  reuse.  Recreating its pipe for every request is unnecessary,
+         --  but a pending notification must not wake the next stream that
+         --  occupies this slot.
+         if Streams (Slot).Wake_Signalled then
+            Flyology.Wake_Sources.Consume (Streams (Slot).Wake);
          end if;
          Streams (Slot).Wake_Signalled := False;
       end Release_Stream;

--- a/src/flyology-http-server-http_3.adb
+++ b/src/flyology-http-server-http_3.adb
@@ -1169,15 +1169,12 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Item.Response_Ended := True;
    end Mark_Failed;
 
-   type Header_Block_Access is access H3.Header_Block;
-
-   procedure Free_Header_Block is new Ada.Unchecked_Deallocation
-     (H3.Header_Block, Header_Block_Access);
-
    type Request_Slot is record
       Occupied    : Boolean := False;
       Stream      : QUIC.Stream_ID := 0;
-      Headers     : Header_Block_Access := null;
+      Value       : aliased Request;
+      Authority   : Unbounded_String;
+      Has_Host    : Boolean := False;
       Saw_Headers : Boolean := False;
       Payload_Bytes : Bytes.Unbounded_Bytes;
       Started     : Ada.Real_Time.Time := Ada.Real_Time.Time_Last;
@@ -1260,62 +1257,33 @@ package body Flyology.HTTP.Server.HTTP_3 is
          Send (State.all, Control, Handshake_Timeout);
       end Start_HTTP_3;
 
-      function Header_Value
-        (Fields : H3.Header_Block; Name : String) return String is
-      begin
-         for Index in 1 .. H3.Header_Count (Fields) loop
-            if H3.Field_Name (H3.Field_At (Fields, Index)) = Name then
-               return H3.Field_Value (H3.Field_At (Fields, Index));
-            end if;
-         end loop;
-         return "";
-      end Header_Value;
-
       procedure Dispatch_Request (Slot : Positive) is
-         Method : constant String := Header_Value
-           (Requests (Slot).Headers.all, ":method");
-         Target : constant String := Header_Value
-           (Requests (Slot).Headers.all, ":path");
-         Authority : constant String := Header_Value
-           (Requests (Slot).Headers.all, ":authority");
+         Method : constant String :=
+           To_String (Requests (Slot).Value.Method_Value);
+         Target : constant String :=
+           To_String (Requests (Slot).Value.Target_Value);
+         Authority : constant String :=
+           To_String (Requests (Slot).Authority);
          Validated : constant Flyology.HTTP.Method := To_Method (Method);
          pragma Unreferenced (Validated);
          Backend : aliased Stream_Backend;
-         Value : aliased Request;
          Deadline : constant Ada.Real_Time.Time :=
            (if Timeout < 0.0 then Ada.Real_Time.Time_Last
             else Requests (Slot).Started +
               Ada.Real_Time.To_Time_Span (Timeout));
          X : Applications.Exchange := Applications.Internals.Create
-           (Value, Backend'Access, State.Peer, Token, Deadline,
+           (Requests (Slot).Value, Backend'Access, State.Peer, Token,
+            Deadline,
             Secure_HTTPS);
       begin
          if Method = "CONNECT" or else Target = "" then
             raise Protocol_Error with
               "HTTP/3 CONNECT is not supported by the application adapter";
          end if;
-         Value.Method_Value := To_Unbounded_String (Method);
-         Value.Target_Value := To_Unbounded_String (Target);
-         Value.Version_Value := HTTP_1_1;
-         Value.Protocol_Value := HTTP_3_Protocol;
-         Value.Keep_Alive := True;
-         for Index in 1 .. H3.Header_Count (Requests (Slot).Headers.all) loop
-            declare
-               Field : constant H3.Header_Field :=
-                 H3.Field_At (Requests (Slot).Headers.all, Index);
-               Name : constant String := H3.Field_Name (Field);
-            begin
-               if Name'Length > 0 and then Name (Name'First) /= ':' then
-                  Append
-                    (Value.Header_Block,
-                     Name & ": " & H3.Field_Value (Field) & CRLF);
-               end if;
-            end;
-         end loop;
-         if Authority /= "" and then Header_Value
-           (Requests (Slot).Headers.all, "host") = ""
-         then
-            Append (Value.Header_Block, "Host: " & Authority & CRLF);
+         if Authority /= "" and then not Requests (Slot).Has_Host then
+            Append
+              (Requests (Slot).Value.Header_Block,
+               "Host: " & Authority & CRLF);
          end if;
          Backend.Owner := State;
          Backend.Stream := Requests (Slot).Stream;
@@ -1399,10 +1367,10 @@ package body Flyology.HTTP.Server.HTTP_3 is
       begin
          Requests (Slot).Occupied := False;
          Requests (Slot).Stream := 0;
+         Requests (Slot).Value := (others => <>);
+         Requests (Slot).Authority := Null_Unbounded_String;
+         Requests (Slot).Has_Host := False;
          Requests (Slot).Saw_Headers := False;
-         if Requests (Slot).Headers /= null then
-            H3.Clear (Requests (Slot).Headers.all);
-         end if;
          Requests (Slot).Started := Ada.Real_Time.Time_Last;
          Bytes.Clear (Requests (Slot).Payload_Bytes);
       end Release;
@@ -1425,16 +1393,42 @@ package body Flyology.HTTP.Server.HTTP_3 is
                   Requests (Slot).Occupied := True;
                   Requests (Slot).Stream := Value.Stream;
                   Requests (Slot).Started := Ada.Real_Time.Clock;
-                  if Requests (Slot).Headers = null then
-                     Requests (Slot).Headers := new H3.Header_Block;
-                  end if;
                end if;
                if not Requests (Slot).Saw_Headers then
-                  H3.Clear (Requests (Slot).Headers.all);
+                  Requests (Slot).Value := (others => <>);
+                  Requests (Slot).Authority := Null_Unbounded_String;
+                  Requests (Slot).Has_Host := False;
+                  Requests (Slot).Value.Version_Value := HTTP_1_1;
+                  Requests (Slot).Value.Protocol_Value := HTTP_3_Protocol;
+                  Requests (Slot).Value.Keep_Alive := True;
                   for Index in 1 .. H3.Header_Count (Value.Headers) loop
-                     H3.Append
-                       (Requests (Slot).Headers.all,
-                        H3.Field_At (Value.Headers, Index));
+                     declare
+                        Field : constant H3.Header_Field :=
+                          H3.Field_At (Value.Headers, Index);
+                        Name : constant String := H3.Field_Name (Field);
+                        Field_Value : constant String :=
+                          H3.Field_Value (Field);
+                     begin
+                        if Name = ":method" then
+                           Requests (Slot).Value.Method_Value :=
+                             To_Unbounded_String (Field_Value);
+                        elsif Name = ":path" then
+                           Requests (Slot).Value.Target_Value :=
+                             To_Unbounded_String (Field_Value);
+                        elsif Name = ":authority" then
+                           Requests (Slot).Authority :=
+                             To_Unbounded_String (Field_Value);
+                        elsif Name'Length > 0
+                          and then Name (Name'First) /= ':'
+                        then
+                           Append
+                             (Requests (Slot).Value.Header_Block,
+                              Name & ": " & Field_Value & CRLF);
+                           if Name = "host" then
+                              Requests (Slot).Has_Host := True;
+                           end if;
+                        end if;
+                     end;
                   end loop;
                   Requests (Slot).Saw_Headers := True;
                end if;
@@ -1483,11 +1477,6 @@ package body Flyology.HTTP.Server.HTTP_3 is
       procedure Cleanup is
       begin
          if Requests /= null then
-            for Index in Requests.all'Range loop
-               if Requests (Index).Headers /= null then
-                  Free_Header_Block (Requests (Index).Headers);
-               end if;
-            end loop;
             Free_Request_Array (Requests);
          end if;
          if State /= null then

--- a/src/flyology-http-server-http_3.adb
+++ b/src/flyology-http-server-http_3.adb
@@ -1169,10 +1169,15 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Item.Response_Ended := True;
    end Mark_Failed;
 
+   type Header_Block_Access is access H3.Header_Block;
+
+   procedure Free_Header_Block is new Ada.Unchecked_Deallocation
+     (H3.Header_Block, Header_Block_Access);
+
    type Request_Slot is record
       Occupied    : Boolean := False;
       Stream      : QUIC.Stream_ID := 0;
-      Headers     : H3.Header_Block;
+      Headers     : Header_Block_Access := null;
       Saw_Headers : Boolean := False;
       Payload_Bytes : Bytes.Unbounded_Bytes;
       Started     : Ada.Real_Time.Time := Ada.Real_Time.Time_Last;
@@ -1268,11 +1273,11 @@ package body Flyology.HTTP.Server.HTTP_3 is
 
       procedure Dispatch_Request (Slot : Positive) is
          Method : constant String := Header_Value
-           (Requests (Slot).Headers, ":method");
+           (Requests (Slot).Headers.all, ":method");
          Target : constant String := Header_Value
-           (Requests (Slot).Headers, ":path");
+           (Requests (Slot).Headers.all, ":path");
          Authority : constant String := Header_Value
-           (Requests (Slot).Headers, ":authority");
+           (Requests (Slot).Headers.all, ":authority");
          Validated : constant Flyology.HTTP.Method := To_Method (Method);
          pragma Unreferenced (Validated);
          Backend : aliased Stream_Backend;
@@ -1294,10 +1299,10 @@ package body Flyology.HTTP.Server.HTTP_3 is
          Value.Version_Value := HTTP_1_1;
          Value.Protocol_Value := HTTP_3_Protocol;
          Value.Keep_Alive := True;
-         for Index in 1 .. H3.Header_Count (Requests (Slot).Headers) loop
+         for Index in 1 .. H3.Header_Count (Requests (Slot).Headers.all) loop
             declare
                Field : constant H3.Header_Field :=
-                 H3.Field_At (Requests (Slot).Headers, Index);
+                 H3.Field_At (Requests (Slot).Headers.all, Index);
                Name : constant String := H3.Field_Name (Field);
             begin
                if Name'Length > 0 and then Name (Name'First) /= ':' then
@@ -1308,7 +1313,7 @@ package body Flyology.HTTP.Server.HTTP_3 is
             end;
          end loop;
          if Authority /= "" and then Header_Value
-           (Requests (Slot).Headers, "host") = ""
+           (Requests (Slot).Headers.all, "host") = ""
          then
             Append (Value.Header_Block, "Host: " & Authority & CRLF);
          end if;
@@ -1395,7 +1400,9 @@ package body Flyology.HTTP.Server.HTTP_3 is
          Requests (Slot).Occupied := False;
          Requests (Slot).Stream := 0;
          Requests (Slot).Saw_Headers := False;
-         H3.Clear (Requests (Slot).Headers);
+         if Requests (Slot).Headers /= null then
+            H3.Clear (Requests (Slot).Headers.all);
+         end if;
          Requests (Slot).Started := Ada.Real_Time.Time_Last;
          Bytes.Clear (Requests (Slot).Payload_Bytes);
       end Release;
@@ -1418,12 +1425,15 @@ package body Flyology.HTTP.Server.HTTP_3 is
                   Requests (Slot).Occupied := True;
                   Requests (Slot).Stream := Value.Stream;
                   Requests (Slot).Started := Ada.Real_Time.Clock;
+                  if Requests (Slot).Headers = null then
+                     Requests (Slot).Headers := new H3.Header_Block;
+                  end if;
                end if;
                if not Requests (Slot).Saw_Headers then
-                  H3.Clear (Requests (Slot).Headers);
+                  H3.Clear (Requests (Slot).Headers.all);
                   for Index in 1 .. H3.Header_Count (Value.Headers) loop
                      H3.Append
-                       (Requests (Slot).Headers,
+                       (Requests (Slot).Headers.all,
                         H3.Field_At (Value.Headers, Index));
                   end loop;
                   Requests (Slot).Saw_Headers := True;
@@ -1473,6 +1483,11 @@ package body Flyology.HTTP.Server.HTTP_3 is
       procedure Cleanup is
       begin
          if Requests /= null then
+            for Index in Requests.all'Range loop
+               if Requests (Index).Headers /= null then
+                  Free_Header_Block (Requests (Index).Headers);
+               end if;
+            end loop;
             Free_Request_Array (Requests);
          end if;
          if State /= null then

--- a/src/flyology-http-server-http_3.adb
+++ b/src/flyology-http-server-http_3.adb
@@ -56,6 +56,7 @@ package body Flyology.HTTP.Server.HTTP_3 is
    type Boolean_Array is array (Positive range <>) of Boolean;
    type Connection_ID_Array is
      array (Positive range <>) of QUIC.Connection_ID;
+   type Stream_ID_Array is array (Positive range <>) of QUIC.Stream_ID;
    type Endpoint_Array is array (Positive range <>) of Sockets.Endpoint;
 
    function Same_ID (Left, Right : QUIC.Connection_ID) return Boolean is
@@ -152,6 +153,11 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Transport : QUIC.Connection;
       Session   : H3.Session;
       Response_Headers : H3.Header_Block;
+      Pending_Responses : H3.Prepared_Response_Array
+        (1 .. H3.Max_Prepared_Responses);
+      Pending_Streams : Stream_ID_Array (1 .. H3.Max_Prepared_Responses) :=
+        (others => 0);
+      Pending_Count : Natural range 0 .. H3.Max_Prepared_Responses := 0;
       H3_Started : Boolean := False;
       ACK_Pending : Boolean := False;
       Closed    : Boolean := False;
@@ -357,6 +363,96 @@ package body Flyology.HTTP.Server.HTTP_3 is
    end Flush_Pending_ACK;
 
    procedure Receive_One
+     (Item : in out Connection_State; Timeout : Duration);
+
+   procedure Flush_Pending_Responses
+     (Item : in out Connection_State; Timeout : Duration)
+   is
+      Packet       : QUIC.Datagram;
+      Status       : H3.Operation_Status;
+      ACK_Included : Boolean;
+
+      procedure Commit
+        (First, Last : Positive)
+      is
+         Released : H3.Operation_Status;
+      begin
+         loop
+            H3.Send_Prepared_Responses
+              (Item.Session, Item.Transport,
+               Item.Pending_Responses (First .. Last), Now (Item), Packet,
+               Status, ACK_Included);
+            exit when Status /= H3.Transport_Blocked;
+            Receive_One (Item, Timeout);
+         end loop;
+         if Status /= H3.Succeeded then
+            raise Flyology.IO.Device_Error with
+              "HTTP/3 prepared response failed: " &
+              H3.Operation_Status'Image (Status);
+         end if;
+         Send (Item, Packet, Timeout);
+         if ACK_Included then
+            Item.ACK_Pending := False;
+         end if;
+         for Index in First .. Last loop
+            H3.Release_Request
+              (Item.Session, Item.Transport, Item.Pending_Streams (Index),
+               Released);
+            if Released /= H3.Succeeded then
+               raise Flyology.IO.Device_Error with
+                 "HTTP/3 prepared request release failed: " &
+                 H3.Operation_Status'Image (Released);
+            end if;
+         end loop;
+      end Commit;
+   begin
+      if Item.Pending_Count = 0 then
+         return;
+      end if;
+      if Debug.Enabled then
+         Debug.Log
+           ("h3", "response-batch",
+            "count=" & Natural'Image (Item.Pending_Count));
+      end if;
+      H3.Send_Prepared_Responses
+        (Item.Session, Item.Transport,
+         Item.Pending_Responses (1 .. Item.Pending_Count), Now (Item), Packet,
+         Status, ACK_Included);
+      if Status = H3.Frame_Too_Large and then Item.Pending_Count > 1 then
+         for Index in 1 .. Item.Pending_Count loop
+            Commit (Index, Index);
+         end loop;
+      elsif Status = H3.Transport_Blocked then
+         Commit (1, Item.Pending_Count);
+      elsif Status = H3.Succeeded then
+         Send (Item, Packet, Timeout);
+         if ACK_Included then
+            Item.ACK_Pending := False;
+         end if;
+         for Index in 1 .. Item.Pending_Count loop
+            declare
+               Released : H3.Operation_Status;
+            begin
+               H3.Release_Request
+                 (Item.Session, Item.Transport, Item.Pending_Streams (Index),
+                  Released);
+               if Released /= H3.Succeeded then
+                  raise Flyology.IO.Device_Error with
+                    "HTTP/3 prepared request release failed: " &
+                    H3.Operation_Status'Image (Released);
+               end if;
+            end;
+         end loop;
+      else
+         raise Flyology.IO.Device_Error with
+           "HTTP/3 prepared response failed: " &
+           H3.Operation_Status'Image (Status);
+      end if;
+      Item.Pending_Count := 0;
+      Item.Pending_Streams := (others => 0);
+   end Flush_Pending_Responses;
+
+   procedure Receive_One
      (Item : in out Connection_State; Timeout : Duration)
    is
       Packet : Stream_Element_Array (1 .. QUIC.Max_Datagram_Length);
@@ -460,6 +556,7 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Head_Request     : Boolean := False;
       Response_Begun   : Boolean := False;
       Response_Ended   : Boolean := False;
+      Response_Buffered : Boolean := False;
    end record;
 
    overriding function Response_Started
@@ -628,6 +725,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Packet : QUIC.Datagram;
       Status : H3.Operation_Status;
    begin
+      Flush_Pending_Responses
+        (Item.Owner.all, Remaining (Item.Deadline));
       loop
          H3.Send_Headers
            (Item.Owner.Session, Item.Owner.Transport, Item.Stream, Fields,
@@ -652,6 +751,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Packet : QUIC.Datagram;
       Status : H3.Operation_Status;
    begin
+      Flush_Pending_Responses
+        (Item.Owner.all, Remaining (Item.Deadline));
       loop
          H3.Send_Data
            (Item.Owner.Session, Item.Owner.Transport, Item.Stream, Data, Fin,
@@ -674,32 +775,31 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Data     : Stream_Element_Array;
       Combined : out Boolean)
    is
-      Packet : QUIC.Datagram;
       Status : H3.Operation_Status;
-      ACK_Included : Boolean;
+      Prepared : H3.Prepared_Response;
    begin
-      loop
-         H3.Send_Response
-           (Item.Owner.Session, Item.Owner.Transport, Item.Stream, Fields,
-            Data, Now (Item.Owner.all), Packet, Status, ACK_Included);
-         exit when Status in H3.Succeeded | H3.Frame_Too_Large;
-         if Status /= H3.Transport_Blocked then
-            raise Flyology.IO.Device_Error with
-              "HTTP/3 complete response failed: " &
-              H3.Operation_Status'Image (Status);
-         end if;
-         Wait_For_Transport (Item);
-      end loop;
+      H3.Prepare_Response
+        (Item.Owner.Session, Item.Owner.Transport, Item.Stream, Fields, Data,
+         Prepared, Status);
       Combined := Status = H3.Succeeded;
       if not Combined then
+         if Status /= H3.Frame_Too_Large then
+            raise Flyology.IO.Device_Error with
+              "HTTP/3 complete response preparation failed: " &
+              H3.Operation_Status'Image (Status);
+         end if;
          return;
       end if;
-      Send (Item.Owner.all, Packet, Remaining (Item.Deadline));
-      if ACK_Included then
-         Item.Owner.ACK_Pending := False;
+      Item.Owner.Pending_Count := Item.Owner.Pending_Count + 1;
+      Item.Owner.Pending_Responses (Item.Owner.Pending_Count) := Prepared;
+      Item.Owner.Pending_Streams (Item.Owner.Pending_Count) := Item.Stream;
+      if Item.Owner.Pending_Count = H3.Max_Prepared_Responses then
+         Flush_Pending_Responses
+           (Item.Owner.all, Remaining (Item.Deadline));
       end if;
       Item.Response_Begun := True;
       Item.Response_Ended := True;
+      Item.Response_Buffered := True;
    end Try_Send_Response;
 
    procedure Append_Field
@@ -1157,6 +1257,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Packet : QUIC.Datagram;
       Status : H3.Operation_Status;
    begin
+      Flush_Pending_Responses
+        (Item.Owner.all, Remaining (Item.Deadline));
       if Item.Response_Ended then
          return;
       end if;
@@ -1257,7 +1359,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
          Send (State.all, Control, Handshake_Timeout);
       end Start_HTTP_3;
 
-      procedure Dispatch_Request (Slot : Positive) is
+      procedure Dispatch_Request
+        (Slot : Positive; Response_Buffered : out Boolean) is
          Method : constant String :=
            To_String (Requests (Slot).Value.Method_Value);
          Target : constant String :=
@@ -1276,6 +1379,7 @@ package body Flyology.HTTP.Server.HTTP_3 is
             Deadline,
             Secure_HTTPS);
       begin
+         Response_Buffered := False;
          if Method = "CONNECT" or else Target = "" then
             raise Protocol_Error with
               "HTTP/3 CONNECT is not supported by the application adapter";
@@ -1313,6 +1417,7 @@ package body Flyology.HTTP.Server.HTTP_3 is
                   X.Mark_Failed;
                end if;
          end;
+         Response_Buffered := Backend.Response_Buffered;
          Served := Served + 1;
          if Debug.Enabled
            and then
@@ -1452,15 +1557,22 @@ package body Flyology.HTTP.Server.HTTP_3 is
                   raise Protocol_Error with
                     "HTTP/3 stream ended without request";
                end if;
-               Dispatch_Request (Positive (Slot));
-               H3.Release_Request
-                 (State.Session, State.Transport,
-                  Requests (Slot).Stream, H3_Status);
-               if H3_Status /= H3.Succeeded then
-                  raise Protocol_Error with
-                    "HTTP/3 request release failed: " &
-                    H3.Operation_Status'Image (H3_Status);
-               end if;
+               declare
+                  Response_Buffered : Boolean;
+               begin
+                  Dispatch_Request
+                    (Positive (Slot), Response_Buffered);
+                  if not Response_Buffered then
+                     H3.Release_Request
+                       (State.Session, State.Transport,
+                        Requests (Slot).Stream, H3_Status);
+                     if H3_Status /= H3.Succeeded then
+                        raise Protocol_Error with
+                          "HTTP/3 request release failed: " &
+                          H3.Operation_Status'Image (H3_Status);
+                     end if;
+                  end if;
+               end;
                Release (Positive (Slot));
                if Served < Max_Requests and then Request_Credit_Due then
                   Return_Request_Credit;
@@ -1547,6 +1659,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
                when H3.Succeeded =>
                   Process_Event (Value);
                when H3.No_Event =>
+                  Flush_Pending_Responses
+                    (State.all, Remaining (Connection_Deadline));
                   Receive_One (State.all, Remaining (Connection_Deadline));
                when others =>
                   Close_For_H3_Error
@@ -1558,6 +1672,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
                exit when Remaining (Connection_Deadline) = 0.0;
          end;
       end loop;
+      Flush_Pending_Responses
+        (State.all, Remaining (Connection_Deadline));
       Cleanup;
    exception
       when others =>

--- a/tests/flyology-http-qpack_static_table-smoke.adb
+++ b/tests/flyology-http-qpack_static_table-smoke.adb
@@ -1,5 +1,19 @@
 procedure Flyology.HTTP.QPACK_Static_Table.Smoke is
 begin
+   for Index in Static_Index loop
+      declare
+         Exact : constant Lookup_Result :=
+           Find_Exact (Name (Index), Value (Index));
+         Named : constant Lookup_Result := Find_Name (Name (Index));
+      begin
+         pragma Assert
+           (Exact.Found
+            and then Name (Exact.Index) = Name (Index)
+            and then Value (Exact.Index) = Value (Index));
+         pragma Assert
+           (Named.Found and then Name (Named.Index) = Name (Index));
+      end;
+   end loop;
    pragma Assert (Name (0) = ":authority" and then Value (0) = "");
    pragma Assert (Name (17) = ":method" and then Value (17) = "GET");
    pragma Assert (Name (23) = ":scheme" and then Value (23) = "https");

--- a/tests/http3_client_stress_probe.adb
+++ b/tests/http3_client_stress_probe.adb
@@ -30,6 +30,9 @@ procedure HTTP3_Client_Stress_Probe is
      (if Ada.Command_Line.Argument_Count < 4 then 1
       else Flyology.Execution_Groups.Loop_Pool_Size'Value
         (Ada.Command_Line.Argument (4)));
+   Max_Idle : constant Natural :=
+     (if Ada.Command_Line.Argument_Count < 5 then 1
+      else Natural'Value (Ada.Command_Line.Argument (5)));
 
    function Decimal (Value : Positive) return String is
       Image : constant String := Positive'Image (Value);
@@ -160,7 +163,8 @@ begin
       Flyology.HTTP.Parse_Origin
         ("https://127.0.0.1:" & Decimal (Port)),
       Client.Require_HTTP_3,
-      HTTP_3_Certificate_DER => Fixtures.Server_Certificate);
+      HTTP_3_Certificate_DER => Fixtures.Server_Certificate,
+      Pool => (Max_Idle => Max_Idle, others => <>));
    Started := Ada.Real_Time.Clock;
    declare
       type Worker_Array is array (Positive range <>) of Worker;
@@ -174,6 +178,8 @@ begin
       Wall : constant Duration :=
         Ada.Real_Time.To_Duration (Ada.Real_Time.Clock - Started);
       Passed : constant Natural := Results.Successes;
+      Pool_State : constant Client.Client_Diagnostics :=
+        Client.Diagnostics (HTTP);
    begin
       Ada.Text_IO.Put_Line
         ("workers=" & Decimal (Worker_Count)
@@ -186,6 +192,11 @@ begin
                else Long_Float (Passed) / Long_Float (Wall)))
          & " mean_s=" & Duration'Image (Results.Mean)
          & " max_s=" & Duration'Image (Results.Maximum));
+      Ada.Text_IO.Put_Line
+        ("pool_created=" & Natural'Image (Pool_State.Transports_Created)
+         & " pool_reused=" & Natural'Image (Pool_State.Transport_Reuses)
+         & " pool_idle=" & Natural'Image (Pool_State.Reusable_Transports)
+         & " pool_closed=" & Natural'Image (Pool_State.Transports_Closed));
       if Results.Failures > 0 then
          Ada.Text_IO.Put_Line ("first_error=" & Results.First_Error);
       end if;

--- a/tests/http3_h3spec_server.adb
+++ b/tests/http3_h3spec_server.adb
@@ -26,6 +26,9 @@ procedure HTTP3_H3Spec_Server is
    Max_Connection_Age : constant Duration :=
      (if Ada.Command_Line.Argument_Count < 4 then 15.0
       else Duration'Value (Ada.Command_Line.Argument (4)));
+   Max_Requests : constant Positive :=
+     (if Ada.Command_Line.Argument_Count < 5 then 5
+      else Positive'Value (Ada.Command_Line.Argument (5)));
 
    type Context is limited null record;
    package Routing is new Flyology.HTTP.Server.Routing (Context);
@@ -36,8 +39,14 @@ procedure HTTP3_H3Spec_Server is
       X.Text (200, "h3spec");
    end Root;
 
+   procedure Hello (State : in out Context; X : in out App.Exchange) is
+      pragma Unreferenced (State);
+   begin
+      X.Text (200, "hello");
+   end Hello;
+
    Routes : aliased Routing.Router
-     (Capacity => 1, Slashes => Routing.Strict_Slashes);
+     (Capacity => 2, Slashes => Routing.Strict_Slashes);
    State  : aliased Context;
    Socket : aliased Sockets.Socket_Type;
    Stop   : aliased Flyology.Cancellation.Token;
@@ -47,6 +56,7 @@ begin
         "HTTP/3 stress server linked an unexpected loop-pool size";
    end if;
    Routes.Get ("/", Root'Access, Name => "root");
+   Routes.Get ("/hello", Hello'Access, Name => "hello");
    Sockets.Create_Socket (Socket, Sockets.IPv4, Sockets.Socket_Datagram);
    Sockets.Bind_Socket
      (Socket, Sockets.Network_Endpoint (Sockets.Loopback_IPv4, Port));
@@ -64,6 +74,6 @@ begin
       Timeout => 5.0,
       Handshake_Timeout => 5.0,
       Max_Connection_Age => Max_Connection_Age,
-      Max_Requests => 5,
+      Max_Requests => Max_Requests,
       Token => Stop'Access);
 end HTTP3_H3Spec_Server;

--- a/tests/oracle/quic-go/cmd/benchmark/main.go
+++ b/tests/oracle/quic-go/cmd/benchmark/main.go
@@ -1,0 +1,259 @@
+// quic-go-h3-benchmark is a compiled HTTP/3 load generator for the unified
+// Flyology HTTP benchmark route. It is intentionally separate from the
+// interoperability oracle so qualification remains a small fixed exchange.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+)
+
+type clientConnection struct {
+	client    *http.Client
+	transport *http3.Transport
+}
+
+type latencySummary struct {
+	Mean float64 `json:"mean"`
+	P50  float64 `json:"p50"`
+	P95  float64 `json:"p95"`
+	P99  float64 `json:"p99"`
+	Max  float64 `json:"max"`
+}
+
+type summary struct {
+	Protocol        string         `json:"protocol"`
+	Requests        uint64         `json:"requests"`
+	Connections     int            `json:"connections"`
+	Streams         int            `json:"streams"`
+	Concurrency     int            `json:"concurrency"`
+	ConnectionReuse float64        `json:"connection_reuse"`
+	WallSeconds     float64        `json:"wall_s"`
+	RequestsPerSec  float64        `json:"requests_per_s"`
+	ResponseBytes   int            `json:"response_bytes"`
+	LatencyMS       latencySummary `json:"latency_ms"`
+	HandshakeMS     latencySummary `json:"handshake_ms"`
+}
+
+func newConnection(timeout time.Duration) clientConnection {
+	transport := &http3.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // The benchmark server uses a test identity.
+			NextProtos:         []string{http3.NextProtoH3},
+			MinVersion:         tls.VersionTLS13,
+		},
+		QUICConfig: &quic.Config{
+			MaxIdleTimeout:          timeout,
+			InitialPacketSize:       1200,
+			DisablePathMTUDiscovery: true,
+		},
+	}
+	return clientConnection{
+		client:    &http.Client{Transport: transport, Timeout: timeout},
+		transport: transport,
+	}
+}
+
+func request(
+	ctx context.Context,
+	client *http.Client,
+	url string,
+	expectedBody []byte,
+) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	response, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	body, readErr := io.ReadAll(response.Body)
+	closeErr := response.Body.Close()
+	if readErr != nil {
+		return readErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if response.StatusCode != http.StatusOK || !bytes.Equal(body, expectedBody) {
+		return fmt.Errorf(
+			"unexpected response: status=%d body=%q",
+			response.StatusCode,
+			body,
+		)
+	}
+	return nil
+}
+
+func summarize(values []time.Duration) latencySummary {
+	if len(values) == 0 {
+		return latencySummary{}
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+	var total time.Duration
+	for _, value := range values {
+		total += value
+	}
+	percentile := func(numerator int) float64 {
+		index := (len(values)*numerator + 99) / 100
+		if index < 1 {
+			index = 1
+		}
+		return float64(values[index-1]) / float64(time.Millisecond)
+	}
+	return latencySummary{
+		Mean: float64(total) / float64(len(values)) / float64(time.Millisecond),
+		P50:  percentile(50),
+		P95:  percentile(95),
+		P99:  percentile(99),
+		Max:  float64(values[len(values)-1]) / float64(time.Millisecond),
+	}
+}
+
+func benchmark(
+	port int,
+	path string,
+	expectedBody []byte,
+	requests uint64,
+	connectionCount int,
+	streams int,
+	timeout time.Duration,
+) (summary, error) {
+	url := fmt.Sprintf("https://localhost:%d%s", port, path)
+	connections := make([]clientConnection, connectionCount)
+	handshakes := make([]time.Duration, connectionCount)
+	for index := range connections {
+		connections[index] = newConnection(timeout)
+		started := time.Now()
+		if err := request(
+			context.Background(), connections[index].client, url, expectedBody,
+		); err != nil {
+			return summary{}, fmt.Errorf("warmup connection %d: %w", index, err)
+		}
+		handshakes[index] = time.Since(started)
+	}
+	defer func() {
+		for _, connection := range connections {
+			_ = connection.transport.Close()
+		}
+	}()
+
+	latencies := make([]time.Duration, requests)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var next atomic.Uint64
+	var wait sync.WaitGroup
+	errCh := make(chan error, 1)
+	workerCount := connectionCount * streams
+	ready := make(chan struct{})
+	for worker := 0; worker < workerCount; worker++ {
+		wait.Add(1)
+		go func(client *http.Client) {
+			defer wait.Done()
+			<-ready
+			for {
+				index := next.Add(1) - 1
+				if index >= requests {
+					return
+				}
+				started := time.Now()
+				if err := request(ctx, client, url, expectedBody); err != nil {
+					select {
+					case errCh <- err:
+						cancel()
+					default:
+					}
+					return
+				}
+				latencies[index] = time.Since(started)
+			}
+		}(connections[worker/streams].client)
+	}
+	started := time.Now()
+	close(ready)
+	wait.Wait()
+	wall := time.Since(started)
+	select {
+	case err := <-errCh:
+		return summary{}, err
+	default:
+	}
+
+	return summary{
+		Protocol:        "h3",
+		Requests:        requests,
+		Connections:     connectionCount,
+		Streams:         streams,
+		Concurrency:     workerCount,
+		ConnectionReuse: float64(requests) / float64(connectionCount),
+		WallSeconds:     wall.Seconds(),
+		RequestsPerSec:  float64(requests) / wall.Seconds(),
+		ResponseBytes:   len(expectedBody),
+		LatencyMS:       summarize(latencies),
+		HandshakeMS:     summarize(handshakes),
+	}, nil
+}
+
+func main() {
+	log.SetFlags(0)
+	port := flag.Int("port", 18443, "UDP port")
+	path := flag.String("path", "/hello/test", "request path")
+	responseBytes := flag.Int("response-bytes", 0, "expected response size (zero uses the path)")
+	requests := flag.Uint64("requests", 10000, "measured requests")
+	connections := flag.Int("connections", 8, "persistent QUIC connections")
+	streams := flag.Int("streams", 8, "concurrent request streams per connection")
+	timeout := flag.Duration("timeout", 10*time.Second, "request and idle timeout")
+	flag.Parse()
+	if *requests == 0 || *connections < 1 || *streams < 1 || *timeout <= 0 {
+		log.Fatal("requests, connections, streams, and timeout must be positive")
+	}
+
+	expectedBody := []byte("hello " + strings.TrimPrefix(*path, "/hello/"))
+	if *responseBytes != 0 {
+		if *responseBytes < len("hello ") {
+			log.Fatal("response-bytes cannot be smaller than 6")
+		}
+		name := strings.Repeat("x", *responseBytes-len("hello "))
+		*path = "/hello/" + name
+		expectedBody = []byte("hello " + name)
+	}
+
+	result, err := benchmark(
+		*port,
+		*path,
+		expectedBody,
+		*requests,
+		*connections,
+		*streams,
+		*timeout,
+	)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(1)
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(result); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What changed

- retain bounded HTTP/2 handler tasks and wake sources across stream-slot reuse
- reduce HPACK and QPACK static-table lookup and header-copy overhead
- tighten HTTP/3 client, request-slot, ACK, and QUIC key-update bookkeeping
- add a maintained multiprocess aioquic benchmark oracle
- transactionally coalesce up to eight complete HTTP/3 responses into one QUIC packet
- document reproducible baselines, profiles, accepted/rejected hypotheses, and final results

## Why

Profiles showed that HTTP/2 was dominated by per-request task and descriptor lifecycle. HTTP/3 was first limited by the Python oracle and connection topology, then by one-packet-per-response output—not primarily by crypto, QPACK, routing, or timers.

On the local M3 Max measurement host, the final 16-loop H3 median is 143,709 requests/s and the post-qualification spot run is 146,562 requests/s at eight persistent connections x 16 streams. The adjacent H2 spot run is 148,167 requests/s. These are experimental machine-local results, not portable server ratings.

The H3 batch path preserves bounded flow control, recovery, retransmission, final-size, and request-release semantics. Oversize responses fall back to individual packets.

## Validation

- `./scripts/test.sh`
- `./scripts/prove.sh`
- `./scripts/docs.sh`
- `./scripts/http2-test.sh qualification`, including h2spec 146/146
- aioquic and quic-go HTTP/3 interop in both client/server directions
- h3spec 49/49
- bounded HTTP/3 malformed-input, churn, concurrency, and Ada-client stress suites
- all HTTP/3 builds used an explicitly verified Flyology lightweight RTS with tracing disabled

The full local notebook is in `docs/http-stack-performance-2026-08-09.md`.