### PR TITLE
Classify without building, and skip no-op preprocessing

### DIFF
--- a/flyology_iri/src/flyology_iri-web.adb
+++ b/flyology_iri/src/flyology_iri-web.adb
@@ -85,17 +85,35 @@ package body Flyology_IRI.Web is
    end Trim_Bounds;
 
    function Preprocess (Input : String) return String is
-      First  : Natural;
-      Last   : Natural;
-      Result : U.Unbounded_String;
+      First : Natural;
+      Last  : Natural;
    begin
       Trim_Bounds (Input, First, Last);
+      --  Almost no input carries the bytes this removes, and for those the
+      --  trimmed slice already is the answer. Appending the kept bytes one
+      --  at a time allocated an accumulator, and grew it, only to reproduce
+      --  the input verbatim.
       for Index in First .. Last loop
-         if Input (Index) not in ASCII.HT | ASCII.LF | ASCII.CR then
-            U.Append (Result, Input (Index));
+         if Input (Index) in ASCII.HT | ASCII.LF | ASCII.CR then
+            declare
+               Result : U.Unbounded_String;
+            begin
+               for Kept in First .. Last loop
+                  if Input (Kept) not in ASCII.HT | ASCII.LF | ASCII.CR then
+                     U.Append (Result, Input (Kept));
+                  end if;
+               end loop;
+               return U.To_String (Result);
+            end;
          end if;
       end loop;
-      return U.To_String (Result);
+      --  Slid to one, because Input_Offset and the parser below read the
+      --  result at one-based offsets.
+      declare
+         subtype Kept_Bytes is String (1 .. Last - First + 1);
+      begin
+         return Kept_Bytes (Input (First .. Last));
+      end;
    end Preprocess;
 
    --  Map a one-based offset into the preprocessed text back onto the

--- a/flyology_iri/src/flyology_iri.adb
+++ b/flyology_iri/src/flyology_iri.adb
@@ -1065,6 +1065,36 @@ package body Flyology_IRI is
       then Web_Validate (Input, Max_Length)
       else Analyze (Input, Syntax, Max_Length).Error);
 
+   procedure Inspect
+     (Input      : String;
+      Kind       : out Reference_Kind;
+      Error      : out Parse_Error;
+      Syntax     : Syntax_Kind := IRI_Syntax;
+      Max_Length : Positive := Default_Max_Length)
+   is
+      Parsed     : Analysis;
+      Need_Slash : Boolean;
+   begin
+      if Syntax = Web_URL_Syntax then
+         if not Web_Fast_Path (Input, Max_Length, Parsed, Need_Slash, Error)
+         then
+            Error := Web_Validate (Input, Max_Length);
+         end if;
+         --  Analyze rejects a web URL that carries no scheme, so every web
+         --  URL that validates classifies the same way and neither route
+         --  has to report Kind_Value separately.
+         Kind :=
+           (if Error.Kind = No_Error then Absolute_Reference
+            else Empty_Reference);
+         return;
+      end if;
+      Parsed := Analyze (Input, Syntax, Max_Length);
+      Error := Parsed.Error;
+      Kind :=
+        (if Error.Kind = No_Error then Parsed.Kind_Value
+         else Empty_Reference);
+   end Inspect;
+
    function Parse
      (Input      : String;
       Syntax     : Syntax_Kind := IRI_Syntax;

--- a/flyology_iri/src/flyology_iri.ads
+++ b/flyology_iri/src/flyology_iri.ads
@@ -87,6 +87,25 @@ package Flyology_IRI is
       Syntax     : Syntax_Kind := IRI_Syntax;
       Max_Length : Positive := Default_Max_Length) return Parse_Error;
 
+   --  Validate and report the structural classification without building a
+   --  Reference. URI and IRI inputs and the common absolute HTTP(S) fast path
+   --  do not allocate, so a caller that only has to admit or reject a
+   --  reference -- an RDF crate deciding whether bytes are an absolute IRI,
+   --  say -- pays no serialization copy. Try_Parse answers the same question
+   --  but must first store the serialization it is about to be asked for.
+   --  @param Input URI, IRI, or URL bytes
+   --  @param Kind Structural classification, meaningful only when Error
+   --     reports No_Error
+   --  @param Error No_Error on success, otherwise the first detected failure
+   --  @param Syntax Grammar and policy to apply
+   --  @param Max_Length Maximum accepted input and serialized byte length
+   procedure Inspect
+     (Input      : String;
+      Kind       : out Reference_Kind;
+      Error      : out Parse_Error;
+      Syntax     : Syntax_Kind := IRI_Syntax;
+      Max_Length : Positive := Default_Max_Length);
+
    --  Parse into a compact owned representation. Web URL mode lowercases the
    --  scheme and ASCII host and inserts `/` for an empty HTTP-style path.
    --  @param Input URI, IRI, or URL bytes

