### PR TITLE
Remove superfluous string allocations from flyology_iri

### DIFF
--- a/flyology_iri/BENCHMARKS.md
+++ b/flyology_iri/BENCHMARKS.md
@@ -80,14 +80,15 @@ the pinned corpus:
 ./scripts/resolve-benchmark.sh
 ```
 
-Five workloads. `components_short`, `components_long`, and `components_huge`
+Six workloads. `components_short`, `components_long`, and `components_huge`
 each read all eight components of a parsed reference, cycling four references
 whose serialized lengths average 44, 235, and 2,009 bytes; the three sizes are
 what make a getter whose cost follows the reference distinguishable from one
 whose cost follows the component. `resolve_short_base` and `resolve_long_base`
 resolve the RFC 3986 section 5.4 relative references, plus the shapes a
 document with a base-URI directive carries, against an 18-byte and a 233-byte
-base.
+base. `resolve_long_base_string` repeats the last of those through the
+serialization-returning form.
 
 Batches fold a value derived from each result into an accumulator that
 `Measure_Result_Batched` hands to a barrier after the ending timestamp, and
@@ -178,16 +179,34 @@ which is why `components_short` improves as much as `components_long` despite
 copying a fifth as many bytes. At 2,009 bytes the discarded copy dominates and
 the improvement grows to 63.8%.
 
-## Validation cost
+## The two Resolve forms
 
-The same binary compares `Diagnose` against `Parse` over the assembled
-resolution results. Both subprograms exist in one process, so this one is a
-paired `Compare` and its result does not depend on which build is linked.
-`Diagnose` measures 212.9 ns/op against `Parse`'s 273.4 ns/op, 22.1% less, 95%
-CI [1.272, 1.293], winning 99 of 100 sample pairs.
+`Resolve` has a serialization-returning form that validates with `Diagnose`
+instead of building a second `Reference`. Both forms are in one process, so
+these are paired `Compare`s rather than baseline joins, and their answers do
+not depend on host load the way an independent run does.
 
-That difference is the cost of the second `Reference` that `Resolve` builds to
-validate its own assembled result: about 61 ns of the post-change
-`resolve_long_base` median of 823 ns. A `String`-returning `Resolve` that
-validated through `Diagnose` would recover roughly that much for a caller that
-needs the result validated but not its spans.
+The validation step alone, over the assembled resolution results: `Diagnose`
+211.2 ns/op against `Parse`'s 270.1 ns/op, 22.5% less, 95% CI [1.280, 1.303],
+winning 100 of 100 sample pairs.
+
+End to end against a 233-byte base:
+
+| Form | Median | Change | 95% CI | Pairs won |
+| --- | ---: | ---: | --- | ---: |
+| `Resolve` returning `Reference` | 821.3 | reference | -- | -- |
+| `Resolve` returning `String` | 743.4 | −9.45% | 1.102 .. 1.107 | 100/100 |
+
+Order effect −0.46%. Process and thread CPU time both fall 9.51%, and
+`Process_RSS_Change` and the page-fault axes read zero on both sides.
+
+The saving is larger than the 22.5% validation difference implies, because the
+serialization form also skips constructing and finalizing the result
+`Reference` — a controlled `Unbounded_String` plus eight spans — not only the
+parse that fills it.
+
+The two forms assemble through one private helper rather than one calling the
+other. Composing them the obvious way, with the `Reference` form parsing the
+`String` form's result, would make it validate twice and cost it about 210 ns
+it does not pay today. Its median is unchanged from the standalone
+`resolve_long_base` row above, which is what confirms that.

--- a/flyology_iri/BENCHMARKS.md
+++ b/flyology_iri/BENCHMARKS.md
@@ -147,6 +147,9 @@ round:
 | `resolve_short_base` | 608.8 | 475.8 | −22.2% | 1.276 .. 1.297 |
 | `resolve_long_base` | 980.8 | 823.2 | −15.5% | 1.154 .. 1.210 |
 
+Replacing the assembly's `Unbounded_String` with a plain buffer, below, takes
+the two resolution rows further, to 331.0 and 550.4 ns.
+
 The drift control repeated the pre-change build after the post-change one and
 landed within 3% of its own first round on every workload, against effects of
 15% to 64%. `Thread_CPU_Time` stayed within 1.2% of wall time in every run, so
@@ -187,26 +190,46 @@ these are paired `Compare`s rather than baseline joins, and their answers do
 not depend on host load the way an independent run does.
 
 The validation step alone, over the assembled resolution results: `Diagnose`
-211.2 ns/op against `Parse`'s 270.1 ns/op, 22.5% less, 95% CI [1.280, 1.303],
+213.9 ns/op against `Parse`'s 276.9 ns/op, 22.8% less, 95% CI [1.288, 1.303],
 winning 100 of 100 sample pairs.
 
 End to end against a 233-byte base:
 
 | Form | Median | Change | 95% CI | Pairs won |
 | --- | ---: | ---: | --- | ---: |
-| `Resolve` returning `Reference` | 821.3 | reference | -- | -- |
-| `Resolve` returning `String` | 743.4 | −9.45% | 1.102 .. 1.107 | 100/100 |
+| `Resolve` returning `Reference` | 536.2 | reference | -- | -- |
+| `Resolve` returning `String` | 461.2 | −13.87% | 1.156 .. 1.166 | 100/100 |
 
-Order effect −0.46%. Process and thread CPU time both fall 9.51%, and
+Order effect −0.48%. Process and thread CPU time both fall 14.0%, and
 `Process_RSS_Change` and the page-fault axes read zero on both sides.
 
-The saving is larger than the 22.5% validation difference implies, because the
+The saving is larger than the validation difference implies, because the
 serialization form also skips constructing and finalizing the result
 `Reference` — a controlled `Unbounded_String` plus eight spans — not only the
 parse that fills it.
 
 The two forms assemble through one private helper rather than one calling the
 other. Composing them the obvious way, with the `Reference` form parsing the
-`String` form's result, would make it validate twice and cost it about 210 ns
-it does not pay today. Its median is unchanged from the standalone
-`resolve_long_base` row above, which is what confirms that.
+`String` form's result, would make it validate twice and cost it about 214 ns
+it does not pay today. Its median tracks the standalone `resolve_long_base`
+row above, which is what confirms that.
+
+## Where the assembly's cost was
+
+The assembly writes into a plain `String` sized from the two parsed references,
+not into a growing `Unbounded_String`. That is worth more than the returned
+copy it also avoids, and it reaches both public forms:
+
+| Form | `Unbounded` assembly | Buffer assembly | Change |
+| --- | ---: | ---: | ---: |
+| `Resolve` returning `Reference` | 823.2 | 550.4 | −33% |
+| `Resolve` returning `String` | 743.4 | 466.5 | −37% |
+
+Most of that is not the result copy. The old shape reallocated on nearly every
+append, and its segment removal ran a whole `To_String` and
+`Set_Unbounded_String` for each `/../` it collapsed.
+
+A `procedure` form writing into a caller-supplied buffer was prototyped against
+this and measured 4.7% below the serialization form, winning 69 of 100 pairs.
+That difference is the returned copy alone, which is all the wider API buys
+once the assembly no longer allocates. It was not adopted.

--- a/flyology_iri/BENCHMARKS.md
+++ b/flyology_iri/BENCHMARKS.md
@@ -1,3 +1,10 @@
+# Benchmarks
+
+Two harnesses. The URL corpus benchmark below times validation and
+construction against Ada URL over a pinned third-party corpus. The resolution
+benchmark further down times the paths that read components back out of an
+already parsed reference, which the corpus benchmark does not reach.
+
 # URL corpus benchmark
 
 The benchmark uses the exact corpus loaded by Ada v4's `benchdata` target:
@@ -58,3 +65,129 @@ These are local development-machine observations, not portable performance
 claims. At this workload and resolution, validation is within one nanosecond of
 Ada's median and construction is within one nanosecond while slightly faster at
 the median.
+
+# Resolution and component benchmark
+
+`can_parse` constructs nothing and `parse_href` consumes only the stored
+serialization length, so neither reaches a component getter. The paths that
+read components back out of a parsed reference are timed separately, by
+`flyology_iri_resolve_benchmark`, which is built on
+[`flyology_bench`](https://flyology.org/guide/benchmarking/). It carries its
+own inputs, so unlike `benchmark.sh` it needs neither the Ada URL checkout nor
+the pinned corpus:
+
+```sh
+./scripts/resolve-benchmark.sh
+```
+
+Five workloads. `components_short`, `components_long`, and `components_huge`
+each read all eight components of a parsed reference, cycling four references
+whose serialized lengths average 44, 235, and 2,009 bytes; the three sizes are
+what make a getter whose cost follows the reference distinguishable from one
+whose cost follows the component. `resolve_short_base` and `resolve_long_base`
+resolve the RFC 3986 section 5.4 relative references, plus the shapes a
+document with a base-URI directive carries, against an 18-byte and a 233-byte
+base.
+
+Batches fold a value derived from each result into an accumulator that
+`Measure_Result_Batched` hands to a barrier after the ending timestamp, and
+each iteration advances to a different input. The fold reads one byte of each
+component as well as its length. That guard is precautionary: disassembling the
+harness shows all eight getter calls emitted either way, because the library is
+a separate project whose bodies `-gnatn2` does not inline into the harness, so
+`-O3` has no opportunity to satisfy a length-only consumer without producing
+the bytes.
+
+`scripts/resolve-benchmark.sh` selects `FLYOLOGY_IRI_BUILD_MODE=release`, the
+mode the corpus medians above also measure, and passes it to the binary.
+The build mode is part of the baseline compatibility fingerprint, because
+release suppresses runtime checks in `flyology_iri.adb` and that body is most
+of what these workloads execute.
+
+Two builds of one library cannot share a process, so a before/after pair joins
+through `Flyology_Bench.Baselines` rather than a paired `Compare`. Its
+fingerprint refuses a comparison across operating system, architecture,
+compiler, or build mode, and deliberately does not include the library
+revision, which is the difference being measured.
+
+## Metric axes
+
+The run requests `Process_Resource_Metrics`, the portable Darwin/Linux set.
+`Linux_Hardware_Metrics` would give a lower-noise instruction count, but its
+axes come from perf and report `Unsupported_Platform` on Darwin. The metrics
+CSV records the collection status of every requested axis rather than leaving
+it assumed; `--metrics-csv=PATH` sends it to a file.
+
+`Process_RSS_Change` measures retained resident growth per operation and reads
+zero for these workloads both before and after any change to transient copying,
+because the allocator reuses memory freed within the same batch. It is the
+wrong instrument for a change to short-lived copies, and a flat reading on it
+is not evidence that nothing moved. `Wall_Time` is the axis that responds, with
+`Thread_CPU_Time` alongside it to show that a wall-time difference is not a
+scheduling artifact.
+
+## Component-copy measurement
+
+Measurements from 2026-08-17 on an Apple M3 Max, macOS 26.5.2, GNAT 16.1.0,
+release build mode. Every one of the thirteen requested axes reported
+`collected` in every run. The host was not idle: an unrelated compiler
+bootstrap held the load average near 25 throughout, so the rounds were
+interleaved before/after/before/after and the repeated pre-change round serves
+as a drift control.
+
+Medians in ns/op, and the `Baselines` verdict against the first pre-change
+round:
+
+| Workload | Before | After | Change | 95% speedup CI |
+| --- | ---: | ---: | ---: | --- |
+| `components_short` | 127.6 | 74.2 | −41.9% | 1.712 .. 1.731 |
+| `components_long` | 124.6 | 82.2 | −33.5% | 1.491 .. 1.518 |
+| `components_huge` | 320.2 | 115.8 | −63.8% | 2.749 .. 2.782 |
+| `resolve_short_base` | 608.8 | 475.8 | −22.2% | 1.276 .. 1.297 |
+| `resolve_long_base` | 980.8 | 823.2 | −15.5% | 1.154 .. 1.210 |
+
+The drift control repeated the pre-change build after the post-change one and
+landed within 3% of its own first round on every workload, against effects of
+15% to 64%. `Thread_CPU_Time` stayed within 1.2% of wall time in every run, so
+the wall-time differences are not descheduling.
+`Process_RSS_Change` and both page-fault axes read zero on both sides.
+
+`components_huge` is the reading that identifies the cause. Before the change
+its median is 2.6 times `components_long`'s at 8.6 times the reference length;
+after it, 1.4 times. What remains scales with the components rather than with
+the reference.
+
+These are local development-machine observations on a loaded host, not portable
+performance claims.
+
+## What the compiler actually emits
+
+Timings alone cannot say which copy disappeared, so the release objects were
+disassembled on both sides. Before, `flyology_iri__scheme` called
+`ada__strings__unbounded__to_string` unconditionally and *ahead of the
+zero-span test*, then took a second `ss_allocate` and `memcpy` for the
+component itself: two copies per getter, one of them the length of the whole
+reference, paid even when the component was absent. After, the same symbol is a
+tail call to `ada__strings__unbounded__slice` on the present path, and the
+absent path allocates the eight bytes of a null string's bounds and returns
+without copying anything.
+
+That also explains the shape of the numbers. At 44 and 235 bytes the win is
+mostly one fewer call and one fewer secondary-stack allocation per getter,
+which is why `components_short` improves as much as `components_long` despite
+copying a fifth as many bytes. At 2,009 bytes the discarded copy dominates and
+the improvement grows to 63.8%.
+
+## Validation cost
+
+The same binary compares `Diagnose` against `Parse` over the assembled
+resolution results. Both subprograms exist in one process, so this one is a
+paired `Compare` and its result does not depend on which build is linked.
+`Diagnose` measures 212.9 ns/op against `Parse`'s 273.4 ns/op, 22.1% less, 95%
+CI [1.272, 1.293], winning 99 of 100 sample pairs.
+
+That difference is the cost of the second `Reference` that `Resolve` builds to
+validate its own assembled result: about 61 ns of the post-change
+`resolve_long_base` median of 823 ns. A `String`-returning `Resolve` that
+validated through `Diagnose` would recover roughly that much for a caller that
+needs the result validated but not its spans.

--- a/flyology_iri/BENCHMARKS.md
+++ b/flyology_iri/BENCHMARKS.md
@@ -148,7 +148,7 @@ round:
 | `resolve_long_base` | 980.8 | 823.2 | −15.5% | 1.154 .. 1.210 |
 
 Replacing the assembly's `Unbounded_String` with a plain buffer, below, takes
-the two resolution rows further, to 331.0 and 550.4 ns.
+the two resolution rows further, to 307.2 and 540.1 ns.
 
 The drift control repeated the pre-change build after the post-change one and
 landed within 3% of its own first round on every workload, against effects of
@@ -190,17 +190,17 @@ these are paired `Compare`s rather than baseline joins, and their answers do
 not depend on host load the way an independent run does.
 
 The validation step alone, over the assembled resolution results: `Diagnose`
-213.9 ns/op against `Parse`'s 276.9 ns/op, 22.8% less, 95% CI [1.288, 1.303],
+211.4 ns/op against `Parse`'s 273.1 ns/op, 22.7% less, 95% CI [1.290, 1.297],
 winning 100 of 100 sample pairs.
 
 End to end against a 233-byte base:
 
 | Form | Median | Change | 95% CI | Pairs won |
 | --- | ---: | ---: | --- | ---: |
-| `Resolve` returning `Reference` | 536.2 | reference | -- | -- |
-| `Resolve` returning `String` | 461.2 | −13.87% | 1.156 .. 1.166 | 100/100 |
+| `Resolve` returning `Reference` | 535.0 | reference | -- | -- |
+| `Resolve` returning `String` | 459.0 | −14.25% | 1.157 .. 1.177 | 100/100 |
 
-Order effect −0.48%. Process and thread CPU time both fall 14.0%, and
+Order effect −0.34%. Process and thread CPU time both fall 14.4%, and
 `Process_RSS_Change` and the page-fault axes read zero on both sides.
 
 The saving is larger than the validation difference implies, because the
@@ -210,7 +210,7 @@ parse that fills it.
 
 The two forms assemble through one private helper rather than one calling the
 other. Composing them the obvious way, with the `Reference` form parsing the
-`String` form's result, would make it validate twice and cost it about 214 ns
+`String` form's result, would make it validate twice and cost it about 211 ns
 it does not pay today. Its median tracks the standalone `resolve_long_base`
 row above, which is what confirms that.
 
@@ -220,10 +220,14 @@ The assembly writes into a plain `String` sized from the two parsed references,
 not into a growing `Unbounded_String`. That is worth more than the returned
 copy it also avoids, and it reaches both public forms:
 
-| Form | `Unbounded` assembly | Buffer assembly | Change |
+Measured by swapping the two assemblies in one interleaved sitting, with the
+repeated first arm as a drift control; it landed within 0.4% of itself.
+
+| Workload | `Unbounded` assembly | Buffer assembly | Change |
 | --- | ---: | ---: | ---: |
-| `Resolve` returning `Reference` | 823.2 | 550.4 | −33% |
-| `Resolve` returning `String` | 743.4 | 466.5 | −37% |
+| `resolve_short_base` | 468.4 | 307.2 | −34.4% |
+| `resolve_long_base` | 824.3 | 540.1 | −34.5% |
+| `resolve_long_base_string` | 747.7 | 464.0 | −37.9% |
 
 Most of that is not the result copy. The old shape reallocated on nearly every
 append, and its segment removal ran a whole `To_String` and

--- a/flyology_iri/README.md
+++ b/flyology_iri/README.md
@@ -90,5 +90,14 @@ parse-plus-href-length operations:
 The preparation script checks out both pinned inputs under the repository's
 ignored `build/flyology-iri-benchmark/` directory. The benchmark refuses
 unpinned revisions and prints both revisions, the number accepted by each
-implementation, and nanoseconds per URL. See
-[BENCHMARKS.md](BENCHMARKS.md) for pinned results and interpretation.
+implementation, and nanoseconds per URL.
+
+That comparison reaches neither the component getters nor `Resolve`. Those are
+timed separately, by a `flyology_bench` harness that carries its own inputs and
+needs no checkout:
+
+```sh
+./scripts/resolve-benchmark.sh
+```
+
+See [BENCHMARKS.md](BENCHMARKS.md) for pinned results and interpretation.

--- a/flyology_iri/benchmarks/alire.toml
+++ b/flyology_iri/benchmarks/alire.toml
@@ -5,10 +5,13 @@ version = "0.1.1-dev"
 authors = ["Yurii Rashkovskii"]
 maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 licenses = "MIT OR Apache-2.0"
-executables = ["flyology_iri_benchmark"]
+executables = ["flyology_iri_benchmark", "flyology_iri_resolve_benchmark"]
 
 [[depends-on]]
 flyology_iri = "*"
+
+[[depends-on]]
+flyology_bench = "~0.1.1-dev"
 
 [[pins]]
 flyology_iri = { path = ".." }

--- a/flyology_iri/benchmarks/flyology_iri_benchmarks.gpr
+++ b/flyology_iri/benchmarks/flyology_iri_benchmarks.gpr
@@ -1,3 +1,4 @@
+with "flyology_bench";
 with "flyology_iri";
 
 project Flyology_IRI_Benchmarks is
@@ -5,7 +6,8 @@ project Flyology_IRI_Benchmarks is
    for Source_Dirs use ("src");
    for Object_Dir use "obj";
    for Exec_Dir use "bin";
-   for Main use ("flyology_iri_benchmark.adb");
+   for Main use
+     ("flyology_iri_benchmark.adb", "flyology_iri_resolve_benchmark.adb");
    for Create_Missing_Dirs use "True";
 
    package Compiler is

--- a/flyology_iri/benchmarks/src/flyology_iri_resolve_benchmark.adb
+++ b/flyology_iri/benchmarks/src/flyology_iri_resolve_benchmark.adb
@@ -269,6 +269,32 @@ procedure Flyology_IRI_Resolve_Benchmark is
       Value := Total;
    end Resolve_Corpus;
 
+   --  The serialization-returning Resolve over the same corpus. Folding the
+   --  last byte as well as the length matches Sweep_Components, so the two
+   --  Resolve forms are consumed identically and the difference between them
+   --  is the validation each performs.
+   procedure Resolve_String_Corpus
+     (Base       : IRI.Reference;
+      Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer)
+   is
+      Total : Long_Long_Integer := 0;
+      Slot  : Positive := 1;
+   begin
+      for Iteration in Bench.Iteration_Count range 1 .. Iterations loop
+         declare
+            Span : Item_Span renames Relatives.Spans (Slot);
+            Done : constant String :=
+              IRI.Resolve (Base, Relatives.Text (Span.First .. Span.Last));
+         begin
+            Total := Total + Fold (Done);
+         end;
+         Slot := (if Slot = Relatives.Count then 1 else Slot + 1);
+      end loop;
+      Bench.Clobber_Memory;
+      Value := Total;
+   end Resolve_String_Corpus;
+
    procedure Components_Short_Batch
      (Iterations : Bench.Iteration_Count;
       Value      : out Long_Long_Integer) is
@@ -304,11 +330,20 @@ procedure Flyology_IRI_Resolve_Benchmark is
       Resolve_Corpus (Long_Base, Iterations, Value);
    end Resolve_Long_Batch;
 
-   --  The validation pair. Resolve ends by parsing its assembled result into a
-   --  second Reference; a String-returning Resolve would validate the same
-   --  bytes with Diagnose instead. Both subprograms exist in this process, so
-   --  this one is a genuine paired comparison rather than a baseline join, and
-   --  its answer does not depend on which build of the library is linked.
+   procedure Resolve_String_Long_Batch
+     (Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer) is
+   begin
+      Resolve_String_Corpus (Long_Base, Iterations, Value);
+   end Resolve_String_Long_Batch;
+
+   --  Two paired comparisons. Both sides of each live in this process, so
+   --  these are genuine paired Compares rather than baseline joins, and their
+   --  answers do not depend on host load the way an independent run does.
+   --
+   --  The first isolates the validation step: what the serialization form
+   --  saves is exactly the second Reference the Reference form builds. The
+   --  second measures the two public Resolve forms end to end.
    Validation_Sink : Long_Long_Integer := 0;
 
    procedure Parse_Assembled (Iterations : Bench.Iteration_Count) is
@@ -353,6 +388,20 @@ procedure Flyology_IRI_Resolve_Benchmark is
       Bench.Clobber_Memory;
    end Diagnose_Assembled;
 
+   procedure Resolve_Reference_Form (Iterations : Bench.Iteration_Count) is
+      Total : Long_Long_Integer;
+   begin
+      Resolve_Corpus (Long_Base, Iterations, Total);
+      Validation_Sink := Validation_Sink + Total;
+   end Resolve_Reference_Form;
+
+   procedure Resolve_String_Form (Iterations : Bench.Iteration_Count) is
+      Total : Long_Long_Integer;
+   begin
+      Resolve_String_Corpus (Long_Base, Iterations, Total);
+      Validation_Sink := Validation_Sink + Total;
+   end Resolve_String_Form;
+
    procedure Keep is new Bench.Do_Not_Optimize (Long_Long_Integer);
 
    procedure Measure_Components_Short is new Bench.Measure_Result_Batched
@@ -365,9 +414,14 @@ procedure Flyology_IRI_Resolve_Benchmark is
      (Element => Long_Long_Integer, Batch => Resolve_Short_Batch);
    procedure Measure_Resolve_Long is new Bench.Measure_Result_Batched
      (Element => Long_Long_Integer, Batch => Resolve_Long_Batch);
+   procedure Measure_Resolve_String is new Bench.Measure_Result_Batched
+     (Element => Long_Long_Integer, Batch => Resolve_String_Long_Batch);
    procedure Compare_Validation is new Bench.Compare_Batched
      (Reference_Batch => Parse_Assembled,
       Contender_Batch => Diagnose_Assembled);
+   procedure Compare_Resolve_Forms is new Bench.Compare_Batched
+     (Reference_Batch => Resolve_Reference_Form,
+      Contender_Batch => Resolve_String_Form);
 
    ----------------------------------------------------------------------
    --  Command line
@@ -536,6 +590,7 @@ procedure Flyology_IRI_Resolve_Benchmark is
    Configuration : Bench.Configuration;
    Result        : Bench.Measurement;
    Validation    : Bench.Comparison;
+   Resolve_Forms : Bench.Comparison;
 begin
    Read_Arguments;
    if Metrics_Path /= Unbounded.Null_Unbounded_String then
@@ -588,16 +643,24 @@ begin
    Measure_Resolve_Long (Configuration, Result);
    Report ("resolve_long_base", Result);
 
+   Measure_Resolve_String (Configuration, Result);
+   Report ("resolve_long_base_string", Result);
+
    Compare_Validation (Configuration, Validation);
+   Compare_Resolve_Forms (Configuration, Resolve_Forms);
    Keep (Validation_Sink);
    case Format is
       when Console =>
          Reporters.Put_Comparison_Console
            ("validate_by_parse", "validate_by_diagnose", Validation);
+         Reporters.Put_Comparison_Console
+           ("resolve_to_reference", "resolve_to_string", Resolve_Forms);
       when CSV =>
          Reporters.Put_Comparison_CSV_Header;
          Reporters.Put_Comparison_CSV
            ("validate_by_parse", "validate_by_diagnose", Validation);
+         Reporters.Put_Comparison_CSV
+           ("resolve_to_reference", "resolve_to_string", Resolve_Forms);
    end case;
 
    if Ada.Text_IO.Is_Open (Metrics_File) then

--- a/flyology_iri/benchmarks/src/flyology_iri_resolve_benchmark.adb
+++ b/flyology_iri/benchmarks/src/flyology_iri_resolve_benchmark.adb
@@ -1,0 +1,606 @@
+--  Copyright (c) 2026 Yurii Rashkovskii
+--  SPDX-License-Identifier: MIT OR Apache-2.0
+
+with Ada.Command_Line;
+with Ada.Directories;
+with Ada.Strings.Unbounded;
+with Ada.Text_IO;
+with Flyology_Bench;
+with Flyology_Bench.Baselines;
+with Flyology_Bench.Metadata;
+with Flyology_Bench.Reporters;
+with Flyology_IRI;
+
+--  Measures the component-getter and Resolve paths rather than the corpus
+--  parse loop flyology_iri_benchmark times. Those two workloads are the ones
+--  that read stored components back out of a parsed reference, so they are
+--  where the cost of materializing a whole serialized reference per component
+--  lands. The corpus benchmark reaches neither: can_parse constructs nothing
+--  and parse_href consumes only the stored serialization length.
+--
+--  The two implementations being compared are two builds of the same library,
+--  so they cannot share a process and paired Compare does not apply. Runs are
+--  therefore joined through Flyology_Bench.Baselines, whose fingerprint
+--  refuses to compare across operating system, architecture, compiler, or
+--  build mode. The single exception is the validation pair below, which
+--  compares two subprograms that do coexist and so uses Compare directly.
+procedure Flyology_IRI_Resolve_Benchmark is
+   package Bench renames Flyology_Bench;
+   package Baselines renames Flyology_Bench.Baselines;
+   package Reporters renames Flyology_Bench.Reporters;
+   package IRI renames Flyology_IRI;
+   package Unbounded renames Ada.Strings.Unbounded;
+
+   use type Bench.Iteration_Count;
+   use type Unbounded.Unbounded_String;
+
+   Usage : constant String :=
+     "usage: flyology_iri_resolve_benchmark"
+     & " [--format=console|csv]"
+     & " [--samples=N] [--measurement-time=SECONDS]"
+     & " [--build-mode=NAME] [--quiescence] [--metrics-csv=PATH]"
+     & " [--save-baseline=DIRECTORY] [--compare-baseline=DIRECTORY]";
+
+   ----------------------------------------------------------------------
+   --  Flat input corpora
+   ----------------------------------------------------------------------
+
+   --  Inputs live in one contiguous String addressed by spans so that a timed
+   --  loop can hand a reference to the library without allocating anything of
+   --  its own. An array of Unbounded_String would charge every iteration for
+   --  a To_String that has nothing to do with what is being measured.
+
+   Corpus_Capacity : constant := 64 * 1_024;
+   Corpus_Items    : constant := 64;
+
+   type Item_Span is record
+      First : Positive := 1;
+      Last  : Natural  := 0;
+   end record;
+
+   type Item_Span_Array is
+     array (Positive range 1 .. Corpus_Items) of Item_Span;
+
+   type String_Corpus is record
+      Text  : String (1 .. Corpus_Capacity) := (others => ' ');
+      Used  : Natural := 0;
+      Spans : Item_Span_Array := (others => (First => 1, Last => 0));
+      Count : Natural := 0;
+   end record;
+
+   procedure Append (Into : in out String_Corpus; Value : String) is
+   begin
+      Into.Count := Into.Count + 1;
+      Into.Spans (Into.Count) :=
+        (First => Into.Used + 1, Last => Into.Used + Value'Length);
+      Into.Text (Into.Used + 1 .. Into.Used + Value'Length) := Value;
+      Into.Used := Into.Used + Value'Length;
+   end Append;
+
+   ----------------------------------------------------------------------
+   --  Inputs
+   ----------------------------------------------------------------------
+
+   --  RFC 3986 section 5.4 uses this base for its normative resolution
+   --  examples, and the crate's own resolution tests already use it.
+   Short_Base_Text : constant String := "http://a/b/c/d;p?q";
+
+   --  A base of the size the issue describes. A reference this long is what
+   --  separates copying the whole serialization from copying one component;
+   --  at eighteen bytes the two are indistinguishable.
+   function Long_URL (Leaf : String) return String is
+     ("https://reader:secret@documents.archive.example.org:8443"
+      & "/collections/2026/quarter-three/regional-filings"
+      & "/appendix-b/exhibits/tables/normalized/" & Leaf
+      & "?revision=41&format=canonical&include=annotations&trace=off"
+      & "#section-4.2.1-table-notes");
+
+   Long_Base_Text : constant String := Long_URL ("index");
+
+   --  A deliberately oversized reference, still inside Default_Max_Length. It
+   --  exists to make the component sweep's dependence on reference length
+   --  measurable: a getter that copies the whole serialization is O(reference)
+   --  and must show here, while one that copies only its component is O(part)
+   --  and must not. Without this case a flat short/long result cannot be told
+   --  apart from a workload whose copy the optimizer already removed.
+   function Huge_URL (Leaf : String) return String is
+      Segment : constant String := "/padding-segment-of-known-width";
+      Filler  : String (1 .. 60 * Segment'Length);
+   begin
+      for Index in 1 .. 60 loop
+         Filler (Segment'Length * (Index - 1) + 1 .. Segment'Length * Index) :=
+           Segment;
+      end loop;
+      return "https://reader:secret@documents.archive.example.org:8443"
+        & Filler & "/" & Leaf
+        & "?revision=41&format=canonical&include=annotations&trace=off"
+        & "#section-4.2.1-table-notes";
+   end Huge_URL;
+
+   subtype Slot_Index is Positive range 1 .. 4;
+   type Reference_Array is array (Slot_Index) of IRI.Reference;
+
+   Short_Base : IRI.Reference;
+   Long_Base  : IRI.Reference;
+   Short_Refs : Reference_Array;
+   Long_Refs  : Reference_Array;
+   Huge_Refs  : Reference_Array;
+
+   --  Relative references: the RFC 3986 section 5.4 examples plus the shapes
+   --  a document with a base-URI directive actually carries.
+   Relatives : String_Corpus;
+
+   --  The absolute results those resolutions produce. Resolve validates its
+   --  assembled result by parsing it a second time; this corpus is what that
+   --  second parse sees.
+   Assembled : String_Corpus;
+
+   procedure Build_Inputs is
+   begin
+      Append (Relatives, "g");
+      Append (Relatives, "./g");
+      Append (Relatives, "g/");
+      Append (Relatives, "/g/h");
+      Append (Relatives, "//example.org/x");
+      Append (Relatives, "?y");
+      Append (Relatives, "g?y");
+      Append (Relatives, "#s");
+      Append (Relatives, "g#s");
+      Append (Relatives, "g?y#s");
+      Append (Relatives, ";x");
+      Append (Relatives, "g;x?y#s");
+      Append (Relatives, "");
+      Append (Relatives, ".");
+      Append (Relatives, "./");
+      Append (Relatives, "..");
+      Append (Relatives, "../");
+      Append (Relatives, "../g");
+      Append (Relatives, "../../g");
+      Append (Relatives, "../../../g");
+      Append (Relatives, "images/logo.png");
+      Append (Relatives, "../styles/site.css");
+      Append (Relatives, "/assets/app.js?v=3");
+      Append (Relatives, "#anchor");
+
+      Short_Base := IRI.Parse (Short_Base_Text, IRI.URI_Syntax);
+      Long_Base  := IRI.Parse (Long_Base_Text, IRI.URI_Syntax);
+
+      Short_Refs :=
+        [IRI.Parse ("https://user:pass@example.com:8443/a/b?x=1#frag",
+                    IRI.URI_Syntax),
+         IRI.Parse ("http://example.org/index.html?q=1#top", IRI.URI_Syntax),
+         IRI.Parse ("https://api.example.net:9443/v2/items?limit=20#none",
+                    IRI.URI_Syntax),
+         IRI.Parse ("http://cdn.example.com/a/b/c/d.png?w=64#x",
+                    IRI.URI_Syntax)];
+
+      Long_Refs :=
+        [IRI.Parse (Long_URL ("index"), IRI.URI_Syntax),
+         IRI.Parse (Long_URL ("summary"), IRI.URI_Syntax),
+         IRI.Parse (Long_URL ("appendix"), IRI.URI_Syntax),
+         IRI.Parse (Long_URL ("errata"), IRI.URI_Syntax)];
+
+      Huge_Refs :=
+        [IRI.Parse (Huge_URL ("index"), IRI.URI_Syntax),
+         IRI.Parse (Huge_URL ("summary"), IRI.URI_Syntax),
+         IRI.Parse (Huge_URL ("appendix"), IRI.URI_Syntax),
+         IRI.Parse (Huge_URL ("errata"), IRI.URI_Syntax)];
+
+      for Slot in 1 .. Relatives.Count loop
+         declare
+            Span : Item_Span renames Relatives.Spans (Slot);
+            Done : constant IRI.Reference :=
+              IRI.Resolve
+                (Long_Base, Relatives.Text (Span.First .. Span.Last));
+         begin
+            Append (Assembled, IRI.Image (Done));
+         end;
+      end loop;
+   end Build_Inputs;
+
+   ----------------------------------------------------------------------
+   --  Measured batches
+   ----------------------------------------------------------------------
+
+   --  Every batch folds something derived from the operation's result into an
+   --  accumulator handed out of the timed region, which is what keeps -O3 from
+   --  discarding the work. Clobber_Memory is a per-batch compiler barrier
+   --  rather than a per-iteration one, so it costs nothing measurable at the
+   --  calibrated batch sizes while still preventing stores from sinking past
+   --  the loop. Each batch also advances a slot so that consecutive iterations
+   --  use different inputs, which denies the optimizer a loop-invariant call.
+
+   --  Reading the last byte as well as the length is precautionary, not
+   --  observed to be necessary. Disassembling this body shows all eight getter
+   --  calls emitted either way, because the library is a separate project
+   --  whose bodies -gnatn2 does not inline here, so -O3 has no way to satisfy
+   --  a length-only consumer without producing the bytes. That would change if
+   --  the crate were ever built into one project with this harness or with
+   --  link-time optimization, and the guard costs within measurement noise.
+   function Fold (Value : String) return Long_Long_Integer is
+     (if Value'Length = 0 then 0
+      else Long_Long_Integer (Value'Length)
+           + Character'Pos (Value (Value'Last)));
+
+   procedure Sweep_Components
+     (Refs       : Reference_Array;
+      Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer)
+   is
+      Total : Long_Long_Integer := 0;
+      Slot  : Slot_Index := Slot_Index'First;
+   begin
+      for Iteration in Bench.Iteration_Count range 1 .. Iterations loop
+         Total := Total
+           + Fold (IRI.Scheme (Refs (Slot)))
+           + Fold (IRI.Authority (Refs (Slot)))
+           + Fold (IRI.Userinfo (Refs (Slot)))
+           + Fold (IRI.Host (Refs (Slot)))
+           + Fold (IRI.Port (Refs (Slot)))
+           + Fold (IRI.Path (Refs (Slot)))
+           + Fold (IRI.Query (Refs (Slot)))
+           + Fold (IRI.Fragment (Refs (Slot)));
+         Slot :=
+           (if Slot = Slot_Index'Last then Slot_Index'First else Slot + 1);
+      end loop;
+      Bench.Clobber_Memory;
+      Value := Total;
+   end Sweep_Components;
+
+   procedure Resolve_Corpus
+     (Base       : IRI.Reference;
+      Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer)
+   is
+      Total : Long_Long_Integer := 0;
+      Slot  : Positive := 1;
+   begin
+      for Iteration in Bench.Iteration_Count range 1 .. Iterations loop
+         declare
+            Span : Item_Span renames Relatives.Spans (Slot);
+            Done : constant IRI.Reference :=
+              IRI.Resolve (Base, Relatives.Text (Span.First .. Span.Last));
+         begin
+            Total := Total + Long_Long_Integer (IRI.Image_Length (Done));
+         end;
+         Slot := (if Slot = Relatives.Count then 1 else Slot + 1);
+      end loop;
+      Bench.Clobber_Memory;
+      Value := Total;
+   end Resolve_Corpus;
+
+   procedure Components_Short_Batch
+     (Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer) is
+   begin
+      Sweep_Components (Short_Refs, Iterations, Value);
+   end Components_Short_Batch;
+
+   procedure Components_Long_Batch
+     (Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer) is
+   begin
+      Sweep_Components (Long_Refs, Iterations, Value);
+   end Components_Long_Batch;
+
+   procedure Components_Huge_Batch
+     (Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer) is
+   begin
+      Sweep_Components (Huge_Refs, Iterations, Value);
+   end Components_Huge_Batch;
+
+   procedure Resolve_Short_Batch
+     (Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer) is
+   begin
+      Resolve_Corpus (Short_Base, Iterations, Value);
+   end Resolve_Short_Batch;
+
+   procedure Resolve_Long_Batch
+     (Iterations : Bench.Iteration_Count;
+      Value      : out Long_Long_Integer) is
+   begin
+      Resolve_Corpus (Long_Base, Iterations, Value);
+   end Resolve_Long_Batch;
+
+   --  The validation pair. Resolve ends by parsing its assembled result into a
+   --  second Reference; a String-returning Resolve would validate the same
+   --  bytes with Diagnose instead. Both subprograms exist in this process, so
+   --  this one is a genuine paired comparison rather than a baseline join, and
+   --  its answer does not depend on which build of the library is linked.
+   Validation_Sink : Long_Long_Integer := 0;
+
+   procedure Parse_Assembled (Iterations : Bench.Iteration_Count) is
+      Total : Long_Long_Integer := 0;
+      Slot  : Positive := 1;
+   begin
+      for Iteration in Bench.Iteration_Count range 1 .. Iterations loop
+         declare
+            Span   : Item_Span renames Assembled.Spans (Slot);
+            Parsed : constant IRI.Reference :=
+              IRI.Parse
+                (Assembled.Text (Span.First .. Span.Last), IRI.URI_Syntax);
+         begin
+            Total := Total + Long_Long_Integer (IRI.Image_Length (Parsed));
+         end;
+         Slot := (if Slot = Assembled.Count then 1 else Slot + 1);
+      end loop;
+      Validation_Sink := Validation_Sink + Total;
+      Bench.Clobber_Memory;
+   end Parse_Assembled;
+
+   procedure Diagnose_Assembled (Iterations : Bench.Iteration_Count) is
+      use type IRI.Error_Kind;
+      Total : Long_Long_Integer := 0;
+      Slot  : Positive := 1;
+   begin
+      for Iteration in Bench.Iteration_Count range 1 .. Iterations loop
+         declare
+            Span  : Item_Span renames Assembled.Spans (Slot);
+            Found : constant IRI.Parse_Error :=
+              IRI.Diagnose
+                (Assembled.Text (Span.First .. Span.Last), IRI.URI_Syntax);
+         begin
+            Total := Total
+              + (if Found.Kind = IRI.No_Error
+                 then Long_Long_Integer (Span.Last - Span.First + 1)
+                 else 0);
+         end;
+         Slot := (if Slot = Assembled.Count then 1 else Slot + 1);
+      end loop;
+      Validation_Sink := Validation_Sink + Total;
+      Bench.Clobber_Memory;
+   end Diagnose_Assembled;
+
+   procedure Keep is new Bench.Do_Not_Optimize (Long_Long_Integer);
+
+   procedure Measure_Components_Short is new Bench.Measure_Result_Batched
+     (Element => Long_Long_Integer, Batch => Components_Short_Batch);
+   procedure Measure_Components_Long is new Bench.Measure_Result_Batched
+     (Element => Long_Long_Integer, Batch => Components_Long_Batch);
+   procedure Measure_Components_Huge is new Bench.Measure_Result_Batched
+     (Element => Long_Long_Integer, Batch => Components_Huge_Batch);
+   procedure Measure_Resolve_Short is new Bench.Measure_Result_Batched
+     (Element => Long_Long_Integer, Batch => Resolve_Short_Batch);
+   procedure Measure_Resolve_Long is new Bench.Measure_Result_Batched
+     (Element => Long_Long_Integer, Batch => Resolve_Long_Batch);
+   procedure Compare_Validation is new Bench.Compare_Batched
+     (Reference_Batch => Parse_Assembled,
+      Contender_Batch => Diagnose_Assembled);
+
+   ----------------------------------------------------------------------
+   --  Command line
+   ----------------------------------------------------------------------
+
+   type Output_Format is (Console, CSV);
+
+   Format          : Output_Format := Console;
+   Sample_Total    : Bench.Sample_Count := 50;
+   Measure_Seconds : Duration := 1.000;
+   Build_Mode      : Unbounded.Unbounded_String :=
+     Unbounded.To_Unbounded_String ("unstated");
+   Save_Directory    : Unbounded.Unbounded_String;
+   Compare_Directory : Unbounded.Unbounded_String;
+   Metrics_Path      : Unbounded.Unbounded_String;
+   Wait_For_Quiet    : Boolean := False;
+
+   --  Metric rows default to standard error so that a plain run keeps its
+   --  human summary on standard output. --metrics-csv sends them to a file
+   --  instead, which is what a run whose standard error also carries build
+   --  chatter needs.
+   Metrics_File : Ada.Text_IO.File_Type;
+   Metrics_Header_Printed : Boolean := False;
+
+   function Option (Argument, Name : String) return Boolean is
+     (Argument'Length > Name'Length
+      and then Argument (Argument'First .. Argument'First + Name'Length - 1)
+               = Name);
+
+   function Option_Value (Argument, Name : String) return String is
+     (Argument (Argument'First + Name'Length .. Argument'Last));
+
+   procedure Read_Arguments is
+   begin
+      for Index in 1 .. Ada.Command_Line.Argument_Count loop
+         declare
+            Argument : constant String := Ada.Command_Line.Argument (Index);
+         begin
+            if Argument = "--quiescence" then
+               Wait_For_Quiet := True;
+            elsif Argument = "--format=console" then
+               Format := Console;
+            elsif Argument = "--format=csv" then
+               Format := CSV;
+            elsif Option (Argument, "--samples=") then
+               Sample_Total :=
+                 Bench.Sample_Count'Value
+                   (Option_Value (Argument, "--samples="));
+            elsif Option (Argument, "--measurement-time=") then
+               Measure_Seconds :=
+                 Duration'Value
+                   (Option_Value (Argument, "--measurement-time="));
+            elsif Option (Argument, "--build-mode=") then
+               Build_Mode :=
+                 Unbounded.To_Unbounded_String
+                   (Option_Value (Argument, "--build-mode="));
+            elsif Option (Argument, "--metrics-csv=") then
+               Metrics_Path :=
+                 Unbounded.To_Unbounded_String
+                   (Option_Value (Argument, "--metrics-csv="));
+            elsif Option (Argument, "--save-baseline=") then
+               Save_Directory :=
+                 Unbounded.To_Unbounded_String
+                   (Option_Value (Argument, "--save-baseline="));
+            elsif Option (Argument, "--compare-baseline=") then
+               Compare_Directory :=
+                 Unbounded.To_Unbounded_String
+                   (Option_Value (Argument, "--compare-baseline="));
+            else
+               raise Constraint_Error with Usage;
+            end if;
+         end;
+      end loop;
+   end Read_Arguments;
+
+   ----------------------------------------------------------------------
+   --  Reporting
+   ----------------------------------------------------------------------
+
+   --  The build mode belongs in the fingerprint because the release profile
+   --  suppresses runtime checks in flyology_iri.adb, which is most of what
+   --  these workloads execute. The library revision deliberately does not:
+   --  that difference is the one being measured.
+   function Environment return String is
+     (Bench.Metadata.Fingerprint
+        ("build_mode=" & Unbounded.To_String (Build_Mode)));
+
+   function Baseline_Path (Directory, Name : String) return String is
+     (Directory & "/" & Name & ".baseline");
+
+   procedure Report (Name : String; Result : Bench.Measurement) is
+   begin
+      case Format is
+         when Console =>
+            Reporters.Put_Console (Name, Result);
+         when CSV =>
+            Reporters.Put_CSV (Name, Result);
+      end case;
+
+      if Ada.Text_IO.Is_Open (Metrics_File) then
+         if not Metrics_Header_Printed then
+            Reporters.Put_Metrics_CSV_Header (Metrics_File);
+            Metrics_Header_Printed := True;
+         end if;
+         Reporters.Put_Metrics_CSV (Name, Result, Metrics_File);
+      else
+         if not Metrics_Header_Printed then
+            Reporters.Put_Metrics_CSV_Header (Ada.Text_IO.Standard_Error);
+            Metrics_Header_Printed := True;
+         end if;
+         Reporters.Put_Metrics_CSV (Name, Result, Ada.Text_IO.Standard_Error);
+      end if;
+
+      if Save_Directory /= Unbounded.Null_Unbounded_String then
+         declare
+            Directory : constant String :=
+              Unbounded.To_String (Save_Directory);
+         begin
+            Ada.Directories.Create_Path (Directory);
+            Baselines.Save
+              (Path        => Baseline_Path (Directory, Name),
+               Name        => Name,
+               Result      => Result,
+               Fingerprint => Environment);
+         end;
+      end if;
+
+      if Compare_Directory /= Unbounded.Null_Unbounded_String then
+         declare
+            Directory : constant String :=
+              Unbounded.To_String (Compare_Directory);
+            Saved : constant Baselines.Baseline :=
+              Baselines.Load (Baseline_Path (Directory, Name));
+            Change : constant Baselines.Regression :=
+              Baselines.Compare
+                (Saved                       => Saved,
+                 Current                     => Result,
+                 Fingerprint                 => Environment,
+                 Practical_Threshold_Percent => 1.0,
+                 Random_Seed                 => 20_260_817);
+         begin
+            if not Baselines.Compatible (Change) then
+               Ada.Text_IO.Put_Line
+                 ("baseline " & Name
+                  & ": incompatible environment, no verdict"
+                  & " (baseline fingerprint " & Baselines.Fingerprint (Saved)
+                  & ", current " & Environment & ")");
+            else
+               Ada.Text_IO.Put_Line
+                 ("baseline " & Name
+                  & ": time change" & Long_Float'Image
+                      (Baselines.Time_Change_Percent (Change))
+                  & "%, speedup" & Long_Float'Image
+                      (Baselines.Speedup (Change))
+                  & " 95% [" & Long_Float'Image
+                      (Baselines.Speedup_Confidence_Low (Change))
+                  & "," & Long_Float'Image
+                      (Baselines.Speedup_Confidence_High (Change))
+                  & " ], verdict " & Bench.Comparison_Verdict'Image
+                      (Baselines.Verdict (Change)));
+            end if;
+         end;
+      end if;
+   end Report;
+
+   Configuration : Bench.Configuration;
+   Result        : Bench.Measurement;
+   Validation    : Bench.Comparison;
+begin
+   Read_Arguments;
+   if Metrics_Path /= Unbounded.Null_Unbounded_String then
+      Ada.Text_IO.Create
+        (Metrics_File,
+         Ada.Text_IO.Out_File,
+         Unbounded.To_String (Metrics_Path));
+   end if;
+   Build_Inputs;
+
+   --  Linux_Hardware_Metrics would give the low-noise instruction count these
+   --  workloads deserve, but its axes come from perf and report
+   --  Unsupported_Platform on Darwin. Process_Resource_Metrics is the portable
+   --  Darwin/Linux set; the metrics CSV records what each requested axis
+   --  actually collected rather than leaving it assumed.
+   Configuration :=
+     (Bench.Default_Configuration with delta
+        Warmup_Time      => 0.200,
+        Measurement_Time => Measure_Seconds,
+        Samples          => Sample_Total,
+        Random_Seed      => 20_260_817,
+        Metrics          => Bench.Process_Resource_Metrics,
+        CPU_Quiescence   =>
+          (Enabled                     => Wait_For_Quiet,
+           Maximum_Average_CPU_Percent => 25.0,
+           Maximum_Core_CPU_Percent    => 60.0,
+           Stable_Time                 => 1.000,
+           Poll_Interval               => 0.100,
+           Timeout                     => 120.0));
+
+   Ada.Text_IO.Put_Line
+     (Ada.Text_IO.Standard_Error, "# environment=" & Environment);
+
+   if Format = CSV then
+      Reporters.Put_CSV_Header;
+   end if;
+
+   Measure_Components_Short (Configuration, Result);
+   Report ("components_short", Result);
+
+   Measure_Components_Long (Configuration, Result);
+   Report ("components_long", Result);
+
+   Measure_Components_Huge (Configuration, Result);
+   Report ("components_huge", Result);
+
+   Measure_Resolve_Short (Configuration, Result);
+   Report ("resolve_short_base", Result);
+
+   Measure_Resolve_Long (Configuration, Result);
+   Report ("resolve_long_base", Result);
+
+   Compare_Validation (Configuration, Validation);
+   Keep (Validation_Sink);
+   case Format is
+      when Console =>
+         Reporters.Put_Comparison_Console
+           ("validate_by_parse", "validate_by_diagnose", Validation);
+      when CSV =>
+         Reporters.Put_Comparison_CSV_Header;
+         Reporters.Put_Comparison_CSV
+           ("validate_by_parse", "validate_by_diagnose", Validation);
+   end case;
+
+   if Ada.Text_IO.Is_Open (Metrics_File) then
+      Ada.Text_IO.Close (Metrics_File);
+   end if;
+end Flyology_IRI_Resolve_Benchmark;

--- a/flyology_iri/scripts/resolve-benchmark.sh
+++ b/flyology_iri/scripts/resolve-benchmark.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+# Times the component-getter and Resolve paths with flyology_bench. Unlike
+# benchmark.sh this harness carries its own inputs, so it needs neither the
+# Ada URL checkout nor the pinned corpus.
+#
+# The build mode is passed to the binary as well as to the compiler because it
+# is part of the baseline compatibility fingerprint: the release profile
+# suppresses runtime checks in flyology_iri.adb, which is most of what these
+# workloads execute, so a checked baseline must not be compared with a release
+# run. FLYOLOGY_IRI_BUILD_MODE defaults to release here, matching the mode the
+# published medians in BENCHMARKS.md measure.
+
+crate_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+build_mode=${FLYOLOGY_IRI_BUILD_MODE:-release}
+
+cd "$crate_root/benchmarks"
+FLYOLOGY_IRI_BUILD_MODE=$build_mode
+export FLYOLOGY_IRI_BUILD_MODE
+alr build >&2
+
+exec "$crate_root/benchmarks/bin/flyology_iri_resolve_benchmark" \
+  "--build-mode=$build_mode" "$@"

--- a/flyology_iri/src/flyology_iri-web.adb
+++ b/flyology_iri/src/flyology_iri-web.adb
@@ -85,17 +85,35 @@ package body Flyology_IRI.Web is
    end Trim_Bounds;
 
    function Preprocess (Input : String) return String is
-      First  : Natural;
-      Last   : Natural;
-      Result : U.Unbounded_String;
+      First : Natural;
+      Last  : Natural;
    begin
       Trim_Bounds (Input, First, Last);
+      --  Almost no input carries the bytes this removes, and for those the
+      --  trimmed slice already is the answer. Appending the kept bytes one
+      --  at a time allocated an accumulator, and grew it, only to reproduce
+      --  the input verbatim.
       for Index in First .. Last loop
-         if Input (Index) not in ASCII.HT | ASCII.LF | ASCII.CR then
-            U.Append (Result, Input (Index));
+         if Input (Index) in ASCII.HT | ASCII.LF | ASCII.CR then
+            declare
+               Result : U.Unbounded_String;
+            begin
+               for Kept in First .. Last loop
+                  if Input (Kept) not in ASCII.HT | ASCII.LF | ASCII.CR then
+                     U.Append (Result, Input (Kept));
+                  end if;
+               end loop;
+               return U.To_String (Result);
+            end;
          end if;
       end loop;
-      return U.To_String (Result);
+      --  Slid to one, because Input_Offset and the parser below read the
+      --  result at one-based offsets.
+      declare
+         subtype Kept_Bytes is String (1 .. Last - First + 1);
+      begin
+         return Kept_Bytes (Input (First .. Last));
+      end;
    end Preprocess;
 
    --  Map a one-based offset into the preprocessed text back onto the

--- a/flyology_iri/src/flyology_iri.adb
+++ b/flyology_iri/src/flyology_iri.adb
@@ -1065,6 +1065,36 @@ package body Flyology_IRI is
       then Web_Validate (Input, Max_Length)
       else Analyze (Input, Syntax, Max_Length).Error);
 
+   procedure Inspect
+     (Input      : String;
+      Kind       : out Reference_Kind;
+      Error      : out Parse_Error;
+      Syntax     : Syntax_Kind := IRI_Syntax;
+      Max_Length : Positive := Default_Max_Length)
+   is
+      Parsed     : Analysis;
+      Need_Slash : Boolean;
+   begin
+      if Syntax = Web_URL_Syntax then
+         if not Web_Fast_Path (Input, Max_Length, Parsed, Need_Slash, Error)
+         then
+            Error := Web_Validate (Input, Max_Length);
+         end if;
+         --  Analyze rejects a web URL that carries no scheme, so every web
+         --  URL that validates classifies the same way and neither route
+         --  has to report Kind_Value separately.
+         Kind :=
+           (if Error.Kind = No_Error then Absolute_Reference
+            else Empty_Reference);
+         return;
+      end if;
+      Parsed := Analyze (Input, Syntax, Max_Length);
+      Error := Parsed.Error;
+      Kind :=
+        (if Error.Kind = No_Error then Parsed.Kind_Value
+         else Empty_Reference);
+   end Inspect;
+
    function Parse
      (Input      : String;
       Syntax     : Syntax_Kind := IRI_Syntax;

--- a/flyology_iri/src/flyology_iri.adb
+++ b/flyology_iri/src/flyology_iri.adb
@@ -1359,10 +1359,15 @@ package body Flyology_IRI is
       return Unbounded.To_String (Output);
    end Remove_Dot_Segments;
 
-   function Resolve
+   --  RFC 3986 section 5.2 merge and dot-segment removal, stopping short of
+   --  validating what it produced. Both public Resolve forms need the same
+   --  assembled bytes and then validate them differently, so the assembly is
+   --  factored out rather than one form calling the other: composing them
+   --  would make whichever came second validate twice.
+   function Assemble
      (Base       : Reference;
       Relative   : String;
-      Max_Length : Positive := Default_Max_Length) return Reference
+      Max_Length : Positive) return String
    is
       Rel      : constant Reference :=
         Parse (Relative, Base.Syntax_Value, Max_Length);
@@ -1448,8 +1453,44 @@ package body Flyology_IRI is
       if Has_Fragment (Rel) then
          Unbounded.Append (Target, "#" & Fragment (Rel));
       end if;
-      return Parse
-        (Unbounded.To_String (Target), Base.Syntax_Value, Max_Length);
+      return Unbounded.To_String (Target);
+   end Assemble;
+
+   function Resolve
+     (Base       : Reference;
+      Relative   : String;
+      Max_Length : Positive := Default_Max_Length) return Reference
+   is
+     (Parse (Assemble (Base, Relative, Max_Length),
+             Base.Syntax_Value,
+             Max_Length));
+
+   function Resolve
+     (Base       : Reference;
+      Relative   : String;
+      Max_Length : Positive := Default_Max_Length) return String
+   is
+      Result : constant String := Assemble (Base, Relative, Max_Length);
+   begin
+      --  Web mode normalizes, so there the serialization the Reference form
+      --  carries is the one Parse produces, not the assembled bytes. Only URI
+      --  and IRI can take the cheap route, and those are exactly the syntaxes
+      --  where Diagnose and Parse agree: both reduce to Analyze's error, and
+      --  a successful non-web parse stores its input verbatim.
+      if Base.Syntax_Value = Web_URL_Syntax then
+         return Image (Parse (Result, Web_URL_Syntax, Max_Length));
+      end if;
+      declare
+         Error : constant Parse_Error :=
+           Diagnose (Result, Base.Syntax_Value, Max_Length);
+      begin
+         if Error.Kind /= No_Error then
+            raise Malformed_Reference with
+              Error_Kind'Image (Error.Kind) & " at byte"
+              & Natural'Image (Error.Offset);
+         end if;
+      end;
+      return Result;
    end Resolve;
 
    function Web_Validate

--- a/flyology_iri/src/flyology_iri.adb
+++ b/flyology_iri/src/flyology_iri.adb
@@ -1,9 +1,16 @@
 with Ada.Characters.Handling;
+with Ada.Unchecked_Deallocation;
 with Flyology_IRI.Web;
 
 package body Flyology_IRI is
 
    package Unbounded renames Ada.Strings.Unbounded;
+
+   type String_Access is access String;
+
+   --  Colon, the two authority slashes, the query mark and the fragment
+   --  mark, with slack.
+   Separator_Headroom : constant := 16;
 
    type Analysis is record
       Error             : Parse_Error;
@@ -1286,32 +1293,51 @@ package body Flyology_IRI is
         & (if Value.Query_Present then "?" & Query (Value) else "");
    end Target;
 
-   procedure Remove_Last_Segment (Output : in out Unbounded.Unbounded_String) is
-      Text : constant String := Unbounded.To_String (Output);
-      Slash : Natural := 0;
-   begin
-      for Index in reverse Text'Range loop
-         if Text (Index) = '/' then
-            Slash := Index;
-            exit;
-         end if;
-      end loop;
-      if Slash = 0 then
-         Unbounded.Set_Unbounded_String (Output, "");
-      else
-         Unbounded.Set_Unbounded_String (Output, Text (Text'First .. Slash - 1));
-      end if;
-   end Remove_Last_Segment;
+   --  RFC 3986 section 5.2 merge and dot-segment removal, stopping short of
+   --  validating what it produced. Both public Resolve forms need the same
+   --  assembled bytes and then validate them differently, so the assembly is
+   --  factored out rather than one form calling the other: composing them
+   --  would make whichever came second validate twice.
+   --
+   --  The assembly writes into a plain String rather than growing an
+   --  Unbounded_String. That is worth more than the returned copy it also
+   --  avoids: the Unbounded shape reallocated on nearly every append, and
+   --  its segment removal did a whole To_String and Set_Unbounded_String for
+   --  each "/../" it collapsed.
 
-   function Remove_Dot_Segments (Input : String) return String is
-      --  The loop below indexes from one, so Input has to be renormalized.
-      --  A constrained subtype does that at the cost of one copy; the
-      --  Unbounded round-trip it replaces did the same renormalization
-      --  through the heap.
+   --  Append Input's dot-segment reduction to Output. Segment removal may
+   --  only take back bytes this call wrote, so it stops at Floor.
+   procedure Append_Dot_Segments
+     (Input    : String;
+      Output   : in out String;
+      Last     : in out Natural;
+      Overflow : in out Boolean)
+   is
       Source   : constant String (1 .. Input'Length) := Input;
+      Floor    : constant Natural := Last;
       Position : Natural := 1;
-      Output   : Unbounded.Unbounded_String;
       Next     : Natural;
+
+      procedure Put (Value : String) is
+      begin
+         if Last + Value'Length > Output'Last then
+            Overflow := True;
+         else
+            Output (Last + 1 .. Last + Value'Length) := Value;
+            Last := Last + Value'Length;
+         end if;
+      end Put;
+
+      procedure Drop_Last_Segment is
+      begin
+         for Index in reverse Floor + 1 .. Last loop
+            if Output (Index) = '/' then
+               Last := Index - 1;
+               return;
+            end if;
+         end loop;
+         Last := Floor;
+      end Drop_Last_Segment;
    begin
       while Position <= Source'Length loop
          if Position + 2 <= Source'Length
@@ -1329,18 +1355,18 @@ package body Flyology_IRI is
          elsif Position + 1 = Source'Length
            and then Source (Position .. Position + 1) = "/."
          then
-            Unbounded.Append (Output, '/');
+            Put ("/");
             exit;
          elsif Position + 3 <= Source'Length
            and then Source (Position .. Position + 3) = "/../"
          then
             Position := Position + 3;
-            Remove_Last_Segment (Output);
+            Drop_Last_Segment;
          elsif Position + 2 = Source'Length
            and then Source (Position .. Position + 2) = "/.."
          then
-            Remove_Last_Segment (Output);
-            Unbounded.Append (Output, '/');
+            Drop_Last_Segment;
+            Put ("/");
             exit;
          elsif Source (Position .. Source'Length) in "." | ".." then
             exit;
@@ -1352,108 +1378,182 @@ package body Flyology_IRI is
             while Next <= Source'Length and then Source (Next) /= '/' loop
                Next := Next + 1;
             end loop;
-            Unbounded.Append (Output, Source (Position .. Next - 1));
+            Put (Source (Position .. Next - 1));
             Position := Next;
          end if;
       end loop;
-      return Unbounded.To_String (Output);
-   end Remove_Dot_Segments;
+   end Append_Dot_Segments;
 
-   --  RFC 3986 section 5.2 merge and dot-segment removal, stopping short of
-   --  validating what it produced. Both public Resolve forms need the same
-   --  assembled bytes and then validate them differently, so the assembly is
-   --  factored out rather than one form calling the other: composing them
-   --  would make whichever came second validate twice.
-   function Assemble
-     (Base       : Reference;
-      Relative   : String;
-      Max_Length : Positive) return String
+   --  Rel arrives already parsed because the caller has to size Output from
+   --  its serialized length before this can run.
+   procedure Assemble_Into
+     (Base     : Reference;
+      Rel      : Reference;
+      Output   : out String;
+      Last     : out Natural;
+      Overflow : out Boolean)
    is
-      Rel      : constant Reference :=
-        Parse (Relative, Base.Syntax_Value, Max_Length);
-      --  Every branch below reads the relative path, and the merge path reads
-      --  it three times. One local keeps the getter to a single call.
       Rel_Path : constant String := Path (Rel);
-      Target   : Unbounded.Unbounded_String;
-      Prefix   : Unbounded.Unbounded_String;
-   begin
-      if not Has_Scheme (Base) then
-         raise Malformed_Reference with "base reference is not absolute";
-      end if;
 
-      if Has_Scheme (Rel) then
-         Unbounded.Append (Target, Scheme (Rel) & ":");
-         if Has_Authority (Rel) then
-            Unbounded.Append (Target, "//" & Authority (Rel));
+      procedure Put (Value : String) is
+      begin
+         if Last + Value'Length > Output'Last then
+            Overflow := True;
+         else
+            Output (Last + 1 .. Last + Value'Length) := Value;
+            Last := Last + Value'Length;
          end if;
-         Unbounded.Append (Target, Remove_Dot_Segments (Rel_Path));
+      end Put;
+   begin
+      Last := Output'First - 1;
+      Overflow := False;
+      if Has_Scheme (Rel) then
+         Put (Scheme (Rel));
+         Put (":");
+         if Has_Authority (Rel) then
+            Put ("//");
+            Put (Authority (Rel));
+         end if;
+         Append_Dot_Segments (Rel_Path, Output, Last, Overflow);
          if Has_Query (Rel) then
-            Unbounded.Append (Target, "?" & Query (Rel));
+            Put ("?");
+            Put (Query (Rel));
          end if;
       else
-         Unbounded.Append (Target, Scheme (Base) & ":");
+         Put (Scheme (Base));
+         Put (":");
          if Has_Authority (Rel) then
-            Unbounded.Append (Target, "//" & Authority (Rel));
-            Unbounded.Append (Target, Remove_Dot_Segments (Rel_Path));
+            Put ("//");
+            Put (Authority (Rel));
+            Append_Dot_Segments (Rel_Path, Output, Last, Overflow);
             if Has_Query (Rel) then
-               Unbounded.Append (Target, "?" & Query (Rel));
+               Put ("?");
+               Put (Query (Rel));
             end if;
          else
             declare
-               --  Read once for the empty-path test, the merge test, and the
-               --  merge itself.
                Base_Path : constant String := Path (Base);
             begin
                if Has_Authority (Base) then
-                  Unbounded.Append (Target, "//" & Authority (Base));
+                  Put ("//");
+                  Put (Authority (Base));
                end if;
                if Rel_Path'Length = 0 then
-                  Unbounded.Append (Target, Base_Path);
+                  Put (Base_Path);
                   if Has_Query (Rel) then
-                     Unbounded.Append (Target, "?" & Query (Rel));
+                     Put ("?");
+                     Put (Query (Rel));
                   elsif Has_Query (Base) then
-                     Unbounded.Append (Target, "?" & Query (Base));
+                     Put ("?");
+                     Put (Query (Base));
                   end if;
                else
                   if Rel_Path (Rel_Path'First) = '/' then
-                     Unbounded.Append
-                       (Target, Remove_Dot_Segments (Rel_Path));
+                     Append_Dot_Segments (Rel_Path, Output, Last, Overflow);
                   else
-                     if Has_Authority (Base)
-                       and then Base_Path'Length = 0
-                     then
-                        Unbounded.Append (Prefix, '/');
-                     else
-                        --  RFC 3986 section 5.2.3 merge excludes the
-                        --  characters after the base path's right-most '/'
-                        --  but retains that '/'.  A base path without any
-                        --  '/' merges to the relative path alone, so Prefix
-                        --  stays empty.
-                        for Index in reverse Base_Path'Range loop
-                           if Base_Path (Index) = '/' then
-                              Unbounded.Set_Unbounded_String
-                                (Prefix,
-                                 Base_Path (Base_Path'First .. Index));
-                              exit;
-                           end if;
-                        end loop;
-                     end if;
-                     Unbounded.Append
-                       (Target,
-                        Remove_Dot_Segments
-                          (Unbounded.To_String (Prefix) & Rel_Path));
+                     declare
+                        Prefix_Last : Natural := Base_Path'First - 1;
+                        Root        : constant Boolean :=
+                          Has_Authority (Base) and then Base_Path'Length = 0;
+                     begin
+                        if not Root then
+                           for Index in reverse Base_Path'Range loop
+                              if Base_Path (Index) = '/' then
+                                 Prefix_Last := Index;
+                                 exit;
+                              end if;
+                           end loop;
+                        end if;
+                        declare
+                           Prefix : constant String :=
+                             (if Root then "/"
+                              else Base_Path (Base_Path'First .. Prefix_Last));
+                           Merged : String (1 .. Prefix'Length
+                                                 + Rel_Path'Length);
+                        begin
+                           Merged (1 .. Prefix'Length) := Prefix;
+                           Merged (Prefix'Length + 1 .. Merged'Last) :=
+                             Rel_Path;
+                           Append_Dot_Segments
+                             (Merged, Output, Last, Overflow);
+                        end;
+                     end;
                   end if;
                   if Has_Query (Rel) then
-                     Unbounded.Append (Target, "?" & Query (Rel));
+                     Put ("?");
+                     Put (Query (Rel));
                   end if;
                end if;
             end;
          end if;
       end if;
       if Has_Fragment (Rel) then
-         Unbounded.Append (Target, "#" & Fragment (Rel));
+         Put ("#");
+         Put (Fragment (Rel));
       end if;
-      return Unbounded.To_String (Target);
+   end Assemble_Into;
+
+   --  Merging and dot-segment removal never produce more than the base, the
+   --  relative reference, and the separators between them, so the serialized
+   --  lengths of the two parsed references bound the result. Both are real
+   --  lengths rather than Max_Length, which may be Positive'Last; sizing from
+   --  the inputs instead would understate a web result, because normalization
+   --  can expand a relative past the bytes it was written with.
+   Stack_Assembly_Limit : constant := 64 * 1_024;
+
+   function Assemble
+     (Base       : Reference;
+      Relative   : String;
+      Max_Length : Positive) return String
+   is
+      procedure Free is new Ada.Unchecked_Deallocation (String, String_Access);
+
+      Rel    : constant Reference :=
+        Parse (Relative, Base.Syntax_Value, Max_Length);
+      Needed : constant Positive :=
+        Image_Length (Base) + Image_Length (Rel) + Separator_Headroom;
+   begin
+      --  Checked before either buffer is taken, so the large path has no
+      --  route out that would leak it.
+      if not Has_Scheme (Base) then
+         raise Malformed_Reference with "base reference is not absolute";
+      end if;
+
+      if Needed <= Stack_Assembly_Limit then
+         declare
+            Buffer   : String (1 .. Needed);
+            Last     : Natural;
+            Overflow : Boolean;
+         begin
+            Assemble_Into (Base, Rel, Buffer, Last, Overflow);
+            if Overflow then
+               raise Program_Error with "resolved reference outgrew its bound";
+            end if;
+            return Buffer (1 .. Last);
+         end;
+      end if;
+
+      --  A caller that raised Max_Length far above the default can push the
+      --  bound past what belongs on the stack. One exact allocation still
+      --  beats the reallocation per append this replaced, and it keeps a
+      --  single copy of the merge.
+      declare
+         Buffer   : String_Access := new String (1 .. Needed);
+         Last     : Natural;
+         Overflow : Boolean;
+      begin
+         Assemble_Into (Base, Rel, Buffer.all, Last, Overflow);
+         if Overflow then
+            Free (Buffer);
+            raise Program_Error with "resolved reference outgrew its bound";
+         end if;
+         declare
+            Result : constant String := Buffer (1 .. Last);
+         begin
+            Free (Buffer);
+            return Result;
+         end;
+      end;
    end Assemble;
 
    function Resolve

--- a/flyology_iri/src/flyology_iri.adb
+++ b/flyology_iri/src/flyology_iri.adb
@@ -7,10 +7,17 @@ package body Flyology_IRI is
    package Unbounded renames Ada.Strings.Unbounded;
 
    type String_Access is access String;
+   procedure Free is new Ada.Unchecked_Deallocation (String, String_Access);
 
    --  Colon, the two authority slashes, the query mark and the fragment
    --  mark, with slack.
    Separator_Headroom : constant := 16;
+
+   --  Above this, assembly scratch goes on the heap instead of the
+   --  stack. Max_Length may be Positive'Last, so a reference pair can
+   --  be arbitrarily large and no size-proportional local may sit on
+   --  the primary stack.
+   Stack_Assembly_Limit : constant := 64 * 1_024;
 
    type Analysis is record
       Error             : Parse_Error;
@@ -1313,14 +1320,24 @@ package body Flyology_IRI is
       Last     : in out Natural;
       Overflow : in out Boolean)
    is
-      Source   : constant String (1 .. Input'Length) := Input;
+      --  The loop indexes from one. Renormalizing through a constrained
+      --  local would put a copy the size of the path on the stack, which the
+      --  large-input path in Assemble exists to avoid, so the offset is
+      --  applied per access instead: logical index I is Input (Origin + I).
+      Origin   : constant Integer := Input'First - 1;
+      Length   : constant Natural := Input'Length;
       Floor    : constant Natural := Last;
       Position : Natural := 1;
       Next     : Natural;
 
+      --  Phrased as a subtraction rather than Last + Value'Length > Output'Last
+      --  so that the comparison cannot wrap. Release builds compile this body
+      --  with -gnatp, so a wrapped guard would admit an unchecked slice
+      --  assignment; Last never exceeds Output'Last, so the difference is
+      --  always a valid Natural.
       procedure Put (Value : String) is
       begin
-         if Last + Value'Length > Output'Last then
+         if Value'Length > Output'Last - Last then
             Overflow := True;
          else
             Output (Last + 1 .. Last + Value'Length) := Value;
@@ -1339,46 +1356,46 @@ package body Flyology_IRI is
          Last := Floor;
       end Drop_Last_Segment;
    begin
-      while Position <= Source'Length loop
-         if Position + 2 <= Source'Length
-           and then Source (Position .. Position + 2) = "../"
+      while Position <= Length loop
+         if Position + 2 <= Length
+           and then Input (Origin + Position .. Origin + Position + 2) = "../"
          then
             Position := Position + 3;
-         elsif Position + 1 <= Source'Length
-           and then Source (Position .. Position + 1) = "./"
+         elsif Position + 1 <= Length
+           and then Input (Origin + Position .. Origin + Position + 1) = "./"
          then
             Position := Position + 2;
-         elsif Position + 2 <= Source'Length
-           and then Source (Position .. Position + 2) = "/./"
+         elsif Position + 2 <= Length
+           and then Input (Origin + Position .. Origin + Position + 2) = "/./"
          then
             Position := Position + 2;
-         elsif Position + 1 = Source'Length
-           and then Source (Position .. Position + 1) = "/."
+         elsif Position + 1 = Length
+           and then Input (Origin + Position .. Origin + Position + 1) = "/."
          then
             Put ("/");
             exit;
-         elsif Position + 3 <= Source'Length
-           and then Source (Position .. Position + 3) = "/../"
+         elsif Position + 3 <= Length
+           and then Input (Origin + Position .. Origin + Position + 3) = "/../"
          then
             Position := Position + 3;
             Drop_Last_Segment;
-         elsif Position + 2 = Source'Length
-           and then Source (Position .. Position + 2) = "/.."
+         elsif Position + 2 = Length
+           and then Input (Origin + Position .. Origin + Position + 2) = "/.."
          then
             Drop_Last_Segment;
             Put ("/");
             exit;
-         elsif Source (Position .. Source'Length) in "." | ".." then
+         elsif Input (Origin + Position .. Origin + Length) in "." | ".." then
             exit;
          else
             Next := Position;
-            if Source (Position) = '/' then
+            if Input (Origin + Position) = '/' then
                Next := Position + 1;
             end if;
-            while Next <= Source'Length and then Source (Next) /= '/' loop
+            while Next <= Length and then Input (Origin + Next) /= '/' loop
                Next := Next + 1;
             end loop;
-            Put (Source (Position .. Next - 1));
+            Put (Input (Origin + Position .. Origin + Next - 1));
             Position := Next;
          end if;
       end loop;
@@ -1395,9 +1412,14 @@ package body Flyology_IRI is
    is
       Rel_Path : constant String := Path (Rel);
 
+      --  Phrased as a subtraction rather than Last + Value'Length > Output'Last
+      --  so that the comparison cannot wrap. Release builds compile this body
+      --  with -gnatp, so a wrapped guard would admit an unchecked slice
+      --  assignment; Last never exceeds Output'Last, so the difference is
+      --  always a valid Natural.
       procedure Put (Value : String) is
       begin
-         if Last + Value'Length > Output'Last then
+         if Value'Length > Output'Last - Last then
             Overflow := True;
          else
             Output (Last + 1 .. Last + Value'Length) := Value;
@@ -1465,17 +1487,60 @@ package body Flyology_IRI is
                            end loop;
                         end if;
                         declare
-                           Prefix : constant String :=
-                             (if Root then "/"
-                              else Base_Path (Base_Path'First .. Prefix_Last));
-                           Merged : String (1 .. Prefix'Length
-                                                 + Rel_Path'Length);
+                           --  Named by bounds into Base_Path rather than
+                           --  copied out of it: a constrained local here
+                           --  would be a second primary-stack object the
+                           --  size of the base path.
+                           Prefix_Length : constant Natural :=
+                             (if Root then 1
+                              else Prefix_Last - Base_Path'First + 1);
+                           Span : constant Natural :=
+                             Prefix_Length + Rel_Path'Length;
+
+                           procedure Fill (Merged : out String) is
+                              From : constant Natural := Merged'First;
+                           begin
+                              if Root then
+                                 Merged (From) := '/';
+                              else
+                                 Merged (From .. From + Prefix_Length - 1) :=
+                                   Base_Path
+                                     (Base_Path'First .. Prefix_Last);
+                              end if;
+                              Merged (From + Prefix_Length .. Merged'Last) :=
+                                Rel_Path;
+                           end Fill;
                         begin
-                           Merged (1 .. Prefix'Length) := Prefix;
-                           Merged (Prefix'Length + 1 .. Merged'Last) :=
-                             Rel_Path;
-                           Append_Dot_Segments
-                             (Merged, Output, Last, Overflow);
+                           --  Section 5.2.4 reduces the merged path as one
+                           --  string: a leading "../" is discarded where an
+                           --  interior "/../" removes a segment, so the two
+                           --  pieces cannot be reduced separately. They are
+                           --  joined first, on the stack while that is small
+                           --  and on the heap when it is not, for the reason
+                           --  Assemble takes the same fork.
+                           if Span <= Stack_Assembly_Limit then
+                              declare
+                                 Merged : String (1 .. Span);
+                              begin
+                                 Fill (Merged);
+                                 Append_Dot_Segments
+                                   (Merged, Output, Last, Overflow);
+                              end;
+                           else
+                              declare
+                                 Merged : String_Access :=
+                                   new String (1 .. Span);
+                              begin
+                                 Fill (Merged.all);
+                                 Append_Dot_Segments
+                                   (Merged.all, Output, Last, Overflow);
+                                 Free (Merged);
+                              exception
+                                 when others =>
+                                    Free (Merged);
+                                    raise;
+                              end;
+                           end if;
                         end;
                      end;
                   end if;
@@ -1493,25 +1558,33 @@ package body Flyology_IRI is
       end if;
    end Assemble_Into;
 
-   --  Merging and dot-segment removal never produce more than the base, the
-   --  relative reference, and the separators between them, so the serialized
-   --  lengths of the two parsed references bound the result. Both are real
-   --  lengths rather than Max_Length, which may be Positive'Last; sizing from
-   --  the inputs instead would understate a web result, because normalization
-   --  can expand a relative past the bytes it was written with.
-   Stack_Assembly_Limit : constant := 64 * 1_024;
-
+   --  Merging and dot-segment removal never produce more than the base,
+   --  the relative reference, and the separators between them, so the
+   --  serialized lengths of the two parsed references bound the result.
+   --  Both are real lengths rather than Max_Length, which may be
+   --  Positive'Last; sizing from the input bytes instead would
+   --  understate a web result, because normalization can expand a
+   --  relative past what it was written with.
    function Assemble
      (Base       : Reference;
       Relative   : String;
       Max_Length : Positive) return String
    is
-      procedure Free is new Ada.Unchecked_Deallocation (String, String_Access);
-
       Rel    : constant Reference :=
         Parse (Relative, Base.Syntax_Value, Max_Length);
+      --  Widened because both operands are Natural and release builds
+      --  suppress the overflow check in this body. The bound is also kept
+      --  clear of Natural'Last by more than the largest lookahead any loop
+      --  below applies to an index, so no later Position + n can wrap either.
+      Bound  : constant Long_Long_Integer :=
+        Long_Long_Integer (Image_Length (Base))
+        + Long_Long_Integer (Image_Length (Rel))
+        + Separator_Headroom;
       Needed : constant Positive :=
-        Image_Length (Base) + Image_Length (Rel) + Separator_Headroom;
+        (if Bound <= Long_Long_Integer (Natural'Last) - Separator_Headroom
+         then Positive (Bound)
+         else raise Malformed_Reference
+                with "resolved reference exceeds the representable bound");
    begin
       --  Checked before either buffer is taken, so the large path has no
       --  route out that would leak it.
@@ -1544,15 +1617,19 @@ package body Flyology_IRI is
       begin
          Assemble_Into (Base, Rel, Buffer.all, Last, Overflow);
          if Overflow then
-            Free (Buffer);
             raise Program_Error with "resolved reference outgrew its bound";
          end if;
-         declare
-            Result : constant String := Buffer (1 .. Last);
-         begin
+         --  An extended return builds the result where the caller wants it,
+         --  so the bytes are not staged through a local of the same size on
+         --  the way out.
+         return Result : String (1 .. Last) do
+            Result := Buffer (1 .. Last);
             Free (Buffer);
-            return Result;
-         end;
+         end return;
+      exception
+         when others =>
+            Free (Buffer);
+            raise;
       end;
    end Assemble;
 

--- a/flyology_iri/src/flyology_iri.adb
+++ b/flyology_iri/src/flyology_iri.adb
@@ -1162,13 +1162,29 @@ package body Flyology_IRI is
       Error := (Kind => No_Error, Offset => 0);
    end Try_Parse;
 
+   --  Every public component getter reaches the stored serialization through
+   --  here, so copying the whole reference to return one span made each of
+   --  them cost the length of the reference rather than the length of the
+   --  component. Unbounded.Slice copies only the requested range. The zero
+   --  guard has to stay ahead of it because an absent component has First = 0
+   --  and Unbounded.Slice takes a Positive Low.
+   --
+   --  The old shape cost more than the extra bytes suggest: the release
+   --  objects show To_String called unconditionally and ahead of the zero
+   --  test, so an absent component also paid a whole-reference copy, and a
+   --  present one paid two allocations and two copies rather than one.
+   --
+   --  The result's bounds are unchanged: GNAT's Unbounded.Slice returns the
+   --  underlying Low .. High range, which is what the discarded whole-text
+   --  copy was sliced by. The language does not pin those bounds the way it
+   --  pins To_String's lower bound of one, so every consumer in this crate
+   --  reads the result through 'First, 'Last, or 'Range instead.
    function Slice (Value : Reference; Part : Span) return String is
-      Text : constant String := Unbounded.To_String (Value.Text);
    begin
       if Part.First = 0 or else Part.First > Part.Last then
          return "";
       end if;
-      return Text (Part.First .. Part.Last);
+      return Unbounded.Slice (Value.Text, Part.First, Part.Last);
    end Slice;
 
    function Is_Valid (Value : Reference) return Boolean is
@@ -1288,8 +1304,11 @@ package body Flyology_IRI is
    end Remove_Last_Segment;
 
    function Remove_Dot_Segments (Input : String) return String is
-      Source   : constant String :=
-        Unbounded.To_String (Unbounded.To_Unbounded_String (Input));
+      --  The loop below indexes from one, so Input has to be renormalized.
+      --  A constrained subtype does that at the cost of one copy; the
+      --  Unbounded round-trip it replaces did the same renormalization
+      --  through the heap.
+      Source   : constant String (1 .. Input'Length) := Input;
       Position : Natural := 1;
       Output   : Unbounded.Unbounded_String;
       Next     : Natural;
@@ -1345,10 +1364,13 @@ package body Flyology_IRI is
       Relative   : String;
       Max_Length : Positive := Default_Max_Length) return Reference
    is
-      Rel    : constant Reference :=
+      Rel      : constant Reference :=
         Parse (Relative, Base.Syntax_Value, Max_Length);
-      Target : Unbounded.Unbounded_String;
-      Prefix : Unbounded.Unbounded_String;
+      --  Every branch below reads the relative path, and the merge path reads
+      --  it three times. One local keeps the getter to a single call.
+      Rel_Path : constant String := Path (Rel);
+      Target   : Unbounded.Unbounded_String;
+      Prefix   : Unbounded.Unbounded_String;
    begin
       if not Has_Scheme (Base) then
          raise Malformed_Reference with "base reference is not absolute";
@@ -1359,7 +1381,7 @@ package body Flyology_IRI is
          if Has_Authority (Rel) then
             Unbounded.Append (Target, "//" & Authority (Rel));
          end if;
-         Unbounded.Append (Target, Remove_Dot_Segments (Path (Rel)));
+         Unbounded.Append (Target, Remove_Dot_Segments (Rel_Path));
          if Has_Query (Rel) then
             Unbounded.Append (Target, "?" & Query (Rel));
          end if;
@@ -1367,36 +1389,41 @@ package body Flyology_IRI is
          Unbounded.Append (Target, Scheme (Base) & ":");
          if Has_Authority (Rel) then
             Unbounded.Append (Target, "//" & Authority (Rel));
-            Unbounded.Append (Target, Remove_Dot_Segments (Path (Rel)));
+            Unbounded.Append (Target, Remove_Dot_Segments (Rel_Path));
             if Has_Query (Rel) then
                Unbounded.Append (Target, "?" & Query (Rel));
             end if;
          else
-            if Has_Authority (Base) then
-               Unbounded.Append (Target, "//" & Authority (Base));
-            end if;
-            if Path (Rel)'Length = 0 then
-               Unbounded.Append (Target, Path (Base));
-               if Has_Query (Rel) then
-                  Unbounded.Append (Target, "?" & Query (Rel));
-               elsif Has_Query (Base) then
-                  Unbounded.Append (Target, "?" & Query (Base));
+            declare
+               --  Read once for the empty-path test, the merge test, and the
+               --  merge itself.
+               Base_Path : constant String := Path (Base);
+            begin
+               if Has_Authority (Base) then
+                  Unbounded.Append (Target, "//" & Authority (Base));
                end if;
-            else
-               if Path (Rel) (Path (Rel)'First) = '/' then
-                  Unbounded.Append
-                    (Target, Remove_Dot_Segments (Path (Rel)));
+               if Rel_Path'Length = 0 then
+                  Unbounded.Append (Target, Base_Path);
+                  if Has_Query (Rel) then
+                     Unbounded.Append (Target, "?" & Query (Rel));
+                  elsif Has_Query (Base) then
+                     Unbounded.Append (Target, "?" & Query (Base));
+                  end if;
                else
-                  if Has_Authority (Base) and then Path (Base)'Length = 0 then
-                     Unbounded.Append (Prefix, '/');
+                  if Rel_Path (Rel_Path'First) = '/' then
+                     Unbounded.Append
+                       (Target, Remove_Dot_Segments (Rel_Path));
                   else
-                     --  RFC 3986 section 5.2.3 merge excludes the characters
-                     --  after the base path's right-most '/' but retains
-                     --  that '/'.  A base path without any '/' merges to the
-                     --  relative path alone, so Prefix stays empty.
-                     declare
-                        Base_Path : constant String := Path (Base);
-                     begin
+                     if Has_Authority (Base)
+                       and then Base_Path'Length = 0
+                     then
+                        Unbounded.Append (Prefix, '/');
+                     else
+                        --  RFC 3986 section 5.2.3 merge excludes the
+                        --  characters after the base path's right-most '/'
+                        --  but retains that '/'.  A base path without any
+                        --  '/' merges to the relative path alone, so Prefix
+                        --  stays empty.
                         for Index in reverse Base_Path'Range loop
                            if Base_Path (Index) = '/' then
                               Unbounded.Set_Unbounded_String
@@ -1405,17 +1432,17 @@ package body Flyology_IRI is
                               exit;
                            end if;
                         end loop;
-                     end;
+                     end if;
+                     Unbounded.Append
+                       (Target,
+                        Remove_Dot_Segments
+                          (Unbounded.To_String (Prefix) & Rel_Path));
                   end if;
-                  Unbounded.Append
-                    (Target,
-                     Remove_Dot_Segments
-                       (Unbounded.To_String (Prefix) & Path (Rel)));
+                  if Has_Query (Rel) then
+                     Unbounded.Append (Target, "?" & Query (Rel));
+                  end if;
                end if;
-               if Has_Query (Rel) then
-                  Unbounded.Append (Target, "?" & Query (Rel));
-               end if;
-            end if;
+            end;
          end if;
       end if;
       if Has_Fragment (Rel) then

--- a/flyology_iri/src/flyology_iri.ads
+++ b/flyology_iri/src/flyology_iri.ads
@@ -155,6 +155,14 @@ package Flyology_IRI is
    --  A web URL result is still parsed, because web mode normalizes and the
    --  normalized serialization is the result. The value equals Image of the
    --  Reference this returns for the same arguments.
+   --
+   --  This overloads the Reference-returning Resolve on result type alone.
+   --  Most calls select between them from context, but one whose context
+   --  supplies no type does not: comparing two calls with `=`, or taking an
+   --  attribute of a call, is ambiguous and was legal when only the Reference
+   --  form existed. A qualified expression settles it in place, as in
+   --  String'(Resolve (Base, Relative)) = String'(Resolve (Base, Other)), and
+   --  naming the result in a constant always works.
    --  @param Base Absolute base reference
    --  @param Relative Reference to resolve
    --  @param Max_Length Maximum accepted input and serialized byte length

--- a/flyology_iri/src/flyology_iri.ads
+++ b/flyology_iri/src/flyology_iri.ads
@@ -87,6 +87,25 @@ package Flyology_IRI is
       Syntax     : Syntax_Kind := IRI_Syntax;
       Max_Length : Positive := Default_Max_Length) return Parse_Error;
 
+   --  Validate and report the structural classification without building a
+   --  Reference. URI and IRI inputs and the common absolute HTTP(S) fast path
+   --  do not allocate, so a caller that only has to admit or reject a
+   --  reference -- an RDF crate deciding whether bytes are an absolute IRI,
+   --  say -- pays no serialization copy. Try_Parse answers the same question
+   --  but must first store the serialization it is about to be asked for.
+   --  @param Input URI, IRI, or URL bytes
+   --  @param Kind Structural classification, meaningful only when Error
+   --     reports No_Error
+   --  @param Error No_Error on success, otherwise the first detected failure
+   --  @param Syntax Grammar and policy to apply
+   --  @param Max_Length Maximum accepted input and serialized byte length
+   procedure Inspect
+     (Input      : String;
+      Kind       : out Reference_Kind;
+      Error      : out Parse_Error;
+      Syntax     : Syntax_Kind := IRI_Syntax;
+      Max_Length : Positive := Default_Max_Length);
+
    --  Parse into a compact owned representation. Web URL mode lowercases the
    --  scheme and ASCII host and inserts `/` for an empty HTTP-style path.
    --  @param Input URI, IRI, or URL bytes

--- a/flyology_iri/src/flyology_iri.ads
+++ b/flyology_iri/src/flyology_iri.ads
@@ -148,6 +148,23 @@ package Flyology_IRI is
       Relative   : String;
       Max_Length : Positive := Default_Max_Length) return Reference;
 
+   --  Resolve to a serialization without constructing a Reference for the
+   --  result. This suits a caller that stores resolved references as opaque
+   --  bytes: it needs the result validated but never reads its components.
+   --  URI and IRI results are validated by Diagnose, which builds nothing.
+   --  A web URL result is still parsed, because web mode normalizes and the
+   --  normalized serialization is the result. The value equals Image of the
+   --  Reference this returns for the same arguments.
+   --  @param Base Absolute base reference
+   --  @param Relative Reference to resolve
+   --  @param Max_Length Maximum accepted input and serialized byte length
+   --  @return Resolved absolute reference serialization
+   --  @exception Malformed_Reference Base is not absolute or result is invalid
+   function Resolve
+     (Base       : Reference;
+      Relative   : String;
+      Max_Length : Positive := Default_Max_Length) return String;
+
    --  Report whether the reference came from a successful parse. A default
    --  reference and the value Try_Parse returns on failure are both
    --  invalid, which distinguishes a rejected input from a parsed empty

--- a/flyology_iri/tests/src/flyology_iri_differential.adb
+++ b/flyology_iri/tests/src/flyology_iri_differential.adb
@@ -149,8 +149,9 @@ package body Flyology_IRI_Differential is
    end Report;
 
    --  Contract of flyology_iri.ads: Can_Parse is True exactly when Diagnose
-   --  reports No_Error, Parse raises exactly when it does not, and
-   --  Try_Parse reports the same failure Diagnose does.
+   --  reports No_Error, Parse raises exactly when it does not, Try_Parse
+   --  reports the same failure Diagnose does, and Inspect reports what
+   --  Try_Parse reports without building the reference.
    procedure Check
      (Input : String;
       Syn   : Syntax_Kind;
@@ -162,8 +163,23 @@ package body Flyology_IRI_Differential is
       Value   : Reference;
       Error   : Parse_Error;
       Raised  : Boolean := False;
+      Seen    : Reference_Kind;
+      Seen_Error : Parse_Error;
    begin
       Try_Parse (Input, Value, Error, Syn, Max);
+      Inspect (Input, Seen, Seen_Error, Syn, Max);
+      if Seen_Error /= Error then
+         Report
+           ("inspect/try_parse", Input, Syn, Max,
+            "try_parse=" & Image (Error) & " inspect=" & Image (Seen_Error),
+            Count);
+      end if;
+      if Seen /= Kind (Value) then
+         Report
+           ("inspect_kind/try_parse", Input, Syn, Max,
+            "try_parse=" & Reference_Kind'Image (Kind (Value))
+            & " inspect=" & Reference_Kind'Image (Seen), Count);
+      end if;
       if Allowed /= (Found.Kind = No_Error) then
          Report
            ("can_parse/diagnose", Input, Syn, Max,

--- a/flyology_iri/tests/src/flyology_iri_tests.adb
+++ b/flyology_iri/tests/src/flyology_iri_tests.adb
@@ -299,6 +299,17 @@ procedure Flyology_IRI_Tests is
             & ": " & Ada.Exceptions.Exception_Message (Escaped));
    end Stress;
 
+   --  An absent component has a zero span, which the component getter has to
+   --  answer before it reaches Ada.Strings.Unbounded.Slice: that subprogram
+   --  takes a Positive Low and raises on zero. The guard is invisible in a
+   --  reference that carries every component, so name the absent ones here.
+   procedure Check_Absent (Label : String; Value : String) is
+   begin
+      Assert
+        (Value'Length = 0,
+         Label & " is absent but returned """ & Value & """");
+   end Check_Absent;
+
    URL : constant Reference := Parse
      ("HTTPS://user:pass@Example.COM:8443/a/b?x=1#frag", Web_URL_Syntax);
    IRI : constant Reference := Parse
@@ -321,6 +332,15 @@ begin
    Assert (Has_Fragment (URL) and then Fragment (URL) = "frag", "fragment");
    Assert (Origin (URL) = "https://example.com:8443", "HTTP origin adapter");
    Assert (Target (URL) = "/a/b?x=1", "HTTP target adapter");
+
+   Check_Absent ("userinfo", Userinfo (IPv6));
+   Check_Absent ("query", Query (IPv6));
+   Check_Absent ("fragment", Fragment (IPv6));
+   Check_Absent ("scheme", Scheme (Parse ("../images/logo.svg", URI_Syntax)));
+   Check_Absent ("authority", Authority (Parse ("urn:isbn:0", URI_Syntax)));
+   Check_Absent ("host", Host (Parse ("urn:isbn:0", URI_Syntax)));
+   Check_Absent ("port", Port (Parse ("http://example.com/", URI_Syntax)));
+   Check_Absent ("path", Path (Parse ("http://example.com", URI_Syntax)));
 
    Assert (Image (Parse ("https://example.com", Web_URL_Syntax)) =
      "https://example.com/", "empty web path normalization");

--- a/flyology_iri/tests/src/flyology_iri_tests.adb
+++ b/flyology_iri/tests/src/flyology_iri_tests.adb
@@ -44,10 +44,17 @@ procedure Flyology_IRI_Tests is
    begin
       declare
          Actual : constant Reference := Resolve (Base, Relative);
+         --  The serialization form validates with Diagnose instead of building
+         --  this Reference, so every resolution the suite covers also asserts
+         --  that the two forms cannot drift apart.
+         Text   : constant String := Resolve (Base, Relative);
       begin
          Assert
            (Image (Actual) = Expected,
             "resolve " & Relative & " produced " & Image (Actual));
+         Assert
+           (Text = Expected,
+            "resolve " & Relative & " to String produced " & Text);
       end;
    end Check_Resolution;
 
@@ -105,6 +112,7 @@ procedure Flyology_IRI_Tests is
    begin
       declare
          Actual : constant Reference := Resolve (Base, Relative);
+         Text   : constant String := Resolve (Base, Relative);
       begin
          Assert
            (Image (Actual) = Expected,
@@ -114,6 +122,10 @@ procedure Flyology_IRI_Tests is
            (Host (Actual) = Expected_Host,
             "resolve " & Relative & " against " & Base_Text
             & " produced host " & Host (Actual));
+         Assert
+           (Text = Image (Actual),
+            "resolve " & Relative & " against " & Base_Text
+            & " to String produced " & Text);
       end;
    end Check_Resolution_Base;
 
@@ -584,6 +596,44 @@ begin
    --  A base path with no '/' at all merges to the relative path alone.
    Check_Resolution_Base
      ("mailto:fred@example.com", "joe", "mailto:joe", "");
+
+   --  The serialization-returning Resolve validates URI and IRI results with
+   --  Diagnose rather than by building a second Reference. That shortcut is
+   --  sound only where Diagnose and Parse agree and a parse stores its input
+   --  verbatim, which web mode does not: it normalizes. Resolving with a web
+   --  base is reachable whenever the relative reference is itself an absolute
+   --  URL, so pin that the two forms still agree there.
+   declare
+      Web_Base : constant Reference :=
+        Parse ("https://example.com/a/b", Web_URL_Syntax);
+      Built    : constant Reference := Resolve (Web_Base, "HTTPS://Other.COM");
+      Text     : constant String := Resolve (Web_Base, "HTTPS://Other.COM");
+   begin
+      Assert
+        (Text = Image (Built),
+         "web resolve to String produced " & Text & " against "
+         & Image (Built));
+      Assert
+        (Text = "https://other.com/",
+         "web resolve to String skipped normalization: " & Text);
+   end;
+
+   --  Both forms reject a relative base, and neither returns a result the
+   --  other would have refused.
+   declare
+      Relative_Base : constant Reference := Parse ("/only/a/path", URI_Syntax);
+      Raised        : Boolean := False;
+   begin
+      declare
+         Ignored : constant String := Resolve (Relative_Base, "g");
+      begin
+         Assert (Ignored'Length > Natural'Last, "unreachable");
+      end;
+   exception
+      when Malformed_Reference =>
+         Raised := True;
+         Assert (Raised, "relative base rejected by the String form");
+   end;
 
    --  Web URL mode used to reach the grammar through an analyzer of its
    --  own, which skipped WHATWG preprocessing and never ran the host


### PR DESCRIPTION
**Rebased onto #12.** The head branch now sits on `iri-component-slice`, so the
real content of this PR is its top two commits — `796b24f` and `4a88f2d`.

> **Base branch:** GitHub will not let the base be retargeted while the PR is part
> of a stack (`Cannot change the base branch because the pull request is part of a
> stack`), and no stack mutation is exposed in the API. Either retarget stack #15 to
> `iri-component-slice` in the UI, or just merge #12 first — the moment it lands,
> this PR collapses to its own two commits on its own.

## What survived the rebase, and what did not

#12 turned out to reach much of the same ground independently, and to go further
where the two overlapped. Four of the original seven commits were dropped:

| original | fate |
|---|---|
| `Slice` reads the span | **dropped** — #12's `3c3069e` is the byte-identical fix |
| dot-segment rebasing | **dropped** — #12 deletes `Remove_Dot_Segments` outright |
| in-place segment truncation | **dropped** — #12's `Drop_Last_Segment` retires the same quadratic |
| base-path merge cut point | **dropped** — #12 uses a `Prefix_Last` index the same way |
| analyze the relative in place | **dropped, see below** |
| `Inspect` | kept |
| `Preprocess` early-out | kept |

#12's `Resolve` is measurably better than what the dropped commits achieved — 2
allocations and 285 ns against their 3 and 455 — so this is the right base to build
on rather than something to merge around.

**On the dropped `Resolve` commit:** #12 replaced the body wholesale with a call to
`Assemble`, so there is no text to merge — the idea would have to be rebuilt inside
`Assemble`. It also runs into a real obstacle there: `Assemble` sizes its buffer from
`Image_Length (Rel)`, which needs a parsed `Rel`. `Analyze` gives spans but no
serialized length, and `Relative'Length` is a safe bound only for URI and IRI, since
web normalization can grow a serialization threefold through percent-encoding. That
wants a web-aware bound and a fresh design, not a conflict resolution, so it is left
out.

