### PR TITLE
Fill percent-encode and decode results in place

### DIFF
--- a/flyology_iri/src/flyology_iri-web.adb
+++ b/flyology_iri/src/flyology_iri-web.adb
@@ -175,66 +175,91 @@ package body Flyology_IRI.Web is
       end case;
    end Must_Encode;
 
+   --  Counted first, then written straight into the returned object. The
+   --  count is exact, so the result is the only storage this needs: the
+   --  accumulator it replaces took a heap block, grew it a byte at a time,
+   --  and was then copied out whole.
    function Encode (Input : String; Set : Encode_Set) return String is
-      Result : U.Unbounded_String;
-      Code   : Natural;
+      Length : Natural := 0;
    begin
       for C of Input loop
-         if Must_Encode (C, Set) then
-            Code := Character'Pos (C);
-            U.Append (Result, '%');
-            U.Append (Result, Hex_Digit (Code / 16));
-            U.Append (Result, Hex_Digit (Code mod 16));
-         else
-            U.Append (Result, C);
-         end if;
+         Length := Length + (if Must_Encode (C, Set) then 3 else 1);
       end loop;
-      return U.To_String (Result);
+      return Result : String (1 .. Length) do
+         declare
+            Last : Natural := 0;
+            Code : Natural;
+         begin
+            for C of Input loop
+               if Must_Encode (C, Set) then
+                  Code := Character'Pos (C);
+                  Result (Last + 1) := '%';
+                  Result (Last + 2) := Hex_Digit (Code / 16);
+                  Result (Last + 3) := Hex_Digit (Code mod 16);
+                  Last := Last + 3;
+               else
+                  Result (Last + 1) := C;
+                  Last := Last + 1;
+               end if;
+            end loop;
+         end;
+      end return;
    end Encode;
 
    function Encode_Opaque_Path
-     (Input : String; Has_Tail : Boolean) return String
-   is
-      Result        : U.Unbounded_String;
+     (Input : String; Has_Tail : Boolean) return String is
    begin
       if not Has_Tail then
          return Encode (Input, Opaque_Set);
       end if;
+      --  A single trailing space is the one byte the opaque set leaves alone
+      --  that a tail would run into, so it is escaped here instead. Encoding
+      --  the empty slice yields the empty string, which covers an input that
+      --  is nothing but that space.
       if Input'Length > 0 and then Input (Input'Last) = ' ' then
-         if Input'Length > 1 then
-            U.Append
-              (Result, Encode (Input (Input'First .. Input'Last - 1), Opaque_Set));
-         end if;
-         U.Append (Result, "%20");
-      else
-         U.Append
-           (Result, Encode (Input, Opaque_Set));
+         return Encode (Input (Input'First .. Input'Last - 1), Opaque_Set)
+                & "%20";
       end if;
-      return U.To_String (Result);
+      return Encode (Input, Opaque_Set);
    end Encode_Opaque_Path;
 
+   --  An escape is recognised by the same test in both passes, so the
+   --  counted length is the written length.
+   function Is_Escape_At (Input : String; Position : Natural) return Boolean is
+     (Input (Position) = '%'
+      and then Position + 2 <= Input'Last
+      and then Is_Hex (Input (Position + 1))
+      and then Is_Hex (Input (Position + 2)));
+
    function Percent_Decode (Input : String) return String is
-      Result   : U.Unbounded_String;
+      Length   : Natural := 0;
       Position : Natural := Input'First;
    begin
       while Position <= Input'Last loop
-         if Input (Position) = '%'
-           and then Position + 2 <= Input'Last
-           and then Is_Hex (Input (Position + 1))
-           and then Is_Hex (Input (Position + 2))
-         then
-            U.Append
-              (Result,
-               Character'Val
-                 (Hex_Value (Input (Position + 1)) * 16
-                  + Hex_Value (Input (Position + 2))));
-            Position := Position + 3;
-         else
-            U.Append (Result, Input (Position));
-            Position := Position + 1;
-         end if;
+         Length := Length + 1;
+         Position :=
+           Position + (if Is_Escape_At (Input, Position) then 3 else 1);
       end loop;
