### PR TITLE
Problem: A discarded QUIC Initial ends the HTTP/3 integration exchange

### DIFF
--- a/tests/http3_server_integration.adb
+++ b/tests/http3_server_integration.adb
@@ -181,10 +181,17 @@ begin
                Private_Key => Fixtures.Server_Private_Key,
                Cleartext_Capacity => 4,
                TCP_Capacity => 4,
-               --  Three H3 profiles run per address family. Client shutdown
-               --  does not acknowledge server-side registry release, so keep
-               --  one reclamation slot per family for an overtaking Initial.
-               HTTP_3_Capacity => 8,
+               --  HTTP_3_Capacity is a dual-stack total: Routing.Serve
+               --  gives IPv6 HTTP_3_Capacity / 2 slots and IPv4 the rest.
+               --  Both client profiles below target "localhost", which
+               --  resolves to every loopback family, and the connection race
+               --  completes a full QUIC handshake on each family before it
+               --  discards the losing lane. Each address family therefore
+               --  admits up to five concurrent connections here: two live
+               --  client profiles, two losing race lanes awaiting release,
+               --  and one raw Initial. Size for eight per family so a raw
+               --  Initial is never discarded by a momentarily full registry.
+               HTTP_3_Capacity => 16,
                Timeout => 10.0,
                Handshake_Timeout => 10.0,
                Max_Connection_Age => 20.0,
@@ -222,6 +229,10 @@ begin
          Transport : QUIC.Connection;
          Session : H3.Session;
          Flight : QUIC.Datagram_Batch;
+         --  Last handshake flight handed to the server. Handshake-space loss
+         --  recovery has no probe timeout below this test, so a discarded
+         --  datagram is retransmitted from here.
+         Handshake_Flight : QUIC.Datagram_Batch;
          QUIC_Status : QUIC.Operation_Status;
          H3_Status : H3.Operation_Status;
          Phase : Client_Phase := Initialize_Mixed_Client;
@@ -426,16 +437,30 @@ begin
       Sockets.Connect_Socket (Socket, Raw_Address);
       QUIC.Start_Client (Transport, Flight, QUIC_Status);
       pragma Assert (QUIC_Status = QUIC.Succeeded);
+      Handshake_Flight := Flight;
       QUIC_IO.Send (Socket, Flight, Timeout => 10.0);
 
+      --  A listener whose connection registry is momentarily full discards a
+      --  QUIC Initial without answering it, and no handshake-space probe
+      --  timeout retransmits it. Spend the attempt budget on retransmission
+      --  rather than on one long wait, so a discarded datagram costs a probe
+      --  interval instead of the whole exchange.
       for Attempt in 1 .. 8 loop
          exit when QUIC.Is_Connected (Transport);
          Attempt_Number := Attempt;
-         QUIC_IO.Receive
-           (Socket, Transport, Flight, QUIC_Status, Timeout => 10.0);
-         pragma Assert
-           (QUIC_Status in QUIC.Succeeded | QUIC.Waiting_For_More);
-         QUIC_IO.Send (Socket, Flight, Timeout => 10.0);
+         begin
+            QUIC_IO.Receive
+              (Socket, Transport, Flight, QUIC_Status, Timeout => 2.0);
+            pragma Assert
+              (QUIC_Status in QUIC.Succeeded | QUIC.Waiting_For_More);
+            if Flight.Count > 0 then
+               Handshake_Flight := Flight;
+            end if;
+            QUIC_IO.Send (Socket, Flight, Timeout => 10.0);
+         exception
+            when Flyology.IO.Timeout_Error =>
+               QUIC_IO.Send (Socket, Handshake_Flight, Timeout => 10.0);
+         end;
       end loop;
       Attempt_Number := 0;
       pragma Assert (QUIC.Is_Connected (Transport));
@@ -496,11 +521,21 @@ begin
          Phase := Raw_Response;
          for Attempt in 1 .. 16 loop
             Attempt_Number := Attempt;
-            QUIC_IO.Receive
-              (Socket, Transport, Flight, QUIC_Status, Timeout => 10.0);
-            pragma Assert
-              (QUIC_Status in QUIC.Succeeded | QUIC.Waiting_For_More);
-            QUIC_IO.Send (Socket, Flight, Timeout => 10.0);
+            --  The server drives application-space probe timeouts, so a
+            --  discarded response datagram is retransmitted by the peer.
+            --  Spend the attempt budget waiting for that rather than
+            --  abandoning the exchange on the first quiet interval. Sixteen
+            --  one-second probes stay inside the server's connection age.
+            begin
+               QUIC_IO.Receive
+                 (Socket, Transport, Flight, QUIC_Status, Timeout => 1.0);
+               pragma Assert
+                 (QUIC_Status in QUIC.Succeeded | QUIC.Waiting_For_More);
+               QUIC_IO.Send (Socket, Flight, Timeout => 10.0);
+            exception
+               when Flyology.IO.Timeout_Error =>
+                  null;
+            end;
             loop
                H3.Poll (Session, Transport, Event, H3_Status);
                exit when H3_Status = H3.No_Event;