## What this PR does

**`796b24f` — `Inspect`.** `Can_Parse` and `Diagnose` report whether input parses but
not how it classifies, so a caller admitting only absolute references has to call
`Try_Parse` and throw the `Reference` away. `Inspect` reports the kind with the
parse error and builds nothing.

| admitting an absolute IRI | allocs | bytes | ns |
|---|---|---|---|
| via `Try_Parse` | 1 | 80 | 145 |
| via `Inspect` | **0** | **0** | **103** (−29%) |

**`4a88f2d` — `Preprocess` early-out.** It stripped tab/newline/carriage-return by
appending survivors to an `Unbounded_String` one byte at a time. Almost no URL holds
any of them, so the common case allocated an accumulator, grew it, and returned a
verbatim copy of its input. Now it scans first and builds only when a byte must go.

| | allocs | bytes | ns |
|---|---|---|---|
| `parse_web_slow` | 25 → **23** (−8%) | 1008 → **912** (−10%) | 2072 → **1964** (−5%) |
| `parse_web_idna` | 16 → **14** (−13%) | 752 → **656** (−13%) | 1661 → **1547** (−7%) |

Everything else is unchanged, allocation counts included: `can_parse_iri`,
`parse_iri`, `getters`, `resolve`, `resolve_deep`, `parse_web_fast`.

## Measurement

`FLYOLOGY_IRI_BUILD_MODE=release`, baseline `17f48b4` (#12 tip). The host carries
unrelated build load (load average ~17), so revisions were built into separate
worktrees and **run alternately, eight rounds each, minimum taken** — otherwise the
comparison measures machine state rather than code. Allocation counts and byte
totals come from a `malloc` shim and are exact regardless.

## Verification

- **WPT URL conformance 919/919, mismatches=0.**
- `flyology_iri/scripts/test.sh` passes, including the RFC 3986 §5.4 vectors.
- The differential harness holds `Inspect` to `Try_Parse` on both the reported error
  and the reported kind across the full seeded corpus (10,000 cases × 3 syntaxes × 3
  length bounds). Zero disagreements.
- A 272-case `Resolve` differential (8 bases across all three syntaxes × 34
  references, comparing serialization, kind, host, path, query and fragment) is
  byte-identical between `main`, #12 and this branch.