-      return U.To_String (Result);
+      return Result : String (1 .. Length) do
+         declare
+            Last : Natural := 0;
+         begin
+            Position := Input'First;
+            while Position <= Input'Last loop
+               Last := Last + 1;
+               if Is_Escape_At (Input, Position) then
+                  Result (Last) :=
+                    Character'Val
+                      (Hex_Value (Input (Position + 1)) * 16
+                       + Hex_Value (Input (Position + 2)));
+                  Position := Position + 3;
+               else
+                  Result (Last) := Input (Position);
+                  Position := Position + 1;
+               end if;
+            end loop;
+         end;
+      end return;
    end Percent_Decode;
 
    function Number_Image (Value : Long_Long_Integer) return String is


### PR DESCRIPTION
**Stacked on #13**, which is now rebased onto #12 — so the full order is
**#12 → #13 → #14**. This diff is the single commit `e52e521`, one file.

Follow-on to the item #13 left open: `Encode`, `Encode_Opaque_Path` and
`Percent_Decode` in `flyology_iri-web.adb` each accumulated into an
`Unbounded_String` and copied it out with `To_String`, for results whose length is
a pure function of the input. Two call sites encode a single character at a time
inside a loop, so each iteration was paying for a heap block.

## Why not a sized buffer

#13 stopped here because the a-priori bound is 3 bytes per input byte, and with
`Max_Length` at 1 MiB that reserves 3 MiB on the stack in a crate that does not
build with `-fstack-check`.

The way out is that these functions already return an unconstrained `String`, so
the result is *already* materialized at full size on the secondary stack. An
extended return therefore needs no working buffer at all: count the output in a
first pass, then fill the return object directly in a second. Exact size, no
accumulator, no `alloca`, and one fewer full copy than before. The cost is a second
pass over the input.

## Effect

Absolute web URLs that take the WHATWG pipeline rather than the fast path,
measured against #13's tip:

| | allocs | bytes | ns |
|---|---|---|---|
| `parse_web_slow` | 23 → **17** (−26%) | 912 → **720** (−21%) | 1964 → **1670** (−15%) |
| `parse_web_idna` | 14 → **12** (−14%) | 656 → **592** (−10%) | 1547 → **1449** (−6%) |

Everything else is flat, none of it changing allocation count: `can_parse_iri`,
`parse_iri`, `getters`, `resolve`, `resolve_deep`, `parse_web_fast`.

### Across the whole stack, #12 tip to here

| | allocs | bytes | ns |
|---|---|---|---|
| `parse_web_slow` | 25 → **17** (−32%) | 1008 → **720** (−29%) | 2072 → **1670** (−19%) |
| `parse_web_idna` | 16 → **12** (−25%) | 752 → **592** (−21%) | 1661 → **1449** (−13%) |
| admit an absolute IRI | 1 → **0** (−100%) | 80 → **0** | 145 → **103** (−29%) |

## The corpus benchmark does not move

Over the pinned 100,025-URL ada-url corpus: `can_parse` 22 → 22 ns minimum
(median 24.0 both), `parse_href` 105 → 103 ns minimum (median 109.0 → 105.5),
acceptance identical at 99999/100025. That corpus is dominated by URLs taking the
allocation-free fast path, which never reach either function. `BENCHMARKS.md` needs
no update.

## Measurement

`FLYOLOGY_IRI_BUILD_MODE=release`. The host carries unrelated build load (load
average ~17), so timings are **interleaved A/B**: revisions built into separate
worktrees and run alternately, eight rounds each, minimum taken. Running one
revision to completion and then the other would have compared machine states.
Allocation counts and byte totals come from a `malloc` shim and are exact
regardless.

## Verification

- **WPT URL conformance 919/919, mismatches=0** — this is the corpus that exercises
  percent-encoding and decoding hardest.
- `flyology_iri/scripts/test.sh` passes.
- Corpus acceptance and the rejection histogram are identical to base.

## What still allocates on that path, and why I stopped

`Encode` and `Percent_Decode` no longer appear in the allocation profile at all. The
17 that remain attribute to the `URL_Parts` record's own eight `Unbounded_String`
fields — `Parse_Tail` writing path/query/fragment (5), `Parse_Authority` writing
host/port, `Serialize` building the output — plus IDNA's wide-wide accumulators (3).

Retiring those means changing `URL_Parts` to carry spans into the preprocessed text
rather than owned strings. That is a genuine restructuring of the WHATWG parser
rather than a local rewrite, and a bigger call than this PR should make.