### PR DESCRIPTION
`tests/http3_server_integration.adb` intermittently failed on `macos-latest` only, always
with the same shape:

```
raised ADA.ASSERTIONS.ASSERTION_ERROR : [::1]:49189 phase=RAW_HANDSHAKE exchange=0 attempt=1: raised FLYOLOGY.IO.TIMEOUT_ERROR : socket operation timed out
```

`attempt=1` is the first receive after the initial flight, so the eight-attempt budget was
never reached.

## Cause

The listener discards the raw client's Initial because its per-address-family connection
registry is momentarily full, and nothing retransmits it.

1. The dual-stack overload of `Routing.Serve` splits `HTTP_3_Capacity` between the
   families (`src/flyology-http-server-routing.adb:2904`), so `HTTP_3_Capacity => 8` gave
   each listener four slots, not eight.
2. Both client profiles here address `https://localhost:…`, and the client races the
   address families, completing a full QUIC handshake on each before discarding the losing
   lane (`Start_Connection`, `src/flyology-http-client-http_3_internals.adb:233`). Every
   client connection therefore occupies a slot on both listeners. Five concurrent
   connections per family are possible: two live profiles, two losing lanes awaiting
   release, and the raw Initial.
3. A full registry returns no slot and the receiver loop falls through
   (`src/flyology-http-server-http_3.adb:1853`); the Initial is discarded unanswered.
4. `Flyology.QUIC.Connections` recovers loss only in the application space
   (`Process_Timeout`, whose `Invalid_Timeout_State` is documented as "Application traffic
   keys are not active"). There is no handshake-space probe timeout, and the test's loop
   let `Timeout_Error` escape, so a single discarded datagram ended the run.

The macOS restriction follows from step 2: `localhost` resolves to both `::1` and
`127.0.0.1` there, while the stock Debian/Ubuntu hosts file maps `::1` to `ip6-localhost`
and `ip6-loopback` rather than `localhost`, so the runner's client never opens an IPv6 lane
and neither listener is pressured.

## Evidence

Registry instrumentation reproduced the CI signature locally under contention, with the
discard immediately preceding the failure and the slots freeing about half a second later:

```
TRACE 127.0.0.1:57198 claim cap= 4 live= 4 slot= 4 peer=127.0.0.1:59859 sent=ITEM_SENT
TRACE 127.0.0.1:57198 LISTENER-FULL cap= 4 live= 4 peer=127.0.0.1:50946
raised ASSERTION_ERROR : 127.0.0.1:57198 phase=RAW_HANDSHAKE exchange=0 attempt=1: TIMEOUT_ERROR
```

Twenty runs at each capacity, under load, before this change:

| `HTTP_3_Capacity` | per family | failures | runs with a discarded Initial |
| --- | --- | --- | --- |
| 4 | 2 | 19/20 | 20/20 |
| 6 | 3 | 7/20 | 8/20 |
| 8 (previous) | 4 | 1/20 | 1/20 |
| 16 | 8 | 0/20 | 0/20 |

## Change

- The handshake loop retains the last flight and retransmits it when a receive expires,
  spending its budget as eight two-second probes instead of one ten-second wait.
- The response loop keeps waiting instead of abandoning the exchange; the server drives
  application-space probe timeouts and retransmits on its own. Sixteen one-second probes
  stay inside the server's connection age.
- `HTTP_3_Capacity` becomes sixteen, and the comment records the actual per-family model
  rather than the previous "three profiles per family" reading.

No timeout was raised. The handshake does not need longer.

## Verification

- At two slots per family, where the previous loop failed 19 of 20 runs, the raw handshake
  now completes in all 20.
- 40 of 40 runs clean at the committed configuration under CPU contention.
- `./scripts/test.sh` passes.

## Not addressed here

This is a test change. Two library gaps it exposed are left for separate work:

- No handshake-space probe timeout in the QUIC layer, which RFC 9002 §6.2 requires. A lost
  Initial or server handshake flight stalls a real client, not only this test: at two slots
  per family the fixed test still failed three runs in `POOLED_EXCHANGE`, which is
  `Flyology.HTTP.Client` hitting exactly this gap.
- A race-losing HTTP/3 lane cancelled mid-handshake closes its socket without a close
  frame (`Dispose_Connection` sends one only when connected,
  `src/flyology-http-client.adb:413`), so the server pins that registry slot for its whole
  handshake timeout.

Separately, at four times CPU oversubscription the 8 000-exchange pooled loop begins to
exceed the server's `Max_Connection_Age => 20.0` around exchange 7 500. An A/B run under
identical load gave 4/20 on the unmodified binary and 3/20 on this one, so it is
pre-existing and untouched by this change, but it is a plausible next failure as runners
slow relative to that budget.
