### PR TITLE
Run proofs and WebSocket qualification in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,28 @@ jobs:
       - name: Check the WPT gate wiring
         run: ./flyology_iri/scripts/wpt-gate-test.sh
 
+  proof:
+    name: SPARK proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Alire
+        uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
+        with:
+          version: 2.1.1
+          toolchain: >-
+            gnat_native=16.1.0
+            gprbuild=26.0.1
+          cache: true
+      - name: Configure Flyology index
+        run: |
+          alr index --reset-community
+          alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
+      - name: Prove QUIC and HTTP policy units
+        run: ./scripts/prove.sh
+
   http2-qualification:
     name: HTTP/2 qualification
     runs-on: ubuntu-latest
@@ -151,3 +173,68 @@ jobs:
         run: ./scripts/test-http3-h3spec.sh
       - name: Run bounded HTTP/3 stress campaign
         run: ./scripts/test-http3-stress.sh
+
+  websocket-conformance:
+    name: WebSocket conformance (${{ matrix.profile }}, ${{ matrix.lane }})
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: core
+            lane: lightweight
+          - profile: core
+            lane: native
+          - profile: core-wss
+            lane: lightweight
+          - profile: core-wss
+            lane: native
+          - profile: limits
+            lane: lightweight
+          - profile: limits
+            lane: native
+          - profile: compression
+            lane: lightweight
+          - profile: compression
+            lane: native
+          - profile: compression-wss
+            lane: lightweight
+          - profile: compression-wss
+            lane: native
+          - profile: performance
+            lane: lightweight
+          - profile: performance
+            lane: native
+          - profile: performance-wss
+            lane: lightweight
+          - profile: performance-wss
+            lane: native
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Alire
+        uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
+        with:
+          version: 2.1.1
+          toolchain: >-
+            gnat_native=16.1.0
+            gprbuild=26.0.1
+          cache: true
+      - name: Configure Flyology index
+        run: |
+          alr index --reset-community
+          alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
+      - name: Locate OpenSSL 3 modules
+        if: contains(matrix.profile, '-wss')
+        run: |
+          ssl_library=$(ldconfig -p | awk '$1 == "libssl.so.3" && !found { print $NF; found=1 }')
+          crypto_library=$(ldconfig -p | awk '$1 == "libcrypto.so.3" && !found { print $NF; found=1 }')
+          test -n "$ssl_library"
+          test -n "$crypto_library"
+          library_directory=$(dirname -- "$ssl_library")
+          test "$library_directory" = "$(dirname -- "$crypto_library")"
+          printf 'FLYOLOGY_OPENSSL_LIBRARY_DIR=%s\n' "$library_directory" >> "$GITHUB_ENV"
+      - name: Run Autobahn qualification
+        run: ./scripts/websocket-conformance.sh "${{ matrix.profile }}" "${{ matrix.lane }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
           alr index --reset-community
           alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
       - name: Prove QUIC and HTTP policy units
+        env:
+          FLYOLOGY_PROOF_LEVEL: "2"
         run: ./scripts/prove.sh
 
   http2-qualification:

--- a/flyology_quic/scripts/prove.sh
+++ b/flyology_quic/scripts/prove.sh
@@ -2,13 +2,14 @@
 set -eu
 
 crate_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+proof_level=${FLYOLOGY_PROOF_LEVEL:-1}
 
 cd "$crate_root/proof"
 alr build --stop-after=generation
 alr gnatprove \
   -P "$crate_root/flyology_quic.gpr" \
   --mode=all \
-  --level=1 \
+  --level="$proof_level" \
   -j0 \
   --output=oneline \
   --output-header \

--- a/scripts/prove.sh
+++ b/scripts/prove.sh
@@ -3,6 +3,7 @@ set -eu
 
 http_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 alr=$("$http_root/scripts/find-alr.sh")
+proof_level=${FLYOLOGY_PROOF_LEVEL:-1}
 
 "$http_root/flyology_quic/scripts/prove.sh"
 
@@ -11,7 +12,7 @@ cd "$http_root/proof"
 "$alr" gnatprove \
   -P "$http_root/flyology_http.gpr" \
   --mode=all \
-  --level=1 \
+  --level="$proof_level" \
   -j0 \
   --output=oneline \
   --output-header \


### PR DESCRIPTION
## What changed

- run the complete QUIC and HTTP SPARK proof campaign as a regular CI job
- run every maintained Autobahn profile and task lane from the nightly schedule
- locate matched OpenSSL 3 modules for WSS provenance checks

## Why

The proof and Autobahn campaigns were manual, allowing policy proof or WebSocket conformance regressions to remain unnoticed. Existing HTTP/2 soak and deterministic HTTP client coverage remain unchanged.

## Validation

- QUIC SPARK campaign: all 2,090 checks proved
- HTTP SPARK campaign: all 2,917 checks proved
- 28 WebSocket provenance and publication tests passed
- workflow YAML and all 14 Autobahn matrix configurations validated
