### PR TITLE
Bound network steps so a stalled mirror fails fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,24 @@ concurrency:
   group: flyology-http-ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Every step that reaches the network carries a timeout-minutes bound, so a
+# stalled mirror or registry fails the step instead of hanging it. Without one
+# the step runs until the job timeout -- 150 minutes for the HTTP/2 job -- and
+# the run looks busy the whole time rather than failing and inviting a retry.
+# The apt-get update below stalled three times on 2026-08-19: run 32226557711
+# on main burned the entire 150-minute job budget before the job timeout ended
+# it, and runs 32278682887 and 32294697524 sat there 83 and 64 minutes before
+# someone cancelled them by hand. The same job finishes in 8 to 14 minutes when
+# the mirror answers.
+#
+# The bounds are sized against the slowest healthy observation over the
+# preceding 60 runs, with room to spare, so tripping one means a stall rather
+# than a slow day. Checking out sources and configuring the index take seconds
+# and are given 5 minutes. Installing the HTTP/2 peer takes 11 seconds at the
+# median and 5 minutes at its slowest, so it is given 15. Installing Alire is
+# given 15 for a different reason: every observation of it is a cache hit, and
+# a cold run downloads a whole toolchain, so the observations do not bound it.
+
 jobs:
   test:
     name: HTTP tests (${{ matrix.os }})
@@ -26,8 +44,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Check out sources
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Alire
+        timeout-minutes: 15
         uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
         with:
           version: 2.1.1
@@ -36,6 +56,7 @@ jobs:
             gprbuild=26.0.1
           cache: true
       - name: Configure Flyology index
+        timeout-minutes: 5
         run: |
           alr index --reset-community
           alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
@@ -46,6 +67,7 @@ jobs:
       # medians come from one reviewed revision. It lands under build/, which
       # is ignored, so the checkout leaves no untracked files behind.
       - name: Check out the pinned WPT URL corpus
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ada-url/ada
@@ -66,8 +88,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out sources
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Alire
+        timeout-minutes: 15
         uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
         with:
           version: 2.1.1
@@ -76,6 +100,7 @@ jobs:
             gprbuild=26.0.1
           cache: true
       - name: Configure Flyology index
+        timeout-minutes: 5
         run: |
           alr index --reset-community
           alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
@@ -90,8 +115,10 @@ jobs:
     timeout-minutes: 150
     steps:
       - name: Check out sources
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Alire
+        timeout-minutes: 15
         uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
         with:
           version: 2.1.1
@@ -100,12 +127,31 @@ jobs:
             gprbuild=26.0.1
           cache: true
       - name: Configure Flyology index
+        timeout-minutes: 5
         run: |
           alr index --reset-community
           alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
       - name: Install independent HTTP/2 peer
+        timeout-minutes: 15
         run: |
-          sudo apt-get update
+          # apt-get update is the command that stalls, and it is the one here
+          # that is safe to interrupt and repeat: a killed run leaves partial
+          # package lists behind, which the next run refetches. Bounding each
+          # attempt on its own turns a wedged mirror connection into a retry
+          # against a fresh one, so a single transient failure does not fail
+          # the job, and the step bound above stays a backstop rather than the
+          # mechanism that catches the common case.
+          for attempt in 1 2 3; do
+            if sudo timeout --kill-after=10s 120s apt-get update; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::apt-get update stalled or failed on all 3 attempts"
+              exit 1
+            fi
+            echo "::warning::apt-get update attempt $attempt failed; retrying"
+            sleep $((attempt * 15))
+          done
           sudo apt-get install --yes nghttp2-server
           go version
           node --version
@@ -128,8 +174,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out sources
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Alire
+        timeout-minutes: 15
         uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
         with:
           version: 2.1.1
@@ -138,6 +186,7 @@ jobs:
             gprbuild=26.0.1
           cache: true
       - name: Configure Flyology index
+        timeout-minutes: 5
         run: |
           alr index --reset-community
           alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