--- a/flyology_iri/tests/src/flyology_iri_differential.adb
+++ b/flyology_iri/tests/src/flyology_iri_differential.adb
@@ -149,8 +149,9 @@ package body Flyology_IRI_Differential is
    end Report;
 
    --  Contract of flyology_iri.ads: Can_Parse is True exactly when Diagnose
-   --  reports No_Error, Parse raises exactly when it does not, and
-   --  Try_Parse reports the same failure Diagnose does.
+   --  reports No_Error, Parse raises exactly when it does not, Try_Parse
+   --  reports the same failure Diagnose does, and Inspect reports what
+   --  Try_Parse reports without building the reference.
    procedure Check
      (Input : String;
       Syn   : Syntax_Kind;
@@ -162,8 +163,23 @@ package body Flyology_IRI_Differential is
       Value   : Reference;
       Error   : Parse_Error;
       Raised  : Boolean := False;
+      Seen    : Reference_Kind;
+      Seen_Error : Parse_Error;
    begin
       Try_Parse (Input, Value, Error, Syn, Max);
+      Inspect (Input, Seen, Seen_Error, Syn, Max);
+      if Seen_Error /= Error then
+         Report
+           ("inspect/try_parse", Input, Syn, Max,
+            "try_parse=" & Image (Error) & " inspect=" & Image (Seen_Error),
+            Count);
+      end if;
+      if Seen /= Kind (Value) then
+         Report
+           ("inspect_kind/try_parse", Input, Syn, Max,
+            "try_parse=" & Reference_Kind'Image (Kind (Value))
+            & " inspect=" & Reference_Kind'Image (Seen), Count);
+      end if;
       if Allowed /= (Found.Kind = No_Error) then
          Report
            ("can_parse/diagnose", Input, Syn, Max,


### PR DESCRIPTION
Stacked on #12.

Two allocation removals in `flyology_iri`, one per commit, each measured on its
own. Neither changes what the crate accepts, rejects, or serializes.

## `796b24f` — classify a reference without building one

`Can_Parse` and `Diagnose` report whether input parses but not how it classifies,
so a caller that admits only absolute references — an RDF crate deciding whether
bytes are an absolute IRI, say — has to reach for `Try_Parse`. `Try_Parse` builds a
`Reference`, and building one stores a copy of a serialization that is byte for
byte the input the caller already holds. The caller reads `Kind` and drops it.

`Inspect` runs the analysis `Try_Parse` runs and reports the structural kind
alongside the parse error. `Analyze` works on spans over the caller's `String`, so
nothing is stored and nothing is allocated.

| admitting `http://www.w3.org/1999/02/22-rdf-syntax-ns#type` | allocs | bytes | ns |
|---|---|---|---|
| via `Try_Parse` | 1 | 80 | 145 |
| via `Inspect` | **0** | **0** | **103** (−29%) |

## `4a88f2d` — skip preprocessing that removes nothing

`Preprocess` strips tab, newline and carriage return by appending the surviving
bytes to an `Unbounded_String` one at a time. Almost no URL holds any of them, so
the ordinary case took an accumulator, grew it, and returned a verbatim copy of its
own input. It now scans first and builds only once a byte has to be dropped, which
also keeps the controlled accumulator out of the common path entirely.

| | allocs | bytes | ns |
|---|---|---|---|
| `parse_web_slow` | 25 → **23** (−8%) | 1008 → **912** (−10%) | 2072 → **1964** (−5%) |
| `parse_web_idna` | 16 → **14** (−13%) | 752 → **656** (−13%) | 1661 → **1547** (−7%) |

Everything else is unchanged, allocation counts included: `can_parse_iri`,
`parse_iri`, `getters`, `resolve`, `resolve_deep`, `parse_web_fast`.

## Measurement

`FLYOLOGY_IRI_BUILD_MODE=release`. The host carries unrelated build load, so
revisions were built into separate worktrees and **run alternately, eight rounds
each, with the minimum taken** — otherwise the comparison measures machine state
rather than code. Allocation counts and byte totals come from a `malloc` shim and
are exact regardless.

## Verification

- **WPT URL conformance 919/919, mismatches=0.**
- `flyology_iri/scripts/test.sh` passes, including the RFC 3986 §5.4 vectors.
- The differential harness holds `Inspect` to `Try_Parse` on both the reported error
  and the reported kind across the full seeded corpus (10,000 cases × 3 syntaxes × 3
  length bounds). Zero disagreements.
- A 272-case `Resolve` differential — 8 bases across all three syntaxes × 34
  references, comparing serialization, kind, host, path, query and fragment — is
  byte-identical to the base.