@@ -158,8 +207,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out sources
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Alire
+        timeout-minutes: 15
         uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
         with:
           version: 2.1.1
@@ -168,6 +219,7 @@ jobs:
             gprbuild=26.0.1
           cache: true
       - name: Configure Flyology index
+        timeout-minutes: 5
         run: |
           alr index --reset-community
           alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
@@ -215,8 +267,10 @@ jobs:
             lane: native
     steps:
       - name: Check out sources
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Alire
+        timeout-minutes: 15
         uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
         with:
           version: 2.1.1
@@ -225,6 +279,7 @@ jobs:
             gprbuild=26.0.1
           cache: true
       - name: Configure Flyology index
+        timeout-minutes: 5
         run: |
           alr index --reset-community
           alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,17 +14,31 @@ concurrency:
   group: flyology-http-pages
   cancel-in-progress: false
 
+# The bounds here follow the convention ci.yml states: every step that installs
+# or fetches something carries a timeout-minutes bound, so a stalled mirror or
+# registry fails the step rather than hanging it. The whole build job runs in
+# about 90 seconds when the network answers, and the bounds below are sized far
+# above the slowest healthy observation over the preceding 12 runs, so tripping
+# one means a stall rather than a slow day.
+#
+# Both jobs also carry a job-level bound, which neither had before. Without one,
+# a stall in a step that has no bound of its own -- the site build, or the
+# deploy -- runs to the six-hour GitHub default.
+
 jobs:
   build:
     name: Build site and API reference
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check out sources
+        timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: flyology-http
           submodules: true
       - name: Install Alire
+        timeout-minutes: 15
         uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
         with:
           version: 2.1.1
@@ -33,12 +47,14 @@ jobs:
             gprbuild=26.0.1
           cache: true
       - name: Select toolchain
+        timeout-minutes: 10
         run: |
           alr --non-interactive toolchain --select \
             gnat_native=16.1.0 \
             gprbuild=26.0.1
           printf 'ALR=%s\n' "$(command -v alr)" >> "$GITHUB_ENV"
       - name: Configure Flyology index
+        timeout-minutes: 5
         run: |
           alr index --reset-community
           alr index \
@@ -46,13 +62,16 @@ jobs:
             --name=flyology \
             --before=community
       - name: Install GNATdoc
+        timeout-minutes: 10
         run: alr install gnatdoc_bin
       - name: Configure Pages
+        timeout-minutes: 5
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Build site
         run: ./scripts/build-site.sh
         working-directory: flyology-http
       - name: Upload artifact
+        timeout-minutes: 10
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: flyology-http/build/site
@@ -62,6 +81,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 30
     steps:
       - name: Deploy
         id: deployment

--- a/scripts/test-http3-h3spec.sh
+++ b/scripts/test-http3-h3spec.sh
@@ -49,7 +49,13 @@ if [ -z "$h3spec" ]; then
   h3spec="$http_root/build/oracle/h3spec-$version-$asset"
   if [ ! -x "$h3spec" ]; then
     mkdir -p "$http_root/build/oracle"
-    curl -fL \
+    # Bounded the way the workflow bounds its package installs: a stalled
+    # connection becomes a retry and then a failure, instead of hanging the
+    # step until the job timeout. --max-time is counted per attempt once
+    # --retry is in play, and the checksum below is what makes retrying safe,
+    # because a truncated or resumed body never survives it.
+    curl -fL --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 20 --max-time 300 \
       "https://github.com/kazu-yamamoto/h3spec/releases/download/v$version/$asset" \
       -o "$h3spec.download"
     actual=$(shasum -a 256 "$h3spec.download" | awk '{print $1}')


### PR DESCRIPTION
## What changed

- add `timeout-minutes` to every step in `ci.yml` that reaches the network, sized against the slowest healthy observation over the preceding 60 runs
- wrap `apt-get update` in three attempts, each bounded on its own by `timeout`, so a wedged mirror connection becomes a retry rather than a hang
- add job-level timeouts to both `pages.yml` jobs, which had none, plus step bounds on its fetch and install steps
- bound the h3spec download in `scripts/test-http3-h3spec.sh` with `--retry` and a per-attempt `--max-time`

Nothing about what is installed, or how anything is built or tested, changes. On a healthy run every command runs exactly as before; the bounds only decide how a stalled run ends.

## Why

`sudo apt-get update` in the HTTP/2 qualification job had no bound. When the mirror stops answering, apt-get does not fail — it waits, and so does the step. On 2026-08-19 that happened three times:

| run | duration | ended by |
| --- | --- | --- |
| [32226557711](https://github.com/flyology-ada/flyology-http/actions/runs/32226557711) (on `main`) | 150m | the job timeout, unattended |
| [32278682887](https://github.com/flyology-ada/flyology-http/actions/runs/32278682887) | 83m | cancelled by hand |
| [32294697524](https://github.com/flyology-ada/flyology-http/actions/runs/32294697524) attempt 1 | 64m | cancelled by hand |

The same job finishes in 8 to 14 minutes when the mirror answers, and the install itself takes 11 seconds at the median, so each of those runs spent between four and eleven times the job's whole healthy duration waiting on one command. The first is the case that matters most: nobody was watching, and the run burned the entire 150-minute budget before the job timeout ended it. A hung run also reads as a working run — there is no failure to retry, and the concurrency group keeps the branch occupied until someone intervenes.

The step bound alone would convert a stall into a failure but not into a recovery, which is why `apt-get update` also retries. Only the update is retried: it is the command that stalled, and it is the one here that is safe to interrupt and repeat, since a killed run leaves partial package lists that the next run refetches. Retrying `apt-get install` would risk resuming from a half-configured dpkg state to no purpose.

## Sizing

Measured from `started_at`/`completed_at` across the preceding 60 runs, successful samples only:

| step | median | slowest healthy | bound |
| --- | --- | --- | --- |
| Check out sources / WPT corpus | 1–2s | 4s | 5m |
| Configure Flyology index | 2s | 8s | 5m |
| Install Alire | 19s | 38s | 15m |
| Install independent HTTP/2 peer | 11s | 303s | 15m |

Install Alire is given 15 minutes on different grounds from the rest: all 382 observations of it are cache hits, so they bound the cached path and say nothing about a cold toolchain download.

## Validation

The retry loop was exercised by extracting the shipped `run:` body from the YAML and executing it under the runner's exact shell flags (`bash --noprofile --norc -e -o pipefail`) against `apt-get` shims:

- healthy: one attempt, proceeds, exit 0
- fails twice then succeeds: retries, recovers, exit 0
- stalls indefinitely: each attempt killed by `timeout`, exit 1 with `::error::apt-get update stalled or failed on all 3 attempts`

CI run [32304778449](https://github.com/flyology-ada/flyology-http/actions/runs/32304778449) is green on all six jobs. The bounded step took the healthy path with room to spare:

- HTTP/2 peer install: 52s against a 15-minute bound; `apt-get update` ran once, fetched 11.4 MB in 3s, emitted no retry warning
- `apt-get install` fetched 347 kB in 26s at 13.5 kB/s, confirming the install is the variable leg and worth keeping a backstop over
- worst case elsewhere: Install Alire 28s (bound 15m), checkout 3s (5m), index configuration 3s (5m)

Both workflows parse, and `bash -n` accepts the modified script.

## Note for reviewers

The `pages.yml` and `test-http3-h3spec.sh` changes are the same defect class found in two other places rather than the reported incident, and can be dropped without affecting the fix. `pages.yml` is the more valuable of the two: it had no job-level timeout at all, so a stall there ran to the six-hour GitHub default.

Related work is in flight for the same failure mode in `flyology-ada/flyology` and `flyology-ada/gnat-patches`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)