### PR TITLE
Handshake-space loss detection and probe timeouts

### DIFF
--- a/flyology_quic/scripts/test.sh
+++ b/flyology_quic/scripts/test.sh
@@ -58,6 +58,7 @@ for test in \
   flyology-quic-application_frame_policy-smoke \
   flyology-quic-connection_state_policy-smoke \
   flyology-quic-connection_driver-smoke \
+  flyology-quic-connections-recovery_smoke \
   flyology-quic-crypto_frame_policy-smoke \
   flyology-quic-crypto_openssl-smoke \
   flyology-quic-crypto_reassembly_policy-smoke \

--- a/flyology_quic/src/flyology-quic-connection_driver.adb
+++ b/flyology_quic/src/flyology-quic-connection_driver.adb
@@ -3,6 +3,7 @@ with Flyology.QUIC.Debug;
 with Flyology.QUIC.Handshake_Packet_Policy;
 with Flyology.QUIC.Initial_Connection;
 with Flyology.QUIC.Initial_Packet_Policy;
+with Flyology.QUIC.Sent_Packet_Policy;
 with Flyology.QUIC.Stream_ID_Policy;
 with Flyology.QUIC.TLS_Key_Schedule;
 with Flyology.QUIC.Transport_Parameter_Policy;
@@ -20,6 +21,7 @@ package body Flyology.QUIC.Connection_Driver is
    use type Initial_Space.Process_Status;
    use type Initial_Packet_Policy.Parse_Status;
    use type Recovery_Policy.Duration;
+   use type Sent_Packet_Policy.Timestamp;
    use type TLS_Session.Operation_Status;
 
    function State (Item : Connection) return Connection_State is
@@ -41,14 +43,103 @@ package body Flyology.QUIC.Connection_Driver is
      (Item : Connection) return Varint_Policy.Value_Type is
      (Item.Close_Error);
 
-   function Has_Recovery_Timeout (Item : Connection) return Boolean is
+   --  RFC 9002 section 6.2 arms a probe timeout for the Initial and Handshake
+   --  spaces until the handshake is confirmed. A client keeps the timer armed
+   --  even with nothing in flight so it can send the anti-deadlock probe of
+   --  section 6.2.2.1; a server with nothing outstanding has nothing to probe
+   --  with and lets its peer drive.
+   function Handshake_Unacknowledged (Item : Connection) return Boolean is
+     (Initial_Space.Has_Unacknowledged (Item.Initial)
+      or else (Item.Handshake_Initialized
+               and then Handshake_Space.Has_Unacknowledged (Item.Handshake)));
+
+   function Has_Handshake_Timeout (Item : Connection) return Boolean is
+     (Item.Has_Handshake_Sent
+      and then not Item.Is_Handshake_Confirmed
+      and then Item.Current in Client_Initial | Client_Handshake
+        | Server_Initial | Server_Handshake | Connected
+      and then (Handshake_Unacknowledged (Item)
+                or else (Item.Is_Client and then not Item.Peer_Validated)));
+
+   function Handshake_Deadline
+     (Item : Connection) return Application_Space.Timestamp
+   is
+      --  Handshake packets are acknowledged immediately, so their probe
+      --  timeout excludes the peer's max_ack_delay.
+      Length : constant Recovery_Policy.Duration :=
+        Recovery_Policy.Probe_Timeout
+          (Item.Handshake_Recovery,
+           Maximum_ACK_Delay => 0,
+           Include_ACK_Delay => False);
+   begin
+      if Length >
+        Application_Space.Timestamp'Last - Item.Last_Handshake_Sent
+      then
+         return Application_Space.Timestamp'Last;
+      else
+         return Item.Last_Handshake_Sent + Length;
+      end if;
+   end Handshake_Deadline;
+
+   function Has_Application_Timeout (Item : Connection) return Boolean is
      (Item.Current = Connected
       and then Application_Space.Has_Recovery_Timeout (Item.Application));
 
+   function Has_Recovery_Timeout (Item : Connection) return Boolean is
+     (Has_Handshake_Timeout (Item) or else Has_Application_Timeout (Item));
+
    function Recovery_Deadline
      (Item : Connection) return Application_Space.Timestamp
-   is (Application_Space.Recovery_Deadline
-         (Item.Application, Item.Peer_Max_ACK_Delay));
+   is
+      Result : Application_Space.Timestamp := Application_Space.Timestamp'Last;
+   begin
+      if Has_Handshake_Timeout (Item) then
+         Result := Handshake_Deadline (Item);
+      end if;
+      if Has_Application_Timeout (Item) then
+         Result := Application_Space.Timestamp'Min
+           (Result,
+            Application_Space.Recovery_Deadline
+              (Item.Application, Item.Peer_Max_ACK_Delay));
+      end if;
+      return Result;
+   end Recovery_Deadline;
+
+   --  Record that an ack-eliciting handshake-space packet has just been sent,
+   --  which is what the probe timeout is measured from.
+   procedure Note_Handshake_Sent
+     (Item : in out Connection; Now : Application_Space.Timestamp) is
+   begin
+      Item.Has_Handshake_Sent := True;
+      Item.Last_Handshake_Sent := Now;
+   end Note_Handshake_Sent;
+
+   --  Fold one space's ACK outcome into the shared handshake recovery state.
+   procedure Apply_Handshake_Recovery
+     (Item            : in out Connection;
+      Resolved        : Sent_Packet_Policy.Apply_Result;
+      ACKed_Eliciting : Boolean;
+      Has_Sample      : Boolean;
+      Sample          : Application_Space.Timestamp;
+      Now             : Application_Space.Timestamp) is
+   begin
+      if Has_Sample then
+         Recovery_Policy.Update_RTT
+           (Item.Handshake_Recovery, Sample,
+            ACK_Delay => 0, Maximum_ACK_Delay => 0,
+            Handshake_Confirmed => False);
+      end if;
+      if ACKed_Eliciting then
+         Recovery_Policy.On_ACK_Received (Item.Handshake_Recovery);
+      end if;
+      Recovery_Policy.On_Packets_Resolved
+        (Item.Handshake_Recovery, Resolved.Events, Resolved.Count, Now,
+         Application_Limited => False);
+   end Apply_Handshake_Recovery;
+
+   function Handshake_Loss_Delay
+     (Item : Connection) return Application_Space.Timestamp is
+     (Recovery_Policy.Loss_Delay (Item.Handshake_Recovery));
 
    function Has_Stream
      (Item : Connection; Stream_ID : Varint_Policy.Value_Type) return Boolean
@@ -286,8 +377,12 @@ package body Flyology.QUIC.Connection_Driver is
    is
      (case Value is
          when Initial_Space.Built => Application_Space.Sent,
+         when Initial_Space.Nothing_To_ACK => Application_Space.Nothing_To_ACK,
          when Initial_Space.Crypto_Range_Too_Large =>
            Application_Space.Internal_State_Error,
+         when Initial_Space.Crypto_Retention_Exceeded
+            | Initial_Space.Recovery_Capacity_Exceeded =>
+           Application_Space.Recovery_Capacity_Exceeded,
          when Initial_Space.Packet_Number_Exhausted =>
            Application_Space.Packet_Number_Exhausted,
          when Initial_Space.Packet_Number_Unrepresentable =>
@@ -303,8 +398,12 @@ package body Flyology.QUIC.Connection_Driver is
    is
      (case Value is
          when Handshake_Space.Built => Application_Space.Sent,
+         when Handshake_Space.Nothing_To_ACK => Application_Space.Nothing_To_ACK,
          when Handshake_Space.Crypto_Range_Too_Large =>
            Application_Space.Internal_State_Error,
+         when Handshake_Space.Crypto_Retention_Exceeded
+            | Handshake_Space.Recovery_Capacity_Exceeded =>
+           Application_Space.Recovery_Capacity_Exceeded,
          when Handshake_Space.Packet_Number_Exhausted =>
            Application_Space.Packet_Number_Exhausted,
          when Handshake_Space.Packet_Number_Unrepresentable =>
@@ -402,6 +501,8 @@ package body Flyology.QUIC.Connection_Driver is
          when Initial_Space.Frame_Truncated
             | Initial_Space.Frame_Value_Too_Large
             | Initial_Space.Invalid_ACK_Range => 16#07#,
+         when Initial_Space.ACK_Range_Capacity_Exceeded
+            | Initial_Space.Acknowledges_Unsent_Packet => 16#0A#,
          when Initial_Space.Crypto_Data_Too_Large => 16#0D#,
          when Initial_Space.Processed
             | Initial_Space.Duplicate_Packet
@@ -420,6 +521,8 @@ package body Flyology.QUIC.Connection_Driver is
          when Handshake_Space.Frame_Truncated
             | Handshake_Space.Frame_Value_Too_Large
             | Handshake_Space.Invalid_ACK_Range => 16#07#,
+         when Handshake_Space.ACK_Range_Capacity_Exceeded
+            | Handshake_Space.Acknowledges_Unsent_Packet => 16#0A#,
          when Handshake_Space.Crypto_Data_Too_Large => 16#0D#,
          when Handshake_Space.Processed
             | Handshake_Space.Duplicate_Packet
@@ -727,7 +830,8 @@ package body Flyology.QUIC.Connection_Driver is
    procedure Start_Client
      (Item   : in out Connection;
       Output : out Datagram_Batch;
-      Result : out Operation_Result)
+      Result : out Operation_Result;
+      Now    : Application_Space.Timestamp := 0)
    is
       Hello : Ada.Streams.Stream_Element_Array (1 .. 1_200);
       TLS_Result : TLS_Session.Operation_Result;
@@ -747,10 +851,10 @@ package body Flyology.QUIC.Connection_Driver is
          return;
       end if;
       Initial_Space.Build_Crypto_Packet
-        (Item.Initial, (1 .. 0 => 0), 0,
+        (Item.Initial, 0,
          Hello (1 .. Ada.Streams.Stream_Element_Offset
                        (TLS_Result.Output_Length)),
-         Packet, Built);
+         Now, Packet, Built);
       if Built.Status /= Initial_Space.Built
         or else not Append (Output, Packet, Built.Packet_Length)
       then
@@ -758,6 +862,7 @@ package body Flyology.QUIC.Connection_Driver is
          Result.Status := Packet_Error;
          return;
       end if;
+      Note_Handshake_Sent (Item, Now);
       Result.Status := Succeeded;
    end Start_Client;
 
@@ -765,12 +870,14 @@ package body Flyology.QUIC.Connection_Driver is
      (Item   : in out Connection;
       Packet : Ada.Streams.Stream_Element_Array;
       Output : in out Datagram_Batch;
-      Result : in out Operation_Result)
+      Result : in out Operation_Result;
+      Now    : Application_Space.Timestamp)
    is
       Processed : Initial_Space.Process_Result;
       Length : Natural;
    begin
-      Initial_Space.Process_Packet (Item.Initial, Packet, Processed);
+      Initial_Space.Process_Packet
+        (Item.Initial, Packet, Now, Handshake_Loss_Delay (Item), Processed);
       if Processed.Status in
         Initial_Space.Duplicate_Packet | Initial_Space.Packet_Too_Old
           | Initial_Space.Envelope_Rejected
@@ -803,6 +910,9 @@ package body Flyology.QUIC.Connection_Driver is
          Result.Status := Connection_Closed;
          return;
       end if;
+      Apply_Handshake_Recovery
+        (Item, Processed.Resolved, Processed.ACKed_Eliciting,
+         Processed.Has_Sample, Processed.Sample, Now);
       Length := Message_Length (Item.Initial);
       if Length = 0 then
          Result.Status := Waiting_For_More;
@@ -844,11 +954,11 @@ package body Flyology.QUIC.Connection_Driver is
                return;
             end if;
             Initial_Space.Build_Crypto_Packet
-              (Item.Initial, (1 .. 0 => 0), 0,
+              (Item.Initial, 0,
                Server_Hello
                  (1 .. Ada.Streams.Stream_Element_Offset
                          (TLS_Result.Server_Hello_Length)),
-               Packet_Out, Initial_Built);
+               Now, Packet_Out, Initial_Built);
             if Initial_Built.Status /= Initial_Space.Built
               or else not Append
                 (Output, Packet_Out, Initial_Built.Packet_Length)
@@ -872,7 +982,7 @@ package body Flyology.QUIC.Connection_Driver is
                   Authentication
                     (Ada.Streams.Stream_Element_Offset (Offset + 1)
                        .. Ada.Streams.Stream_Element_Offset (Offset + Chunk)),
-                  Packet_Out, Handshake_Built);
+                  Now, Packet_Out, Handshake_Built);
                if Handshake_Built.Status /= Handshake_Space.Built
                  or else not Append
                    (Output, Packet_Out, Handshake_Built.Packet_Length)
@@ -883,6 +993,7 @@ package body Flyology.QUIC.Connection_Driver is
                end if;
                Offset := Offset + Chunk;
             end loop;
+            Note_Handshake_Sent (Item, Now);
             Item.Current := Server_Handshake;
             Result.Status := Succeeded;
          end;
@@ -908,6 +1019,10 @@ package body Flyology.QUIC.Connection_Driver is
                Item.Local_ID);
             Item.Handshake_Initialized := True;
             Item.Handshake_Consumed := 0;
+            --  A ServerHello can only follow delivery of the ClientHello, so
+            --  the Initial flight needs no further retransmission.
+            Initial_Space.Acknowledge_Flight (Item.Initial);
+            Recovery_Policy.On_ACK_Received (Item.Handshake_Recovery);
             Item.Current := Client_Handshake;
             Result.Status := Succeeded;
          end;
@@ -932,7 +1047,8 @@ package body Flyology.QUIC.Connection_Driver is
          Result.Status := Invalid_State;
          return;
       end if;
-      Handshake_Space.Process_Packet (Item.Handshake, Packet, Processed);
+      Handshake_Space.Process_Packet
+        (Item.Handshake, Packet, Now, Handshake_Loss_Delay (Item), Processed);
       if Processed.Status in
         Handshake_Space.Duplicate_Packet | Handshake_Space.Packet_Too_Old
           | Handshake_Space.Envelope_Rejected
@@ -962,6 +1078,12 @@ package body Flyology.QUIC.Connection_Driver is
          Result.Status := Connection_Closed;
          return;
       end if;
+      Apply_Handshake_Recovery
+        (Item, Processed.Resolved, Processed.ACKed_Eliciting,
+         Processed.Has_Sample, Processed.Sample, Now);
+      --  Receiving a Handshake packet completes the peer's address
+      --  validation, so a client no longer owes anti-deadlock probes.
+      Item.Peer_Validated := True;
 
       if Item.Current = Client_Handshake then
          Length := Authentication_Length (Item.Handshake);
@@ -1000,7 +1122,7 @@ package body Flyology.QUIC.Connection_Driver is
                Finished
                  (1 .. Ada.Streams.Stream_Element_Offset
                          (TLS_Result.Output_Length)),
-               Packet_Out, Built);
+               Now, Packet_Out, Built);
             if Built.Status /= Handshake_Space.Built
               or else not Append (Output, Packet_Out, Built.Packet_Length)
             then
@@ -1008,6 +1130,7 @@ package body Flyology.QUIC.Connection_Driver is
                Result.Status := Packet_Error;
                return;
             end if;
+            Note_Handshake_Sent (Item, Now);
             Initialize_Application (Item);
             Item.Handshake_Consumed := Length;
             Item.Current := Connected;
@@ -1053,6 +1176,10 @@ package body Flyology.QUIC.Connection_Driver is
                Result.Status := Output_Capacity_Exceeded;
                return;
             end if;
+            --  The client Finished can only follow delivery of the server
+            --  flight, so neither handshake space needs a probe timer now.
+            Initial_Space.Acknowledge_Flight (Item.Initial);
+            Handshake_Space.Acknowledge_Flight (Item.Handshake);
             Item.Is_Handshake_Confirmed := True;
             Item.Handshake_Consumed := Length;
             Item.Current := Connected;
@@ -1086,10 +1213,13 @@ package body Flyology.QUIC.Connection_Driver is
          Defer_Application_ACK => False, ACK_Deferred => ACK_Deferred);
    end Process_Datagram;
 
-   procedure Process_Datagram
+   --  Walk the coalesced packets of one datagram. Acknowledgments owed by the
+   --  handshake spaces are flushed by the caller once the whole datagram has
+   --  been consumed, so a multi-packet flight is acknowledged once.
+   procedure Scan_Datagram
      (Item                  : in out Connection;
       Packet                : Ada.Streams.Stream_Element_Array;
-      Output                : out Datagram_Batch;
+      Output                : in out Datagram_Batch;
       Result                : out Operation_Result;
       Now                   : Application_Space.Timestamp;
       Defer_Application_ACK : Boolean;
@@ -1100,7 +1230,6 @@ package body Flyology.QUIC.Connection_Driver is
       Total               : constant Natural := Natural (Packet'Length);
       Accepted            : Boolean := False;
    begin
-      Clear (Output);
       Result := (others => <>);
       ACK_Deferred := False;
       if Packet'Length = 0 then
@@ -1199,6 +1328,12 @@ package body Flyology.QUIC.Connection_Driver is
                      Result.Status := Connection_Closed;
                      return;
                   elsif Application_Result.Handshake_Done then
+                     --  HANDSHAKE_DONE can only follow delivery of the client
+                     --  Finished, retiring both handshake spaces.
+                     Initial_Space.Acknowledge_Flight (Item.Initial);
+                     if Item.Handshake_Initialized then
+                        Handshake_Space.Acknowledge_Flight (Item.Handshake);
+                     end if;
                      Item.Is_Handshake_Confirmed := True;
                   end if;
                   if Application_Result.ACK_Eliciting
@@ -1253,7 +1388,7 @@ package body Flyology.QUIC.Connection_Driver is
                           .. Remaining'First
                                + Ada.Streams.Stream_Element_Offset
                                    (Envelope.Consumed - 1)),
-                     Output, Result);
+                     Output, Result, Now);
                   if Result.Status not in Succeeded | Waiting_For_More then
                      return;
                   end if;
@@ -1297,7 +1432,159 @@ package body Flyology.QUIC.Connection_Driver is
             end if;
          end;
       end loop;
+   end Scan_Datagram;
+
+   procedure Process_Datagram
+     (Item                  : in out Connection;
+      Packet                : Ada.Streams.Stream_Element_Array;
+      Output                : out Datagram_Batch;
+      Result                : out Operation_Result;
+      Now                   : Application_Space.Timestamp;
+      Defer_Application_ACK : Boolean;
+      ACK_Deferred          : out Boolean)
+   is
+      Packet_Out : Ada.Streams.Stream_Element_Array
+        (1 .. Max_Datagram_Length);
+      Initial_Built : Initial_Space.Build_Result;
+      Handshake_Built : Handshake_Space.Build_Result;
+   begin
+      Clear (Output);
+      Scan_Datagram
+        (Item, Packet, Output, Result, Now, Defer_Application_ACK,
+         ACK_Deferred);
+      if Result.Status not in Succeeded | Waiting_For_More
+        or else Item.Current in Uninitialized | Peer_Closed | Failed
+      then
+         return;
+      end if;
+
+      --  RFC 9000 section 13.2.1 requires an immediate acknowledgment of an
+      --  ack-eliciting Initial or Handshake packet. A response this datagram
+      --  already produced in that space carries the acknowledgment with it;
+      --  anything still owed goes out as an ACK-only packet now, so the
+      --  acknowledgment never rides an unrelated later datagram and the
+      --  peer's probe timeout is cleared within one round trip.
+      if Initial_Space.Needs_ACK (Item.Initial)
+        and then Output.Count < Max_Output_Datagrams
+      then
+         Initial_Space.Build_ACK_Packet
+           (Item.Initial, Now, Packet_Out, Initial_Built);
+         if Initial_Built.Status = Initial_Space.Built
+           and then not Append (Output, Packet_Out,
+                                Initial_Built.Packet_Length)
+         then
+            Result.Status := Output_Capacity_Exceeded;
+            return;
+         end if;
+      end if;
+      if Item.Handshake_Initialized
+        and then Handshake_Space.Needs_ACK (Item.Handshake)
+        and then Output.Count < Max_Output_Datagrams
+      then
+         Handshake_Space.Build_ACK_Packet
+           (Item.Handshake, Now, Packet_Out, Handshake_Built);
+         if Handshake_Built.Status = Handshake_Space.Built
+           and then not Append (Output, Packet_Out,
+                                Handshake_Built.Packet_Length)
+         then
+            Result.Status := Output_Capacity_Exceeded;
+            return;
+         end if;
+      end if;
    end Process_Datagram;
+
+   --  RFC 9002 section 6.2.4 probes the handshake spaces by retransmitting
+   --  every CRYPTO range that is still unacknowledged. When nothing remains a
+   --  client sends the anti-deadlock PING of section 6.2.2.1.
+   procedure Process_Handshake_Timeout
+     (Item   : in out Connection;
+      Now    : Application_Space.Timestamp;
+      Output : in out Datagram_Batch;
+      Status : out Timeout_Status)
+   is
+      Packet          : Ada.Streams.Stream_Element_Array
+        (1 .. Max_Datagram_Length);
+      Initial_Built   : Initial_Space.Build_Result;
+      Handshake_Built : Handshake_Space.Build_Result;
+      Emitted         : Natural := 0;
+   begin
+      Status := Probes_Ready;
+      for Index in 1 .. Max_Output_Datagrams loop
+         Initial_Space.Build_Probe_Packet
+           (Item.Initial, Index, Now, Packet, Initial_Built);
+         exit when Initial_Built.Status = Initial_Space.Nothing_To_ACK;
+         if Initial_Built.Status /= Initial_Space.Built then
+            Status := Timeout_Packet_Error;
+            return;
+         elsif not Append (Output, Packet, Initial_Built.Packet_Length) then
+            Status := Timeout_Output_Capacity_Exceeded;
+            return;
+         end if;
+         Emitted := Emitted + 1;
+      end loop;
+
+      if Item.Handshake_Initialized then
+         for Index in 1 .. Max_Output_Datagrams loop
+            Handshake_Space.Build_Probe_Packet
+              (Item.Handshake, Index, Now, Packet, Handshake_Built);
+            exit when Handshake_Built.Status = Handshake_Space.Nothing_To_ACK;
+            if Handshake_Built.Status /= Handshake_Space.Built then
+               Status := Timeout_Packet_Error;
+               return;
+            elsif not Append
+              (Output, Packet, Handshake_Built.Packet_Length)
+            then
+               Status := Timeout_Output_Capacity_Exceeded;
+               return;
+            end if;
+            Emitted := Emitted + 1;
+         end loop;
+      end if;
+
+      if Emitted = 0 then
+         if not Item.Is_Client then
+            --  A server never sends anti-deadlock probes, so with nothing
+            --  left to retransmit it has nothing to arm the timer with.
+            Item.Has_Handshake_Sent := False;
+            Status := No_Pending_Recovery;
+            return;
+         elsif Item.Handshake_Initialized then
+            Handshake_Space.Build_Ping_Packet
+              (Item.Handshake, Now, Packet, Handshake_Built);
+            if Handshake_Built.Status /= Handshake_Space.Built then
+               Status := Timeout_Packet_Error;
+               return;
+            elsif not Append
+              (Output, Packet, Handshake_Built.Packet_Length)
+            then
+               Status := Timeout_Output_Capacity_Exceeded;
+               return;
+            end if;
+         else
+            Initial_Space.Build_Ping_Packet
+              (Item.Initial, Now, Packet, Initial_Built);
+            if Initial_Built.Status /= Initial_Space.Built then
+               Status := Timeout_Packet_Error;
+               return;
+            elsif not Append (Output, Packet, Initial_Built.Packet_Length)
+            then
+               Status := Timeout_Output_Capacity_Exceeded;
+               return;
+            end if;
+         end if;
+      end if;
+
+      Recovery_Policy.On_Probe_Timeout (Item.Handshake_Recovery);
+      Note_Handshake_Sent (Item, Now);
+      if Debug.Enabled then
+         Debug.Log
+           ("quic", "handshake-probe",
+            "state=" & Connection_State'Image (Item.Current) &
+            " packets=" & Natural'Image (Output.Count) &
+            " count=" & Recovery_Policy.PTO_Count_Type'Image
+              (Recovery_Policy.PTO_Count (Item.Handshake_Recovery)));
+      end if;
+   end Process_Handshake_Timeout;
 
    procedure Process_Timeout
      (Item   : in out Connection;
@@ -1309,16 +1596,21 @@ package body Flyology.QUIC.Connection_Driver is
       Built  : Application_Space.Send_Result;
    begin
       Clear (Output);
-      if Item.Current /= Connected then
+      if Item.Current in Uninitialized | Peer_Closed | Failed then
          Status := Timeout_Invalid_State;
          return;
-      elsif not Application_Space.Has_Recovery_Timeout (Item.Application) then
+      elsif not Has_Recovery_Timeout (Item) then
          Status := No_Pending_Recovery;
          return;
-      elsif Now < Application_Space.Recovery_Deadline
-        (Item.Application, Item.Peer_Max_ACK_Delay)
-      then
+      elsif Now < Recovery_Deadline (Item) then
          Status := Not_Due;
+         return;
+      end if;
+
+      if Has_Handshake_Timeout (Item)
+        and then Handshake_Deadline (Item) <= Now
+      then
+         Process_Handshake_Timeout (Item, Now, Output, Status);
          return;
       end if;
 

--- a/flyology_quic/src/flyology-quic-connection_driver.ads
+++ b/flyology_quic/src/flyology-quic-connection_driver.ads
@@ -116,7 +116,8 @@ private package Flyology.QUIC.Connection_Driver is
    procedure Start_Client
      (Item   : in out Connection;
       Output : out Datagram_Batch;
-      Result : out Operation_Result);
+      Result : out Operation_Result;
+      Now    : Application_Space.Timestamp := 0);
 
    procedure Process_Datagram
      (Item   : in out Connection;
@@ -323,6 +324,15 @@ private
       Is_Client             : Boolean := True;
       Peer_ACK_Exponent     : Application_Space.ACK_Delay_Exponent := 3;
       Peer_Max_ACK_Delay    : Recovery_Policy.Duration := 25_000;
+      --  RFC 9002 loss recovery shared by the Initial and Handshake spaces.
+      --  Their probe timeout excludes max_ack_delay and their probe count
+      --  backs off together, so one path-wide state covers both.
+      Handshake_Recovery    : Recovery_Policy.State;
+      Has_Handshake_Sent    : Boolean := False;
+      Last_Handshake_Sent   : Application_Space.Timestamp := 0;
+      --  RFC 9002 PeerCompletedAddressValidation: a client that has processed
+      --  a Handshake packet no longer needs the anti-deadlock probe.
+      Peer_Validated        : Boolean := False;
       Local_ID              : Long_Header_Policy.Connection_ID;
       Peer_ID               : Long_Header_Policy.Connection_ID;
       Local_Parameters      : Transport_Parameter_Policy.Transport_Parameters;

--- a/flyology_quic/src/flyology-quic-connections.adb
+++ b/flyology_quic/src/flyology-quic-connections.adb
@@ -390,13 +390,15 @@ package body Flyology.QUIC.Connections is
    procedure Start_Client
      (Item   : in out Connection;
       Output : out Datagram_Batch;
-      Status : out Operation_Status)
+      Status : out Operation_Status;
+      Now    : Timestamp := 0)
    is
       Internal_Output : Connection_Driver.Datagram_Batch;
       Result          : Connection_Driver.Operation_Result;
    begin
       Connection_Driver.Start_Client
-        (Impl (Item).Driver, Internal_Output, Result);
+        (Impl (Item).Driver, Internal_Output, Result,
+         Application_Space.Timestamp (Now));
       Copy (Internal_Output, Output);
       Status := Public_Status (Result.Status);
    end Start_Client;

--- a/flyology_quic/src/flyology-quic-connections.ads
+++ b/flyology_quic/src/flyology-quic-connections.ads
@@ -329,10 +329,12 @@ package Flyology.QUIC.Connections is
    --  @param Item Initialized client connection
    --  @param Output Datagrams to transmit
    --  @param Status Transition outcome
+   --  @param Now Monotonic microsecond timestamp for recovery accounting
    procedure Start_Client
      (Item   : in out Connection;
       Output : out Datagram_Batch;
-      Status : out Operation_Status)
+      Status : out Operation_Status;
+      Now    : Timestamp := 0)
    with Pre => State (Item) = Client_Initial;
 
    --  Process one UDP payload and return any immediate response flight,
@@ -370,10 +372,10 @@ package Flyology.QUIC.Connections is
    with Pre => Packet'Length <= Max_Datagram_Length;
 
    --  Outcome of processing a recovery timer expiration.
-   --  @enum Probes_Ready Output contains one or two ACK-eliciting PTO probes
+   --  @enum Probes_Ready Output contains ACK-eliciting PTO probes
    --  @enum Not_Due The current recovery deadline is still in the future
-   --  @enum No_Pending_Recovery No in-flight application packet needs a timer
-   --  @enum Invalid_Timeout_State Application traffic keys are not active
+   --  @enum No_Pending_Recovery No in-flight packet needs a timer
+   --  @enum Invalid_Timeout_State No packet-number space is active
    --  @enum Timeout_Packet_Error A protected probe could not be built
    --  @enum Timeout_Output_Capacity_Exceeded Probe output did not fit
    type Timeout_Status is
@@ -384,21 +386,26 @@ package Flyology.QUIC.Connections is
       Timeout_Packet_Error,
       Timeout_Output_Capacity_Exceeded);
 
-   --  Report whether an application-space recovery timer is armed.
+   --  Report whether a recovery timer is armed in any packet-number space.
+   --  Initial and Handshake spaces arm an RFC 9002 section 6.2 probe timeout
+   --  until the handshake is confirmed; the application space arms one while
+   --  an ACK-eliciting 1-RTT packet remains in flight.
    --  @param Item Connection to inspect
-   --  @return True while an ACK-eliciting packet remains in flight
+   --  @return True while a probe timeout is armed
    function Has_Recovery_Timeout (Item : Connection) return Boolean;
 
-   --  Return the absolute monotonic deadline for the armed recovery timer.
-   --  @param Item Connected connection with in-flight application data
+   --  Return the absolute monotonic deadline for the earliest armed recovery
+   --  timer.
+   --  @param Item Connection with an armed recovery timer
    --  @return Monotonic microsecond deadline
    function Recovery_Deadline (Item : Connection) return Timestamp
    with Pre => Has_Recovery_Timeout (Item);
 
-   --  Process an application-space PTO and produce bounded probes. A probe
-   --  retransmits retained STREAM or control data when available and otherwise
-   --  carries PING.
-   --  @param Item Connected endpoint
+   --  Process an expired PTO and produce bounded probes. A handshake-space
+   --  probe retransmits unacknowledged CRYPTO data, or carries the client's
+   --  anti-deadlock PING when none remains. An application-space probe
+   --  retransmits retained STREAM or control data and otherwise carries PING.
+   --  @param Item Initialized endpoint
    --  @param Now Current monotonic microsecond timestamp
    --  @param Output Probe datagrams when Status is Probes_Ready
    --  @param Status Timer transition outcome

--- a/flyology_quic/src/flyology-quic-crypto_flight.adb
+++ b/flyology_quic/src/flyology-quic-crypto_flight.adb
@@ -1,0 +1,131 @@
+package body Flyology.QUIC.Crypto_Flight is
+   use type Varint_Policy.Value_Type;
+
+   procedure Reset (Item : in out Flight) is
+   begin
+      Item.Chunks := (others => (others => <>));
+      Item.Count := 0;
+   end Reset;
+
+   function Can_Retain
+     (Item   : Flight;
+      Offset : Varint_Policy.Value_Type;
+      Length : Ada.Streams.Stream_Element_Offset) return Boolean is
+     (Item.Count < Max_Chunks
+      and then Offset <= Varint_Policy.Value_Type (Item.Capacity)
+      and then Ada.Streams.Stream_Element_Offset (Offset) + Length <=
+        Item.Capacity);
+
+   procedure Retain
+     (Item   : in out Flight;
+      Number : Packet_Number;
+      Offset : Varint_Policy.Value_Type;
+      Data   : Ada.Streams.Stream_Element_Array;
+      Status : out Retain_Status)
+   is
+      First : Ada.Streams.Stream_Element_Offset;
+   begin
+      if Offset > Varint_Policy.Value_Type (Item.Capacity)
+        or else Ada.Streams.Stream_Element_Offset (Offset) + Data'Length >
+          Item.Capacity
+      then
+         Status := Capacity_Exceeded;
+         return;
+      elsif Item.Count = Max_Chunks then
+         Status := Chunk_Table_Full;
+         return;
+      end if;
+
+      First := Ada.Streams.Stream_Element_Offset (Offset) + 1;
+      if Data'Length > 0 then
+         Item.Data (First .. First + Data'Length - 1) := Data;
+      end if;
+      Item.Count := Item.Count + 1;
+      Item.Chunks (Item.Count) :=
+        (Occupied => True,
+         Pending  => True,
+         Number   => Number,
+         Offset   => Offset,
+         Length   => Data'Length);
+      Status := Retained;
+   end Retain;
+
+   procedure Acknowledge (Item : in out Flight; Number : Packet_Number) is
+   begin
+      for Index in 1 .. Item.Count loop
+         if Item.Chunks (Index).Occupied
+           and then Item.Chunks (Index).Number = Number
+         then
+            Item.Chunks (Index).Pending := False;
+         end if;
+      end loop;
+   end Acknowledge;
+
+   procedure Acknowledge_All (Item : in out Flight) is
+   begin
+      for Index in 1 .. Item.Count loop
+         Item.Chunks (Index).Pending := False;
+      end loop;
+   end Acknowledge_All;
+
+   function Has_Pending (Item : Flight) return Boolean is
+     (First_Pending (Item) /= 0);
+
+   function First_Pending (Item : Flight) return Chunk_Count is
+   begin
+      for Index in 1 .. Item.Count loop
+         if Item.Chunks (Index).Occupied
+           and then Item.Chunks (Index).Pending
+         then
+            return Index;
+         end if;
+      end loop;
+      return 0;
+   end First_Pending;
+
+   function Next_Pending
+     (Item : Flight; Index : Chunk_Index) return Chunk_Count is
+   begin
+      for Candidate in Index + 1 .. Item.Count loop
+         if Item.Chunks (Candidate).Occupied
+           and then Item.Chunks (Candidate).Pending
+         then
+            return Candidate;
+         end if;
+      end loop;
+      return 0;
+   end Next_Pending;
+
+   function Offset
+     (Item : Flight; Index : Chunk_Index) return Varint_Policy.Value_Type is
+     (Item.Chunks (Index).Offset);
+
+   function Length
+     (Item : Flight; Index : Chunk_Index)
+      return Ada.Streams.Stream_Element_Offset is
+     (Item.Chunks (Index).Length);
+
+   procedure Copy
+     (Item  : Flight;
+      Index : Chunk_Index;
+      Data  : out Ada.Streams.Stream_Element_Array)
+   is
+      First : constant Ada.Streams.Stream_Element_Offset :=
+        Ada.Streams.Stream_Element_Offset (Item.Chunks (Index).Offset) + 1;
+      Size  : constant Ada.Streams.Stream_Element_Offset :=
+        Item.Chunks (Index).Length;
+   begin
+      Data := (others => 0);
+      if Size > 0 then
+         Data (Data'First .. Data'First + Size - 1) :=
+           Item.Data (First .. First + Size - 1);
+      end if;
+   end Copy;
+
+   procedure Rebind
+     (Item : in out Flight; Index : Chunk_Index; Number : Packet_Number) is
+   begin
+      Item.Chunks (Index).Number := Number;
+      Item.Chunks (Index).Pending := True;
+   end Rebind;
+end Flyology.QUIC.Crypto_Flight;

--- a/flyology_quic/src/flyology-quic-crypto_flight.ads
+++ b/flyology_quic/src/flyology-quic-crypto_flight.ads
@@ -1,0 +1,105 @@
+with Ada.Streams;
+with Flyology.QUIC.Sent_Packet_Policy;
+with Flyology.QUIC.Varint_Policy;
+
+--  Internal retention of the CRYPTO stream one endpoint has sent in a single
+--  packet-number space.
+--
+--  RFC 9002 section 6.2 requires an endpoint to retransmit unacknowledged
+--  Initial and Handshake CRYPTO data when a probe timeout expires. QUIC never
+--  retransmits a packet verbatim, so a space retains the CRYPTO ranges it
+--  built and rebinds a range to a fresh packet number every time it is sent
+--  again. A range stops being pending once the packet carrying it is
+--  acknowledged, either by an ACK frame or by handshake progress that can only
+--  follow its delivery.
+private package Flyology.QUIC.Crypto_Flight is
+   use type Ada.Streams.Stream_Element_Offset;
+
+   subtype Packet_Number is Sent_Packet_Policy.Packet_Number;
+
+   --  Retained CRYPTO octets a space may hold. Both handshake spaces send a
+   --  contiguous stream from offset zero, so one buffer of this size bounds
+   --  the whole outgoing flight.
+   subtype Capacity_Range is
+     Ada.Streams.Stream_Element_Offset range 1 .. 32_768;
+
+   --  Independently acknowledgeable CRYPTO ranges retained by one space.
+   Max_Chunks : constant := 32;
+   subtype Chunk_Count is Natural range 0 .. Max_Chunks;
+   subtype Chunk_Index is Positive range 1 .. Max_Chunks;
+
+   type Flight (Capacity : Capacity_Range) is limited private;
+
+   --  Discard every retained range.
+   procedure Reset (Item : in out Flight);
+
+   type Retain_Status is (Retained, Capacity_Exceeded, Chunk_Table_Full);
+
+   --  Report whether a range would fit, so a caller can refuse before it
+   --  puts a packet on the wire it could not retransmit.
+   function Can_Retain
+     (Item   : Flight;
+      Offset : Varint_Policy.Value_Type;
+      Length : Ada.Streams.Stream_Element_Offset) return Boolean;
+
+   --  Retain the CRYPTO range a freshly built packet carries.
+   procedure Retain
+     (Item   : in out Flight;
+      Number : Packet_Number;
+      Offset : Varint_Policy.Value_Type;
+      Data   : Ada.Streams.Stream_Element_Array;
+      Status : out Retain_Status);
+
+   --  Stop retransmitting the range carried by an acknowledged packet.
+   procedure Acknowledge (Item : in out Flight; Number : Packet_Number);
+
+   --  Stop retransmitting every range, for progress that implies delivery of
+   --  the whole flight.
+   procedure Acknowledge_All (Item : in out Flight);
+
+   --  Report whether any retained range still awaits acknowledgment.
+   function Has_Pending (Item : Flight) return Boolean;
+
+   --  Return the lowest-offset pending range, or zero when none remains.
+   function First_Pending (Item : Flight) return Chunk_Count;
+
+   --  Return the pending range after Index, or zero when none remains.
+   function Next_Pending (Item : Flight; Index : Chunk_Index)
+      return Chunk_Count;
+
+   function Offset
+     (Item : Flight; Index : Chunk_Index) return Varint_Policy.Value_Type;
+
+   function Length
+     (Item : Flight; Index : Chunk_Index)
+      return Ada.Streams.Stream_Element_Offset;
+
+   --  Copy one retained range into caller storage.
+   procedure Copy
+     (Item  : Flight;
+      Index : Chunk_Index;
+      Data  : out Ada.Streams.Stream_Element_Array)
+   with Pre => Data'Length >= Length (Item, Index);
+
+   --  Bind a retained range to the packet number that now carries it.
+   procedure Rebind
+     (Item : in out Flight; Index : Chunk_Index; Number : Packet_Number);
+
+private
+   type Chunk is record
+      Occupied : Boolean := False;
+      Pending  : Boolean := False;
+      Number   : Packet_Number := 0;
+      Offset   : Varint_Policy.Value_Type := 0;
+      Length   : Ada.Streams.Stream_Element_Offset := 0;
+   end record;
+
+   type Chunk_Table is array (Chunk_Index) of Chunk;
+
+   type Flight (Capacity : Capacity_Range) is limited record
+      Data   : Ada.Streams.Stream_Element_Array (1 .. Capacity) :=
+        (others => 0);
+      Chunks : Chunk_Table;
+      Count  : Chunk_Count := 0;
+   end record;
+end Flyology.QUIC.Crypto_Flight;

--- a/flyology_quic/src/flyology-quic-handshake_connection.adb
+++ b/flyology_quic/src/flyology-quic-handshake_connection.adb
@@ -8,6 +8,13 @@ package body Flyology.QUIC.Handshake_Connection is
    function Is_Initialized (Item : Connection) return Boolean is
      (Item.Initialized);
 
+   function Encode_ACK
+     (Item      : Connection;
+      ACK_Delay : Varint_Policy.Value_Type)
+      return ACK_Frame_Policy.Encode_Result
+   is
+     (ACK_Frame_Policy.Encode (Item.Receive_State, ACK_Delay));
+
    procedure Initialize
      (Item        : in out Connection;
       Sending     : TLS_Key_Schedule.QUIC_Traffic_Keys;

--- a/flyology_quic/src/flyology-quic-handshake_connection.ads
+++ b/flyology_quic/src/flyology-quic-handshake_connection.ads
@@ -1,9 +1,11 @@
 with Ada.Streams;
+with Flyology.QUIC.ACK_Frame_Policy;
 with Flyology.QUIC.Connection_State_Policy;
 with Flyology.QUIC.Crypto_OpenSSL;
 with Flyology.QUIC.Handshake_Receiver;
 with Flyology.QUIC.Handshake_Sender;
 with Flyology.QUIC.Long_Header_Policy;
+with Flyology.QUIC.Varint_Policy;
 with Flyology.QUIC.TLS_Key_Schedule;
 
 --  Internal connection state for the QUIC Handshake encryption level.
@@ -90,6 +92,12 @@ private package Flyology.QUIC.Handshake_Connection is
      Post =>
        (if Result.Status /= Processed then
            Plaintext = (Plaintext'Range => 0));
+
+   function Encode_ACK
+     (Item      : Connection;
+      ACK_Delay : Varint_Policy.Value_Type)
+      return ACK_Frame_Policy.Encode_Result
+   with Pre => Is_Initialized (Item);
 private
    type Connection is limited record
       Backend     : Crypto_OpenSSL.Provider;

--- a/flyology_quic/src/flyology-quic-handshake_space.adb
+++ b/flyology_quic/src/flyology-quic-handshake_space.adb
@@ -1,17 +1,42 @@
+with Flyology.QUIC.ACK_Frame_Policy;
+with Flyology.QUIC.ACK_Range_Policy;
 with Flyology.QUIC.Crypto_Frame_Policy;
 with Flyology.QUIC.Initial_Frame_Policy;
 
 package body Flyology.QUIC.Handshake_Space is
    use type Ada.Streams.Stream_Element_Offset;
+   use type ACK_Frame_Policy.Encode_Status;
+   use type ACK_Range_Policy.Decode_Status;
    use type Crypto_Frame_Policy.Encode_Status;
    use type Crypto_Reassembly_Policy.Insert_Status;
+   use type Crypto_Flight.Retain_Status;
    use type Handshake_Connection.Build_Status;
    use type Handshake_Connection.Process_Status;
    use type Initial_Frame_Policy.Frame_Kind;
    use type Initial_Frame_Policy.Parse_Status;
+   use type Sent_Packet_Policy.Apply_Status;
+   use type Sent_Packet_Policy.Event_Kind;
+   use type Sent_Packet_Policy.Record_Status;
+   use type Varint_Policy.Value_Type;
+
+   --  One CRYPTO range plus a bounded ACK frame ahead of it.
+   Max_ACK_Prefix : constant := 128;
+   Max_Plaintext  : constant := Max_Crypto_Payload + 17 + Max_ACK_Prefix;
+
+   --  PING followed by PADDING. Header protection samples sixteen octets from
+   --  four bytes past the packet number, so a bare one-octet probe has too
+   --  little protected payload to be sent.
+   Ping_Frame : constant Ada.Streams.Stream_Element_Array (1 .. 8) :=
+     (1 => 16#01#, others => 16#00#);
 
    function Is_Initialized (Item : State) return Boolean is
      (Item.Initialized);
+
+   function Needs_ACK (Item : State) return Boolean is
+     (Item.ACK_Owed);
+
+   function Has_Unacknowledged (Item : State) return Boolean is
+     (Crypto_Flight.Has_Pending (Item.Outgoing) or else Item.Ping_Sent);
 
    function Contiguous_Length
      (Item : State) return Crypto_Reassembly_Policy.Stream_Offset is
@@ -23,6 +48,15 @@ package body Flyology.QUIC.Handshake_Space is
       return Ada.Streams.Stream_Element is
      (Crypto_Reassembly_Policy.Element (Item.Crypto, Index));
 
+   --  The sent-packet ledger keeps QUIC's strictly sequential packet numbers
+   --  and is never reset while the space can still send, so retirement is
+   --  recorded on the retained flight instead.
+   procedure Acknowledge_Flight (Item : in out State) is
+   begin
+      Crypto_Flight.Acknowledge_All (Item.Outgoing);
+      Item.Ping_Sent := False;
+   end Acknowledge_Flight;
+
    procedure Initialize
      (Item        : in out State;
       Sending     : TLS_Key_Schedule.QUIC_Traffic_Keys;
@@ -33,49 +67,259 @@ package body Flyology.QUIC.Handshake_Space is
       Handshake_Connection.Initialize
         (Item.Packets, Sending, Receiving, Destination, Source);
       Crypto_Reassembly_Policy.Reset (Item.Crypto);
+      Sent_Packet_Policy.Reset (Item.Sent);
+      Crypto_Flight.Reset (Item.Outgoing);
+      Item.ACK_Owed := False;
+      Item.Ping_Sent := False;
       Item.Initialized := True;
    end Initialize;
+
+   function Build_Status_For
+     (Status : Handshake_Connection.Build_Status) return Build_Status is
+     (case Status is
+         when Handshake_Connection.Built => Built,
+         when Handshake_Connection.Packet_Number_Exhausted =>
+           Packet_Number_Exhausted,
+         when Handshake_Connection.Packet_Number_Unrepresentable =>
+           Packet_Number_Unrepresentable,
+         when Handshake_Connection.Insufficient_Protected_Payload
+            | Handshake_Connection.Packet_Too_Large => Packet_Too_Large,
+         when Handshake_Connection.Output_Too_Small => Output_Too_Small);
+
+   --  Prefix Frame with an ACK when this space owes one and the combined
+   --  plaintext still fits.
+   procedure Compose
+     (Item     : in out State;
+      Frame    : Ada.Streams.Stream_Element_Array;
+      Data     : out Ada.Streams.Stream_Element_Array;
+      Length   : out Natural;
+      Included : out Boolean)
+   is
+      ACK : ACK_Frame_Policy.Encode_Result;
+   begin
+      Data := (others => 0);
+      Length := 0;
+      Included := False;
+      if Item.ACK_Owed then
+         ACK := Handshake_Connection.Encode_ACK
+           (Item.Packets, ACK_Delay => 0);
+         if ACK.Status = ACK_Frame_Policy.Encoded
+           and then ACK.Length <= Max_ACK_Prefix
+           and then Ada.Streams.Stream_Element_Offset
+             (ACK.Length) + Frame'Length <= Data'Length
+         then
+            Data (Data'First .. Data'First
+                    + Ada.Streams.Stream_Element_Offset (ACK.Length) - 1) :=
+              ACK.Data (1 .. Ada.Streams.Stream_Element_Offset (ACK.Length));
+            Length := ACK.Length;
+            Included := True;
+         end if;
+      end if;
+      if Frame'Length > 0 then
+         Data (Data'First + Ada.Streams.Stream_Element_Offset (Length)
+                 .. Data'First + Ada.Streams.Stream_Element_Offset (Length)
+                      + Frame'Length - 1) := Frame;
+         Length := Length + Natural (Frame'Length);
+      end if;
+   end Compose;
+
+   --  Build one Handshake packet and account for it in the ledger. The caller
+   --  retains or rebinds any CRYPTO range the packet carries.
+   procedure Emit
+     (Item          : in out State;
+      Plaintext     : Ada.Streams.Stream_Element_Array;
+      ACK_Included  : Boolean;
+      ACK_Eliciting : Boolean;
+      Now           : Timestamp;
+      Packet        : out Ada.Streams.Stream_Element_Array;
+      Result        : out Build_Result)
+   is
+      Built_Packet  : Handshake_Connection.Build_Result;
+      Record_Status : Sent_Packet_Policy.Record_Status;
+   begin
+      Result := (others => <>);
+      if ACK_Eliciting
+        and then Sent_Packet_Policy.Retained (Item.Sent) =
+          Sent_Packet_Policy.Max_Sent_Packets
+      then
+         Packet := (others => 0);
+         Result.Status := Recovery_Capacity_Exceeded;
+         return;
+      end if;
+      Handshake_Connection.Build_Handshake
+        (Item.Packets, Plaintext, Packet, Built_Packet);
+      Result.Number := Built_Packet.Number;
+      if Built_Packet.Status /= Handshake_Connection.Built then
+         Result.Status := Build_Status_For (Built_Packet.Status);
+         return;
+      elsif Built_Packet.Packet_Length > Max_Datagram_Length then
+         Result.Status := Packet_Too_Large;
+         return;
+      end if;
+      Result.Status := Built;
+      Result.Packet_Length := Built_Packet.Packet_Length;
+      Sent_Packet_Policy.Record_Sent
+        (Item.Sent,
+         (Number        => Built_Packet.Number,
+          Sent_At       => Now,
+          Bytes         => Sent_Packet_Policy.Packet_Byte_Count
+            (Built_Packet.Packet_Length),
+          ACK_Eliciting => ACK_Eliciting,
+          In_Flight     => ACK_Eliciting),
+         Record_Status);
+      if (ACK_Eliciting and then Record_Status /= Sent_Packet_Policy.Recorded)
+        or else
+          (not ACK_Eliciting
+           and then Record_Status /= Sent_Packet_Policy.Not_Tracked)
+      then
+         Result.Status := Recovery_Capacity_Exceeded;
+         return;
+      end if;
+      if ACK_Included then
+         Item.ACK_Owed := False;
+      end if;
+   end Emit;
 
    procedure Build_Crypto_Packet
      (Item   : in out State;
       Offset : Varint_Policy.Value_Type;
       Data   : Ada.Streams.Stream_Element_Array;
+      Now    : Timestamp;
       Packet : out Ada.Streams.Stream_Element_Array;
       Result : out Build_Result)
    is
       Frame : constant Crypto_Frame_Policy.Encode_Result :=
         Crypto_Frame_Policy.Encode (Offset, Data);
-      Built : Handshake_Connection.Build_Result;
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+      Retained  : Crypto_Flight.Retain_Status;
    begin
       Packet := (others => 0);
       Result := (others => <>);
       if Frame.Status /= Crypto_Frame_Policy.Encoded then
          Result.Status := Crypto_Range_Too_Large;
          return;
-      end if;
-      Handshake_Connection.Build_Handshake
-        (Item.Packets,
-         Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
-         Packet, Built);
-      if Built.Status = Handshake_Connection.Built
-        and then Built.Packet_Length <= Max_Datagram_Length
+      elsif not Crypto_Flight.Can_Retain
+        (Item.Outgoing, Offset, Data'Length)
       then
-         Result.Status := Handshake_Space.Built;
-         Result.Packet_Length := Built.Packet_Length;
-      else
-         Result.Status :=
-           (case Built.Status is
-               when Handshake_Connection.Built => Packet_Too_Large,
-               when Handshake_Connection.Packet_Number_Exhausted =>
-                 Packet_Number_Exhausted,
-               when Handshake_Connection.Packet_Number_Unrepresentable =>
-                 Packet_Number_Unrepresentable,
-               when Handshake_Connection.Insufficient_Protected_Payload =>
-                 Packet_Too_Large,
-               when Handshake_Connection.Packet_Too_Large => Packet_Too_Large,
-               when Handshake_Connection.Output_Too_Small => Output_Too_Small);
+         --  Refuse before sending. A packet whose CRYPTO range cannot be
+         --  retained could never be retransmitted on a probe timeout.
+         Result.Status := Crypto_Retention_Exceeded;
+         return;
       end if;
+      Compose
+        (Item,
+         Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
+         Plaintext, Length, Included);
+      Emit
+        (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+         Included, ACK_Eliciting => True, Now => Now, Packet => Packet,
+         Result => Result);
+      if Result.Status /= Built then
+         return;
+      end if;
+      Crypto_Flight.Retain
+        (Item.Outgoing, Result.Number, Offset, Data, Retained);
+      pragma Assert (Retained = Crypto_Flight.Retained);
    end Build_Crypto_Packet;
+
+   procedure Build_ACK_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   is
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+   begin
+      Packet := (others => 0);
+      Result := (others => <>);
+      Compose (Item, (1 .. 0 => 0), Plaintext, Length, Included);
+      if not Included then
+         Result.Status := Nothing_To_ACK;
+         return;
+      end if;
+      Emit
+        (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+         Included, ACK_Eliciting => False, Now => Now, Packet => Packet,
+         Result => Result);
+   end Build_ACK_Packet;
+
+   procedure Build_Probe_Packet
+     (Item   : in out State;
+      Index  : Positive;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   is
+      Chunk     : Crypto_Flight.Chunk_Count :=
+        Crypto_Flight.First_Pending (Item.Outgoing);
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+   begin
+      Packet := (others => 0);
+      Result := (others => <>);
+      for Skipped in 2 .. Index loop
+         exit when Chunk = 0;
+         Chunk := Crypto_Flight.Next_Pending (Item.Outgoing, Chunk);
+      end loop;
+
+      if Chunk = 0 then
+         Result.Status := Nothing_To_ACK;
+         return;
+      end if;
+
+      declare
+         Size : constant Ada.Streams.Stream_Element_Offset :=
+           Crypto_Flight.Length (Item.Outgoing, Chunk);
+         Data : Ada.Streams.Stream_Element_Array (1 .. Size);
+         Frame : Crypto_Frame_Policy.Encode_Result;
+      begin
+         Crypto_Flight.Copy (Item.Outgoing, Chunk, Data);
+         Frame := Crypto_Frame_Policy.Encode
+           (Crypto_Flight.Offset (Item.Outgoing, Chunk), Data);
+         if Frame.Status /= Crypto_Frame_Policy.Encoded then
+            Result.Status := Crypto_Range_Too_Large;
+            return;
+         end if;
+         Compose
+           (Item,
+            Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
+            Plaintext, Length, Included);
+         Emit
+           (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+            Included, ACK_Eliciting => True, Now => Now, Packet => Packet,
+            Result => Result);
+         if Result.Status = Built then
+            Crypto_Flight.Rebind (Item.Outgoing, Chunk, Result.Number);
+         end if;
+      end;
+   end Build_Probe_Packet;
+
+   procedure Build_Ping_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   is
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+   begin
+      Packet := (others => 0);
+      Result := (others => <>);
+      Compose (Item, Ping_Frame, Plaintext, Length, Included);
+      Emit
+        (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+         Included, ACK_Eliciting => True, Now => Now, Packet => Packet,
+         Result => Result);
+      if Result.Status = Built then
+         Item.Ping_Sent := True;
+      end if;
+   end Build_Ping_Packet;
 
    procedure Build_Transport_Close_Packet
      (Item       : in out State;
@@ -86,37 +330,97 @@ package body Flyology.QUIC.Handshake_Space is
    is
       Frame : constant Initial_Frame_Policy.Transport_Close_Encode_Result :=
         Initial_Frame_Policy.Encode_Transport_Close (Error_Code, Frame_Type);
-      Built : Handshake_Connection.Build_Result;
+      Built_Packet  : Handshake_Connection.Build_Result;
+      Record_Status : Sent_Packet_Policy.Record_Status;
    begin
       Packet := (others => 0);
       Result := (others => <>);
       Handshake_Connection.Build_Handshake
         (Item.Packets,
          Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
-         Packet, Built);
-      if Built.Status = Handshake_Connection.Built
-        and then Built.Packet_Length <= Max_Datagram_Length
+         Packet, Built_Packet);
+      Result.Number := Built_Packet.Number;
+      if Built_Packet.Status = Handshake_Connection.Built
+        and then Built_Packet.Packet_Length <= Max_Datagram_Length
       then
-         Result.Status := Handshake_Space.Built;
-         Result.Packet_Length := Built.Packet_Length;
+         Result.Status := Built;
+         Result.Packet_Length := Built_Packet.Packet_Length;
+         Sent_Packet_Policy.Record_Sent
+           (Item.Sent,
+            (Number        => Built_Packet.Number,
+             Sent_At       => 0,
+             Bytes         => Sent_Packet_Policy.Packet_Byte_Count
+               (Built_Packet.Packet_Length),
+             ACK_Eliciting => False,
+             In_Flight     => False),
+            Record_Status);
+      elsif Built_Packet.Status = Handshake_Connection.Built then
+         Result.Status := Packet_Too_Large;
       else
-         Result.Status :=
-           (case Built.Status is
-               when Handshake_Connection.Built => Packet_Too_Large,
-               when Handshake_Connection.Packet_Number_Exhausted =>
-                 Packet_Number_Exhausted,
-               when Handshake_Connection.Packet_Number_Unrepresentable =>
-                 Packet_Number_Unrepresentable,
-               when Handshake_Connection.Insufficient_Protected_Payload
-                  | Handshake_Connection.Packet_Too_Large => Packet_Too_Large,
-               when Handshake_Connection.Output_Too_Small => Output_Too_Small);
+         Result.Status := Build_Status_For (Built_Packet.Status);
       end if;
    end Build_Transport_Close_Packet;
 
+   --  Apply one peer ACK frame to the ledger and the retained flight.
+   procedure Apply_Peer_ACK
+     (Item       : in out State;
+      Plaintext  : Ada.Streams.Stream_Element_Array;
+      Frame      : Initial_Frame_Policy.Parse_Result;
+      Now        : Timestamp;
+      Loss_Delay : Timestamp;
+      Result     : in out Process_Result;
+      Rejected   : out Boolean)
+   is
+      Ranges  : ACK_Range_Policy.Decode_Result;
+      Applied : Sent_Packet_Policy.Apply_Result;
+   begin
+      Rejected := True;
+      Ranges := ACK_Range_Policy.Decode (Plaintext, Frame);
+      if Ranges.Status /= ACK_Range_Policy.Decoded then
+         Result.Status :=
+           (case Ranges.Status is
+               when ACK_Range_Policy.Too_Many_Ranges =>
+                 ACK_Range_Capacity_Exceeded,
+               when ACK_Range_Policy.Truncated => Frame_Truncated,
+               when ACK_Range_Policy.Invalid_Range => Invalid_ACK_Range,
+               when ACK_Range_Policy.Decoded => Processed);
+         return;
+      end if;
+      Sent_Packet_Policy.Apply_ACK
+        (Item.Sent, Ranges, Now, Loss_Delay, Applied);
+      if Applied.Status = Sent_Packet_Policy.Acknowledges_Unsent_Packet then
+         Result.Status := Acknowledges_Unsent_Packet;
+         return;
+      end if;
+      Rejected := False;
+      Result.Resolved := Applied;
+      for Index in 1 .. Applied.Count loop
+         if Applied.Events (Index).Kind = Sent_Packet_Policy.Acknowledged then
+            Crypto_Flight.Acknowledge
+              (Item.Outgoing, Applied.Events (Index).Packet.Number);
+            if Applied.Events (Index).Packet.ACK_Eliciting then
+               Result.ACKed_Eliciting := True;
+               Item.Ping_Sent := False;
+               if not Result.Has_Sample
+                 and then Applied.Events (Index).Packet.Number =
+                   Packet_Number (Frame.Largest_Acknowledged)
+                 and then Now >= Applied.Events (Index).Packet.Sent_At
+               then
+                  Result.Has_Sample := True;
+                  Result.Sample :=
+                    Now - Applied.Events (Index).Packet.Sent_At;
+               end if;
+            end if;
+         end if;
+      end loop;
+   end Apply_Peer_ACK;
+
    procedure Process_Packet
-     (Item   : in out State;
-      Packet : Ada.Streams.Stream_Element_Array;
-      Result : out Process_Result)
+     (Item       : in out State;
+      Packet     : Ada.Streams.Stream_Element_Array;
+      Now        : Timestamp;
+      Loss_Delay : Timestamp;
+      Result     : out Process_Result)
    is
       Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Datagram_Length);
       Received  : Handshake_Connection.Process_Result;
@@ -124,6 +428,7 @@ package body Flyology.QUIC.Handshake_Space is
       Cursor    : Initial_Frame_Policy.Frame_Offset := 0;
       Frame     : Initial_Frame_Policy.Parse_Result;
       Inserted  : Crypto_Reassembly_Policy.Insert_Status;
+      Rejected  : Boolean;
    begin
       Result := (others => <>);
       Handshake_Connection.Process_Handshake
@@ -163,7 +468,19 @@ package body Flyology.QUIC.Handshake_Space is
             return;
          end if;
          Result.Frame_Count := Result.Frame_Count + 1;
-         if Frame.Kind = Initial_Frame_Policy.Crypto then
+         if Frame.Kind in Initial_Frame_Policy.Ping
+           | Initial_Frame_Policy.Crypto
+         then
+            Result.ACK_Eliciting := True;
+         end if;
+         if Frame.Kind = Initial_Frame_Policy.Acknowledgment then
+            Apply_Peer_ACK
+              (Item, Plaintext (1 .. Length), Frame, Now, Loss_Delay, Result,
+               Rejected);
+            if Rejected then
+               return;
+            end if;
+         elsif Frame.Kind = Initial_Frame_Policy.Crypto then
             if Frame.Crypto_Length = 0 then
                Crypto_Reassembly_Policy.Insert
                  (Item.Crypto, Frame.Crypto_Offset,
@@ -194,6 +511,9 @@ package body Flyology.QUIC.Handshake_Space is
          end if;
          Cursor := Cursor + Frame.Consumed;
       end loop;
+      if Result.ACK_Eliciting then
+         Item.ACK_Owed := True;
+      end if;
       Result.Status := Processed;
    end Process_Packet;
 end Flyology.QUIC.Handshake_Space;

--- a/flyology_quic/src/flyology-quic-handshake_space.ads
+++ b/flyology_quic/src/flyology-quic-handshake_space.ads
@@ -1,7 +1,9 @@
 with Ada.Streams;
+with Flyology.QUIC.Crypto_Flight;
 with Flyology.QUIC.Crypto_Reassembly_Policy;
 with Flyology.QUIC.Handshake_Connection;
 with Flyology.QUIC.Long_Header_Policy;
+with Flyology.QUIC.Sent_Packet_Policy;
 with Flyology.QUIC.TLS_Key_Schedule;
 with Flyology.QUIC.Varint_Policy;
 
@@ -9,11 +11,25 @@ with Flyology.QUIC.Varint_Policy;
 --  stream. A caller fragments a TLS flight into bounded payloads and may feed
 --  received datagrams in any order; only contiguous authenticated bytes are
 --  exposed to TLS.
+--
+--  The space also owns the RFC 9002 sent-packet ledger for the Handshake
+--  packet-number space. Sent CRYPTO ranges are retained until a peer ACK or
+--  handshake progress retires them, so a probe timeout can retransmit them
+--  under a fresh packet number. RTT estimation and probe-timeout backoff are
+--  path-wide and remain with the caller.
 private package Flyology.QUIC.Handshake_Space is
    use type Ada.Streams.Stream_Element_Offset;
 
    Max_Datagram_Length : constant := 1_350;
    Max_Crypto_Payload  : constant := 1_100;
+
+   --  Retained outgoing CRYPTO octets. The largest flight is a server's
+   --  EncryptedExtensions through Finished, bounded by the TLS session's
+   --  18,000-octet authentication limit.
+   Max_Retained_Crypto : constant := 18_432;
+
+   subtype Packet_Number is Sent_Packet_Policy.Packet_Number;
+   subtype Timestamp is Sent_Packet_Policy.Timestamp;
 
    type State is limited private;
 
@@ -35,7 +51,10 @@ private package Flyology.QUIC.Handshake_Space is
 
    type Build_Status is
      (Built,
+      Nothing_To_ACK,
       Crypto_Range_Too_Large,
+      Crypto_Retention_Exceeded,
+      Recovery_Capacity_Exceeded,
       Packet_Number_Exhausted,
       Packet_Number_Unrepresentable,
       Packet_Too_Large,
@@ -43,13 +62,18 @@ private package Flyology.QUIC.Handshake_Space is
 
    type Build_Result is record
       Status        : Build_Status := Output_Too_Small;
+      Number        : Packet_Number := 0;
       Packet_Length : Natural range 0 .. Max_Datagram_Length := 0;
    end record;
 
+   --  Build a protected Handshake packet carrying one CRYPTO range, preceded
+   --  by an ACK for anything this space still owes the peer.
+   --  @param Now Monotonic microsecond timestamp for recovery accounting
    procedure Build_Crypto_Packet
      (Item   : in out State;
       Offset : Varint_Policy.Value_Type;
       Data   : Ada.Streams.Stream_Element_Array;
+      Now    : Timestamp;
       Packet : out Ada.Streams.Stream_Element_Array;
       Result : out Build_Result)
    with
@@ -57,12 +81,38 @@ private package Flyology.QUIC.Handshake_Space is
        and then Data'Length <= Max_Crypto_Payload
        and then Packet'Length >= Max_Datagram_Length;
 
-   procedure Build_Transport_Close_Packet
-     (Item       : in out State;
-      Error_Code : Varint_Policy.Value_Type;
-      Frame_Type : Varint_Policy.Value_Type;
-      Packet     : out Ada.Streams.Stream_Element_Array;
-      Result     : out Build_Result)
+   --  Build an ACK-only Handshake packet. The packet is not ack-eliciting and
+   --  does not arm the probe timer.
+   procedure Build_ACK_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   with
+     Pre => Is_Initialized (Item)
+       and then Packet'Length >= Max_Datagram_Length;
+
+   --  Retransmit one retained CRYPTO range under a fresh packet number. Index
+   --  selects among the ranges still awaiting acknowledgment, in offset order,
+   --  and Nothing_To_ACK reports that no such range exists.
+   procedure Build_Probe_Packet
+     (Item   : in out State;
+      Index  : Positive;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   with
+     Pre => Is_Initialized (Item)
+       and then Packet'Length >= Max_Datagram_Length;
+
+   --  Build an ack-eliciting PING. RFC 9002 section 6.2.2.1 requires this
+   --  anti-deadlock probe when a probe timeout expires with no unacknowledged
+   --  CRYPTO data left to retransmit.
+   procedure Build_Ping_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
    with
      Pre => Is_Initialized (Item)
        and then Packet'Length >= Max_Datagram_Length;
@@ -78,23 +128,59 @@ private package Flyology.QUIC.Handshake_Space is
       Frame_Not_Allowed,
       Frame_Value_Too_Large,
       Invalid_ACK_Range,
+      ACK_Range_Capacity_Exceeded,
+      Acknowledges_Unsent_Packet,
       Conflicting_Crypto_Data,
       Crypto_Data_Too_Large);
 
    type Process_Result is record
-      Status      : Process_Status := Envelope_Rejected;
-      Frame_Count : Natural := 0;
-      Peer_Closed : Boolean := False;
-      Close_Error : Varint_Policy.Value_Type := 0;
+      Status        : Process_Status := Envelope_Rejected;
+      Frame_Count   : Natural := 0;
+      Peer_Closed   : Boolean := False;
+      Close_Error   : Varint_Policy.Value_Type := 0;
+      --  The packet must be acknowledged.
+      ACK_Eliciting : Boolean := False;
+      --  Packets this space resolved from the peer's ACK frames.
+      Resolved      : Sent_Packet_Policy.Apply_Result;
+      --  An ACK-eliciting packet of ours was newly acknowledged.
+      ACKed_Eliciting : Boolean := False;
+      --  A usable RTT sample was produced by the newest acknowledgment.
+      Has_Sample    : Boolean := False;
+      Sample        : Timestamp := 0;
    end record;
 
+   --  Process one protected Handshake packet.
+   --  @param Now Monotonic microsecond timestamp for recovery accounting
+   --  @param Loss_Delay Path loss-detection delay from RTT estimation
    procedure Process_Packet
-     (Item   : in out State;
-      Packet : Ada.Streams.Stream_Element_Array;
-      Result : out Process_Result)
+     (Item       : in out State;
+      Packet     : Ada.Streams.Stream_Element_Array;
+      Now        : Timestamp;
+      Loss_Delay : Timestamp;
+      Result     : out Process_Result)
    with
      Pre => Is_Initialized (Item)
        and then Packet'Length <= Max_Datagram_Length;
+
+   --  Report whether an ACK-eliciting packet of ours is still unacknowledged.
+   function Has_Unacknowledged (Item : State) return Boolean;
+
+   --  Report whether this space owes the peer an acknowledgment.
+   function Needs_ACK (Item : State) return Boolean;
+
+   --  Retire every retained CRYPTO range after progress that could only
+   --  follow its delivery.
+   procedure Acknowledge_Flight (Item : in out State);
+
+   procedure Build_Transport_Close_Packet
+     (Item       : in out State;
+      Error_Code : Varint_Policy.Value_Type;
+      Frame_Type : Varint_Policy.Value_Type;
+      Packet     : out Ada.Streams.Stream_Element_Array;
+      Result     : out Build_Result)
+   with
+     Pre => Is_Initialized (Item)
+       and then Packet'Length >= Max_Datagram_Length;
 
    function Contiguous_Length
      (Item : State) return Crypto_Reassembly_Policy.Stream_Offset;
@@ -109,6 +195,10 @@ private
    type State is limited record
       Packets     : Handshake_Connection.Connection;
       Crypto      : Crypto_Reassembly_Policy.Reassembly_State;
+      Sent        : Sent_Packet_Policy.Ledger;
+      Outgoing    : Crypto_Flight.Flight (Max_Retained_Crypto);
+      ACK_Owed    : Boolean := False;
+      Ping_Sent   : Boolean := False;
       Initialized : Boolean := False;
    end record;
 end Flyology.QUIC.Handshake_Space;

--- a/flyology_quic/src/flyology-quic-initial_connection.adb
+++ b/flyology_quic/src/flyology-quic-initial_connection.adb
@@ -9,6 +9,13 @@ package body Flyology.QUIC.Initial_Connection is
    function Is_Initialized (Item : Connection) return Boolean is
      (Item.Initialized);
 
+   function Encode_ACK
+     (Item      : Connection;
+      ACK_Delay : Varint_Policy.Value_Type)
+      return ACK_Frame_Policy.Encode_Result
+   is
+     (ACK_Frame_Policy.Encode (Item.Receive_State, ACK_Delay));
+
    procedure Initialize
      (Item                    : in out Connection;
       Role                    : Endpoint_Role;

--- a/flyology_quic/src/flyology-quic-initial_connection.ads
+++ b/flyology_quic/src/flyology-quic-initial_connection.ads
@@ -1,9 +1,11 @@
 with Ada.Streams;
+with Flyology.QUIC.ACK_Frame_Policy;
 with Flyology.QUIC.Connection_State_Policy;
 with Flyology.QUIC.Crypto_OpenSSL;
 with Flyology.QUIC.Initial_Receiver;
 with Flyology.QUIC.Initial_Sender;
 with Flyology.QUIC.Long_Header_Policy;
+with Flyology.QUIC.Varint_Policy;
 
 --  Internal client/server state for the QUIC Initial encryption level.
 --
@@ -110,6 +112,12 @@ private package Flyology.QUIC.Initial_Connection is
      Post =>
        (if Result.Status /= Processed then
            Plaintext = (Plaintext'Range => 0));
+
+   function Encode_ACK
+     (Item      : Connection;
+      ACK_Delay : Varint_Policy.Value_Type)
+      return ACK_Frame_Policy.Encode_Result
+   with Pre => Is_Initialized (Item);
 private
    type Connection is limited record
       Backend : Crypto_OpenSSL.Provider;

--- a/flyology_quic/src/flyology-quic-initial_space.adb
+++ b/flyology_quic/src/flyology-quic-initial_space.adb
@@ -1,18 +1,44 @@
+with Flyology.QUIC.ACK_Frame_Policy;
+with Flyology.QUIC.ACK_Range_Policy;
 with Flyology.QUIC.Crypto_Frame_Policy;
 with Flyology.QUIC.Initial_Frame_Policy;
 
 package body Flyology.QUIC.Initial_Space is
    use type Ada.Streams.Stream_Element_Offset;
+   use type ACK_Frame_Policy.Encode_Status;
+   use type ACK_Range_Policy.Decode_Status;
    use type Crypto_Frame_Policy.Encode_Status;
    use type Crypto_Reassembly_Policy.Insert_Status;
+   use type Crypto_Flight.Retain_Status;
    use type Initial_Connection.Build_Status;
    use type Initial_Connection.Endpoint_Role;
    use type Initial_Connection.Process_Status;
    use type Initial_Frame_Policy.Frame_Kind;
    use type Initial_Frame_Policy.Parse_Status;
+   use type Sent_Packet_Policy.Apply_Status;
+   use type Sent_Packet_Policy.Event_Kind;
+   use type Sent_Packet_Policy.Record_Status;
+   use type Varint_Policy.Value_Type;
+
+   --  One CRYPTO range plus a bounded ACK frame ahead of it.
+   Max_ACK_Prefix : constant := 128;
+   Max_Plaintext  : constant :=
+     Max_Crypto_Payload + 17 + Max_ACK_Prefix;
+
+   --  PING followed by PADDING. Header protection samples sixteen octets from
+   --  four bytes past the packet number, so a bare one-octet probe has too
+   --  little protected payload to be sent.
+   Ping_Frame : constant Ada.Streams.Stream_Element_Array (1 .. 8) :=
+     (1 => 16#01#, others => 16#00#);
 
    function Is_Initialized (Item : State) return Boolean is
      (Item.Initialized);
+
+   function Needs_ACK (Item : State) return Boolean is
+     (Item.ACK_Owed);
+
+   function Has_Unacknowledged (Item : State) return Boolean is
+     (Crypto_Flight.Has_Pending (Item.Outgoing) or else Item.Ping_Sent);
 
    function Contiguous_Length
      (Item : State) return Crypto_Reassembly_Policy.Stream_Offset is
@@ -24,6 +50,15 @@ package body Flyology.QUIC.Initial_Space is
       return Ada.Streams.Stream_Element is
      (Crypto_Reassembly_Policy.Element (Item.Crypto, Index));
 
+   --  The sent-packet ledger keeps QUIC's strictly sequential packet numbers
+   --  and is never reset while the space can still send, so retirement is
+   --  recorded on the retained flight instead.
+   procedure Acknowledge_Flight (Item : in out State) is
+   begin
+      Crypto_Flight.Acknowledge_All (Item.Outgoing);
+      Item.Ping_Sent := False;
+   end Acknowledge_Flight;
+
    procedure Initialize
      (Item                    : in out State;
       Role                    : Initial_Connection.Endpoint_Role;
@@ -34,49 +69,258 @@ package body Flyology.QUIC.Initial_Space is
       Initial_Connection.Initialize
         (Item.Packets, Role, Original_Destination_ID, Destination, Source);
       Crypto_Reassembly_Policy.Reset (Item.Crypto);
+      Sent_Packet_Policy.Reset (Item.Sent);
+      Crypto_Flight.Reset (Item.Outgoing);
+      Item.ACK_Owed := False;
+      Item.Ping_Sent := False;
       Item.Role := Role;
       Item.Initialized := True;
    end Initialize;
 
+   function Build_Status_For
+     (Status : Initial_Connection.Build_Status) return Build_Status is
+     (case Status is
+         when Initial_Connection.Built => Built,
+         when Initial_Connection.Packet_Number_Exhausted =>
+           Packet_Number_Exhausted,
+         when Initial_Connection.Packet_Number_Unrepresentable =>
+           Packet_Number_Unrepresentable,
+         when Initial_Connection.Insufficient_Protected_Payload
+            | Initial_Connection.Packet_Too_Large => Packet_Too_Large,
+         when Initial_Connection.Output_Too_Small => Output_Too_Small);
+
+   --  Prefix Frame with an ACK when this space owes one and the combined
+   --  plaintext still fits.
+   procedure Compose
+     (Item     : in out State;
+      Frame    : Ada.Streams.Stream_Element_Array;
+      Data     : out Ada.Streams.Stream_Element_Array;
+      Length   : out Natural;
+      Included : out Boolean)
+   is
+      ACK : ACK_Frame_Policy.Encode_Result;
+   begin
+      Data := (others => 0);
+      Length := 0;
+      Included := False;
+      if Item.ACK_Owed then
+         ACK := Initial_Connection.Encode_ACK (Item.Packets, ACK_Delay => 0);
+         if ACK.Status = ACK_Frame_Policy.Encoded
+           and then ACK.Length <= Max_ACK_Prefix
+           and then Ada.Streams.Stream_Element_Offset
+             (ACK.Length) + Frame'Length <= Data'Length
+         then
+            Data (Data'First .. Data'First
+                    + Ada.Streams.Stream_Element_Offset (ACK.Length) - 1) :=
+              ACK.Data (1 .. Ada.Streams.Stream_Element_Offset (ACK.Length));
+            Length := ACK.Length;
+            Included := True;
+         end if;
+      end if;
+      if Frame'Length > 0 then
+         Data (Data'First + Ada.Streams.Stream_Element_Offset (Length)
+                 .. Data'First + Ada.Streams.Stream_Element_Offset (Length)
+                      + Frame'Length - 1) := Frame;
+         Length := Length + Natural (Frame'Length);
+      end if;
+   end Compose;
+
+   --  Build one ack-eliciting Initial and account for it in the ledger. The
+   --  caller retains or rebinds any CRYPTO range the packet carries.
+   procedure Emit
+     (Item          : in out State;
+      Plaintext     : Ada.Streams.Stream_Element_Array;
+      ACK_Included  : Boolean;
+      ACK_Eliciting : Boolean;
+      Now           : Timestamp;
+      Packet        : out Ada.Streams.Stream_Element_Array;
+      Result        : out Build_Result)
+   is
+      Built_Packet  : Initial_Connection.Build_Result;
+      Record_Status : Sent_Packet_Policy.Record_Status;
+      Minimum : constant Natural :=
+        (if Item.Role = Initial_Connection.Client then 1_200 else 0);
+   begin
+      Result := (others => <>);
+      if ACK_Eliciting
+        and then Sent_Packet_Policy.Retained (Item.Sent) =
+          Sent_Packet_Policy.Max_Sent_Packets
+      then
+         Packet := (others => 0);
+         Result.Status := Recovery_Capacity_Exceeded;
+         return;
+      end if;
+      Initial_Connection.Build_Initial_At_Least
+        (Item.Packets, (1 .. 0 => 0), Plaintext, Minimum, Packet,
+         Built_Packet);
+      Result.Number := Built_Packet.Number;
+      Result.Status := Build_Status_For (Built_Packet.Status);
+      if Built_Packet.Status /= Initial_Connection.Built then
+         return;
+      end if;
+      Result.Packet_Length := Built_Packet.Packet_Length;
+      Sent_Packet_Policy.Record_Sent
+        (Item.Sent,
+         (Number        => Built_Packet.Number,
+          Sent_At       => Now,
+          Bytes         => Sent_Packet_Policy.Packet_Byte_Count
+            (Built_Packet.Packet_Length),
+          ACK_Eliciting => ACK_Eliciting,
+          In_Flight     => ACK_Eliciting),
+         Record_Status);
+      if (ACK_Eliciting and then Record_Status /= Sent_Packet_Policy.Recorded)
+        or else
+          (not ACK_Eliciting
+           and then Record_Status /= Sent_Packet_Policy.Not_Tracked)
+      then
+         Result.Status := Recovery_Capacity_Exceeded;
+         return;
+      end if;
+      if ACK_Included then
+         Item.ACK_Owed := False;
+      end if;
+   end Emit;
+
    procedure Build_Crypto_Packet
      (Item   : in out State;
-      Token  : Ada.Streams.Stream_Element_Array;
       Offset : Varint_Policy.Value_Type;
       Data   : Ada.Streams.Stream_Element_Array;
+      Now    : Timestamp;
       Packet : out Ada.Streams.Stream_Element_Array;
       Result : out Build_Result)
    is
       Frame : constant Crypto_Frame_Policy.Encode_Result :=
         Crypto_Frame_Policy.Encode (Offset, Data);
-      Built_Packet : Initial_Connection.Build_Result;
-      Minimum : constant Natural :=
-        (if Item.Role = Initial_Connection.Client
-         then 1_200 else 0);
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+      Retained  : Crypto_Flight.Retain_Status;
    begin
       Packet := (others => 0);
       Result := (others => <>);
       if Frame.Status /= Crypto_Frame_Policy.Encoded then
          Result.Status := Crypto_Range_Too_Large;
          return;
+      elsif not Crypto_Flight.Can_Retain
+        (Item.Outgoing, Offset, Data'Length)
+      then
+         --  Refuse before sending. A packet whose CRYPTO range cannot be
+         --  retained could never be retransmitted on a probe timeout.
+         Result.Status := Crypto_Retention_Exceeded;
+         return;
       end if;
-      Initial_Connection.Build_Initial_At_Least
-        (Item.Packets, Token,
+      Compose
+        (Item,
          Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
-         Minimum, Packet, Built_Packet);
-      Result.Status :=
-        (case Built_Packet.Status is
-            when Initial_Connection.Built => Built,
-            when Initial_Connection.Packet_Number_Exhausted =>
-              Packet_Number_Exhausted,
-            when Initial_Connection.Packet_Number_Unrepresentable =>
-              Packet_Number_Unrepresentable,
-            when Initial_Connection.Insufficient_Protected_Payload
-               | Initial_Connection.Packet_Too_Large => Packet_Too_Large,
-            when Initial_Connection.Output_Too_Small => Output_Too_Small);
-      if Built_Packet.Status = Initial_Connection.Built then
-         Result.Packet_Length := Built_Packet.Packet_Length;
+         Plaintext, Length, Included);
+      Emit
+        (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+         Included, ACK_Eliciting => True, Now => Now, Packet => Packet,
+         Result => Result);
+      if Result.Status /= Built then
+         return;
       end if;
+      Crypto_Flight.Retain
+        (Item.Outgoing, Result.Number, Offset, Data, Retained);
+      pragma Assert (Retained = Crypto_Flight.Retained);
    end Build_Crypto_Packet;
+
+   procedure Build_ACK_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   is
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+   begin
+      Packet := (others => 0);
+      Result := (others => <>);
+      Compose (Item, (1 .. 0 => 0), Plaintext, Length, Included);
+      if not Included then
+         Result.Status := Nothing_To_ACK;
+         return;
+      end if;
+      Emit
+        (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+         Included, ACK_Eliciting => False, Now => Now, Packet => Packet,
+         Result => Result);
+   end Build_ACK_Packet;
+
+   procedure Build_Probe_Packet
+     (Item   : in out State;
+      Index  : Positive;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   is
+      Chunk     : Crypto_Flight.Chunk_Count :=
+        Crypto_Flight.First_Pending (Item.Outgoing);
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+   begin
+      Packet := (others => 0);
+      Result := (others => <>);
+      for Skipped in 2 .. Index loop
+         exit when Chunk = 0;
+         Chunk := Crypto_Flight.Next_Pending (Item.Outgoing, Chunk);
+      end loop;
+
+      if Chunk = 0 then
+         Result.Status := Nothing_To_ACK;
+         return;
+      end if;
+
+      declare
+         Size : constant Ada.Streams.Stream_Element_Offset :=
+           Crypto_Flight.Length (Item.Outgoing, Chunk);
+         Data : Ada.Streams.Stream_Element_Array (1 .. Size);
+         Frame : Crypto_Frame_Policy.Encode_Result;
+      begin
+         Crypto_Flight.Copy (Item.Outgoing, Chunk, Data);
+         Frame := Crypto_Frame_Policy.Encode
+           (Crypto_Flight.Offset (Item.Outgoing, Chunk), Data);
+         if Frame.Status /= Crypto_Frame_Policy.Encoded then
+            Result.Status := Crypto_Range_Too_Large;
+            return;
+         end if;
+         Compose
+           (Item,
+            Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
+            Plaintext, Length, Included);
+         Emit
+           (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+            Included, ACK_Eliciting => True, Now => Now, Packet => Packet,
+            Result => Result);
+         if Result.Status = Built then
+            Crypto_Flight.Rebind (Item.Outgoing, Chunk, Result.Number);
+         end if;
+      end;
+   end Build_Probe_Packet;
+
+   procedure Build_Ping_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   is
+      Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Plaintext);
+      Length    : Natural;
+      Included  : Boolean;
+   begin
+      Packet := (others => 0);
+      Result := (others => <>);
+      Compose (Item, Ping_Frame, Plaintext, Length, Included);
+      Emit
+        (Item, Plaintext (1 .. Ada.Streams.Stream_Element_Offset (Length)),
+         Included, ACK_Eliciting => True, Now => Now, Packet => Packet,
+         Result => Result);
+      if Result.Status = Built then
+         Item.Ping_Sent := True;
+      end if;
+   end Build_Ping_Packet;
 
    procedure Build_Transport_Close_Packet
      (Item       : in out State;
@@ -87,7 +331,8 @@ package body Flyology.QUIC.Initial_Space is
    is
       Frame : constant Initial_Frame_Policy.Transport_Close_Encode_Result :=
         Initial_Frame_Policy.Encode_Transport_Close (Error_Code, Frame_Type);
-      Built : Initial_Connection.Build_Result;
+      Built_Packet  : Initial_Connection.Build_Result;
+      Record_Status : Sent_Packet_Policy.Record_Status;
       --  RFC 9000 14.1 has a server discard any client Initial packet whose
       --  datagram payload is under 1,200 bytes, closes included.
       Minimum : constant Natural :=
@@ -99,26 +344,84 @@ package body Flyology.QUIC.Initial_Space is
       Initial_Connection.Build_Initial_At_Least
         (Item.Packets, (1 .. 0 => 0),
          Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
-         Minimum_Packet_Length => Minimum, Packet => Packet, Result => Built);
-      Result.Status :=
-        (case Built.Status is
-            when Initial_Connection.Built => Initial_Space.Built,
-            when Initial_Connection.Packet_Number_Exhausted =>
-              Packet_Number_Exhausted,
-            when Initial_Connection.Packet_Number_Unrepresentable =>
-              Packet_Number_Unrepresentable,
-            when Initial_Connection.Insufficient_Protected_Payload
-               | Initial_Connection.Packet_Too_Large => Packet_Too_Large,
-            when Initial_Connection.Output_Too_Small => Output_Too_Small);
-      if Built.Status = Initial_Connection.Built then
-         Result.Packet_Length := Built.Packet_Length;
+         Minimum_Packet_Length => Minimum, Packet => Packet,
+         Result => Built_Packet);
+      Result.Number := Built_Packet.Number;
+      Result.Status := Build_Status_For (Built_Packet.Status);
+      if Built_Packet.Status = Initial_Connection.Built then
+         Result.Packet_Length := Built_Packet.Packet_Length;
+         Sent_Packet_Policy.Record_Sent
+           (Item.Sent,
+            (Number        => Built_Packet.Number,
+             Sent_At       => 0,
+             Bytes         => Sent_Packet_Policy.Packet_Byte_Count
+               (Built_Packet.Packet_Length),
+             ACK_Eliciting => False,
+             In_Flight     => False),
+            Record_Status);
       end if;
    end Build_Transport_Close_Packet;
 
+   --  Apply one peer ACK frame to the ledger and the retained flight.
+   procedure Apply_Peer_ACK
+     (Item       : in out State;
+      Plaintext  : Ada.Streams.Stream_Element_Array;
+      Frame      : Initial_Frame_Policy.Parse_Result;
+      Now        : Timestamp;
+      Loss_Delay : Timestamp;
+      Result     : in out Process_Result;
+      Rejected   : out Boolean)
+   is
+      Ranges  : ACK_Range_Policy.Decode_Result;
+      Applied : Sent_Packet_Policy.Apply_Result;
+   begin
+      Rejected := True;
+      Ranges := ACK_Range_Policy.Decode (Plaintext, Frame);
+      if Ranges.Status /= ACK_Range_Policy.Decoded then
+         Result.Status :=
+           (case Ranges.Status is
+               when ACK_Range_Policy.Too_Many_Ranges =>
+                 ACK_Range_Capacity_Exceeded,
+               when ACK_Range_Policy.Truncated => Frame_Truncated,
+               when ACK_Range_Policy.Invalid_Range => Invalid_ACK_Range,
+               when ACK_Range_Policy.Decoded => Processed);
+         return;
+      end if;
+      Sent_Packet_Policy.Apply_ACK
+        (Item.Sent, Ranges, Now, Loss_Delay, Applied);
+      if Applied.Status = Sent_Packet_Policy.Acknowledges_Unsent_Packet then
+         Result.Status := Acknowledges_Unsent_Packet;
+         return;
+      end if;
+      Rejected := False;
+      Result.Resolved := Applied;
+      for Index in 1 .. Applied.Count loop
+         if Applied.Events (Index).Kind = Sent_Packet_Policy.Acknowledged then
+            Crypto_Flight.Acknowledge
+              (Item.Outgoing, Applied.Events (Index).Packet.Number);
+            if Applied.Events (Index).Packet.ACK_Eliciting then
+               Result.ACKed_Eliciting := True;
+               Item.Ping_Sent := False;
+               if not Result.Has_Sample
+                 and then Applied.Events (Index).Packet.Number =
+                   Packet_Number (Frame.Largest_Acknowledged)
+                 and then Now >= Applied.Events (Index).Packet.Sent_At
+               then
+                  Result.Has_Sample := True;
+                  Result.Sample :=
+                    Now - Applied.Events (Index).Packet.Sent_At;
+               end if;
+            end if;
+         end if;
+      end loop;
+   end Apply_Peer_ACK;
+
    procedure Process_Packet
-     (Item   : in out State;
-      Packet : Ada.Streams.Stream_Element_Array;
-      Result : out Process_Result)
+     (Item       : in out State;
+      Packet     : Ada.Streams.Stream_Element_Array;
+      Now        : Timestamp;
+      Loss_Delay : Timestamp;
+      Result     : out Process_Result)
    is
       Plaintext : Ada.Streams.Stream_Element_Array (1 .. Max_Datagram_Length);
       Received  : Initial_Connection.Process_Result;
@@ -126,6 +429,7 @@ package body Flyology.QUIC.Initial_Space is
       Cursor    : Initial_Frame_Policy.Frame_Offset := 0;
       Frame     : Initial_Frame_Policy.Parse_Result;
       Inserted  : Crypto_Reassembly_Policy.Insert_Status;
+      Rejected  : Boolean;
    begin
       Result := (others => <>);
       Initial_Connection.Process_Initial
@@ -165,7 +469,19 @@ package body Flyology.QUIC.Initial_Space is
             return;
          end if;
          Result.Frame_Count := Result.Frame_Count + 1;
-         if Frame.Kind = Initial_Frame_Policy.Crypto then
+         if Frame.Kind in Initial_Frame_Policy.Ping
+           | Initial_Frame_Policy.Crypto
+         then
+            Result.ACK_Eliciting := True;
+         end if;
+         if Frame.Kind = Initial_Frame_Policy.Acknowledgment then
+            Apply_Peer_ACK
+              (Item, Plaintext (1 .. Length), Frame, Now, Loss_Delay, Result,
+               Rejected);
+            if Rejected then
+               return;
+            end if;
+         elsif Frame.Kind = Initial_Frame_Policy.Crypto then
             if Frame.Crypto_Length = 0 then
                Crypto_Reassembly_Policy.Insert
                  (Item.Crypto, Frame.Crypto_Offset, (1 .. 0 => 0), Inserted);
@@ -195,6 +511,9 @@ package body Flyology.QUIC.Initial_Space is
          end if;
          Cursor := Cursor + Frame.Consumed;
       end loop;
+      if Result.ACK_Eliciting then
+         Item.ACK_Owed := True;
+      end if;
       Result.Status := Processed;
    end Process_Packet;
 end Flyology.QUIC.Initial_Space;

--- a/flyology_quic/src/flyology-quic-initial_space.ads
+++ b/flyology_quic/src/flyology-quic-initial_space.ads
@@ -1,17 +1,33 @@
 with Ada.Streams;
+with Flyology.QUIC.Crypto_Flight;
 with Flyology.QUIC.Crypto_Reassembly_Policy;
 with Flyology.QUIC.Initial_Connection;
 with Flyology.QUIC.Long_Header_Policy;
+with Flyology.QUIC.Sent_Packet_Policy;
 with Flyology.QUIC.Varint_Policy;
 
 --  Internal composition of protected Initial packets and their CRYPTO stream.
 --  Client packets are padded inside packet protection to QUIC's 1,200-byte
 --  minimum; server packets retain their natural protected length.
+--
+--  The space also owns the RFC 9002 sent-packet ledger for the Initial
+--  packet-number space. Sent CRYPTO ranges are retained until a peer ACK or
+--  handshake progress retires them, so a probe timeout can retransmit them
+--  under a fresh packet number. RTT estimation and probe-timeout backoff are
+--  path-wide and remain with the caller.
 private package Flyology.QUIC.Initial_Space is
    use type Ada.Streams.Stream_Element_Offset;
 
    Max_Datagram_Length : constant := 1_350;
    Max_Crypto_Payload  : constant := 1_100;
+
+   --  Retained outgoing CRYPTO octets. One ClientHello or ServerHello never
+   --  exceeds Max_Crypto_Payload, so this bounds the whole Initial flight
+   --  with room for a fragmented one.
+   Max_Retained_Crypto : constant := 4_096;
+
+   subtype Packet_Number is Sent_Packet_Policy.Packet_Number;
+   subtype Timestamp is Sent_Packet_Policy.Timestamp;
 
    type State is limited private;
 
@@ -34,7 +50,10 @@ private package Flyology.QUIC.Initial_Space is
 
    type Build_Status is
      (Built,
+      Nothing_To_ACK,
       Crypto_Range_Too_Large,
+      Crypto_Retention_Exceeded,
+      Recovery_Capacity_Exceeded,
       Packet_Number_Exhausted,
       Packet_Number_Unrepresentable,
       Packet_Too_Large,
@@ -42,28 +61,57 @@ private package Flyology.QUIC.Initial_Space is
 
    type Build_Result is record
       Status        : Build_Status := Output_Too_Small;
+      Number        : Packet_Number := 0;
       Packet_Length : Natural range 0 .. Max_Datagram_Length := 0;
    end record;
 
+   --  Build a protected Initial carrying one CRYPTO range, preceded by an ACK
+   --  for anything this space still owes the peer.
+   --  @param Now Monotonic microsecond timestamp for recovery accounting
    procedure Build_Crypto_Packet
      (Item   : in out State;
-      Token  : Ada.Streams.Stream_Element_Array;
       Offset : Varint_Policy.Value_Type;
       Data   : Ada.Streams.Stream_Element_Array;
+      Now    : Timestamp;
       Packet : out Ada.Streams.Stream_Element_Array;
       Result : out Build_Result)
    with
      Pre => Is_Initialized (Item)
-       and then Token'Length <= Max_Datagram_Length
        and then Data'Length <= Max_Crypto_Payload
        and then Packet'Length >= Max_Datagram_Length;
 
-   procedure Build_Transport_Close_Packet
-     (Item       : in out State;
-      Error_Code : Varint_Policy.Value_Type;
-      Frame_Type : Varint_Policy.Value_Type;
-      Packet     : out Ada.Streams.Stream_Element_Array;
-      Result     : out Build_Result)
+   --  Build an ACK-only Initial. The packet is not ack-eliciting and does not
+   --  arm the probe timer.
+   procedure Build_ACK_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   with
+     Pre => Is_Initialized (Item)
+       and then Packet'Length >= Max_Datagram_Length;
+
+   --  Retransmit one retained CRYPTO range under a fresh packet number. Index
+   --  selects among the ranges still awaiting acknowledgment, in offset order,
+   --  and Nothing_To_ACK reports that no such range exists.
+   procedure Build_Probe_Packet
+     (Item   : in out State;
+      Index  : Positive;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
+   with
+     Pre => Is_Initialized (Item)
+       and then Packet'Length >= Max_Datagram_Length;
+
+   --  Build an ack-eliciting PING. RFC 9002 section 6.2.2.1 requires this
+   --  anti-deadlock probe when a probe timeout expires with no unacknowledged
+   --  CRYPTO data left to retransmit.
+   procedure Build_Ping_Packet
+     (Item   : in out State;
+      Now    : Timestamp;
+      Packet : out Ada.Streams.Stream_Element_Array;
+      Result : out Build_Result)
    with
      Pre => Is_Initialized (Item)
        and then Packet'Length >= Max_Datagram_Length;
@@ -79,24 +127,60 @@ private package Flyology.QUIC.Initial_Space is
       Frame_Not_Allowed,
       Frame_Value_Too_Large,
       Invalid_ACK_Range,
+      ACK_Range_Capacity_Exceeded,
+      Acknowledges_Unsent_Packet,
       Conflicting_Crypto_Data,
       Crypto_Data_Too_Large);
 
    type Process_Result is record
-      Status      : Process_Status := Envelope_Rejected;
-      Frame_Count : Natural := 0;
-      Peer_Source : Long_Header_Policy.Connection_ID;
-      Peer_Closed : Boolean := False;
-      Close_Error : Varint_Policy.Value_Type := 0;
+      Status        : Process_Status := Envelope_Rejected;
+      Frame_Count   : Natural := 0;
+      Peer_Source   : Long_Header_Policy.Connection_ID;
+      Peer_Closed   : Boolean := False;
+      Close_Error   : Varint_Policy.Value_Type := 0;
+      --  The packet must be acknowledged.
+      ACK_Eliciting : Boolean := False;
+      --  Packets this space resolved from the peer's ACK frames.
+      Resolved      : Sent_Packet_Policy.Apply_Result;
+      --  An ACK-eliciting packet of ours was newly acknowledged.
+      ACKed_Eliciting : Boolean := False;
+      --  A usable RTT sample was produced by the newest acknowledgment.
+      Has_Sample    : Boolean := False;
+      Sample        : Timestamp := 0;
    end record;
 
+   --  Process one protected Initial packet.
+   --  @param Now Monotonic microsecond timestamp for recovery accounting
+   --  @param Loss_Delay Path loss-detection delay from RTT estimation
    procedure Process_Packet
-     (Item   : in out State;
-      Packet : Ada.Streams.Stream_Element_Array;
-      Result : out Process_Result)
+     (Item       : in out State;
+      Packet     : Ada.Streams.Stream_Element_Array;
+      Now        : Timestamp;
+      Loss_Delay : Timestamp;
+      Result     : out Process_Result)
    with
      Pre => Is_Initialized (Item)
        and then Packet'Length <= Max_Datagram_Length;
+
+   --  Report whether an ACK-eliciting packet of ours is still unacknowledged.
+   function Has_Unacknowledged (Item : State) return Boolean;
+
+   --  Report whether this space owes the peer an acknowledgment.
+   function Needs_ACK (Item : State) return Boolean;
+
+   --  Retire every retained CRYPTO range after progress that could only
+   --  follow its delivery.
+   procedure Acknowledge_Flight (Item : in out State);
+
+   procedure Build_Transport_Close_Packet
+     (Item       : in out State;
+      Error_Code : Varint_Policy.Value_Type;
+      Frame_Type : Varint_Policy.Value_Type;
+      Packet     : out Ada.Streams.Stream_Element_Array;
+      Result     : out Build_Result)
+   with
+     Pre => Is_Initialized (Item)
+       and then Packet'Length >= Max_Datagram_Length;
 
    function Contiguous_Length
      (Item : State) return Crypto_Reassembly_Policy.Stream_Offset;
@@ -111,6 +195,10 @@ private
    type State is limited record
       Packets     : Initial_Connection.Connection;
       Crypto      : Crypto_Reassembly_Policy.Reassembly_State;
+      Sent        : Sent_Packet_Policy.Ledger;
+      Outgoing    : Crypto_Flight.Flight (Max_Retained_Crypto);
+      ACK_Owed    : Boolean := False;
+      Ping_Sent   : Boolean := False;
       Role        : Initial_Connection.Endpoint_Role :=
         Initial_Connection.Client;
       Initialized : Boolean := False;

--- a/flyology_quic/tests/flyology_quic_tests.gpr
+++ b/flyology_quic/tests/flyology_quic_tests.gpr
@@ -14,6 +14,7 @@ project Flyology_QUIC_Tests is
       "flyology-quic-application_frame_policy-smoke.adb",
       "flyology-quic-connection_state_policy-smoke.adb",
       "flyology-quic-connection_driver-smoke.adb",
+      "flyology-quic-connections-recovery_smoke.adb",
       "flyology-quic-crypto_frame_policy-smoke.adb",
       "flyology-quic-crypto_openssl-smoke.adb",
       "flyology-quic-crypto_reassembly_policy-smoke.adb",

--- a/flyology_quic/tests/qualification.md
+++ b/flyology_quic/tests/qualification.md
@@ -94,6 +94,14 @@ for the next layer.
   and authenticated replay admission. The client Initial is padded to 1,200
   bytes, and success requires matching directional 1-RTT keys after both
   endpoints process the encrypted peer flight.
+- RFC 9002 section 6.2 handshake-space loss recovery is exercised with an
+  explicit monotonic clock. A dropped client Initial is retransmitted by the
+  probe timeout under a fresh packet number and still completes the handshake;
+  a dropped server Handshake flight is retransmitted by the server while the
+  Initial flight it already had acknowledged is not; and a client whose peer
+  has not yet completed address validation sends the section 6.2.2.1
+  anti-deadlock probe. Backoff doubles the next deadline, and a confirmed
+  endpoint disarms the timer.
 - SPARK discharges the arithmetic, range, index, and contract checks in the
   wire-policy units.
 
@@ -126,7 +134,10 @@ the complete QUIC v1 feature set:
 
 1. Version negotiation, Retry, connection-ID changes, and stateless reset.
 2. Coalesced Initial and Handshake packets, reordered packets, duplicates,
-   loss, PTO, and key discard.
+   and key discard. Initial and Handshake loss detection and probe timeouts
+   are covered deterministically above and end to end in the HTTP crate's
+   `http3_handshake_recovery`; application-space PTO under sustained network
+   loss is not.
 3. Flow control, stream limits, reset/stop semantics, graceful close, and idle
    timeout.
 4. Wildcard and concrete IPv4/IPv6 binds, local-address preservation,

--- a/flyology_quic/tests/src/flyology-quic-connection_driver-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-connection_driver-smoke.adb
@@ -215,20 +215,28 @@ begin
    Connection_IO.Send (Client_Socket, Reply, Timeout => 1.0);
    Connection_IO.Receive
      (Server_Socket, Server, Server_Output, Server_Result, Timeout => 1.0);
+   --  HANDSHAKE_DONE plus the Handshake-space acknowledgment of the client
+   --  Finished, which RFC 9000 13.2.1 requires immediately and which no
+   --  1-RTT packet can carry.
    pragma Assert
      (Server_Result.Status = Succeeded and then Is_Connected (Server)
       and then Handshake_Confirmed (Server)
-      and then Server_Output.Count = 1);
+      and then Server_Output.Count = 2);
 
+   Reply := (others => <>);
    Connection_IO.Send (Server_Socket, Server_Output, Timeout => 1.0);
-   Connection_IO.Receive
-     (Client_Socket, Client, Client_Output, Client_Result,
-      Timeout => 1.0);
-   pragma Assert
-     (Client_Result.Status = Succeeded and then Handshake_Confirmed (Client)
-      and then Client_Output.Count = 1);
+   for Index in 1 .. Server_Output.Count loop
+      Connection_IO.Receive
+        (Client_Socket, Client, Client_Output, Client_Result,
+         Timeout => 1.0);
+      pragma Assert (Client_Result.Status = Succeeded);
+      if Client_Output.Count > 0 then
+         Reply := Client_Output;
+      end if;
+   end loop;
+   pragma Assert (Handshake_Confirmed (Client) and then Reply.Count = 1);
 
-   Connection_IO.Send (Client_Socket, Client_Output, Timeout => 1.0);
+   Connection_IO.Send (Client_Socket, Reply, Timeout => 1.0);
    Connection_IO.Receive
      (Server_Socket, Server, Server_Output, Server_Result, Timeout => 1.0);
    pragma Assert
@@ -379,10 +387,12 @@ begin
          Coalesced.Data
            (1 .. Ada.Streams.Stream_Element_Offset (Coalesced.Length)),
          Finish, Client_Status);
+      --  Finished, plus the Initial-space acknowledgment of the ServerHello
+      --  that no Handshake packet can carry.
       pragma Assert
         (Connections.Is_Connected (Public_Client)
          and then not Connections.Handshake_Confirmed (Public_Client)
-         and then Finish.Count = 1);
+         and then Finish.Count = 2);
       Connections.Process_Datagram
         (Public_Server,
          Finish.Items (1).Data
@@ -392,7 +402,7 @@ begin
       pragma Assert
         (Connections.Is_Connected (Public_Server)
          and then Connections.Handshake_Confirmed (Public_Server)
-         and then Server_Flight.Count = 1);
+         and then Server_Flight.Count = 2);
       Connections.Process_Datagram
         (Public_Client,
          Server_Flight.Items (1).Data

--- a/flyology_quic/tests/src/flyology-quic-connections-recovery_smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-connections-recovery_smoke.adb
@@ -1,0 +1,261 @@
+with Ada.Streams;
+use type Ada.Streams.Stream_Element_Array;
+
+--  RFC 9002 section 6.2 handshake-space loss recovery.
+--
+--  Every step drives the connection with an explicit monotonic timestamp, so
+--  the probe deadlines below are exact rather than wall-clock dependent.
+procedure Flyology.QUIC.Connections.Recovery_Smoke is
+   use type Ada.Streams.Stream_Element_Offset;
+
+   function Nibble (Value : Character) return Natural is
+     (case Value is
+         when '0' .. '9' => Character'Pos (Value) - Character'Pos ('0'),
+         when 'a' .. 'f' => Character'Pos (Value) - Character'Pos ('a') + 10,
+         when 'A' .. 'F' => Character'Pos (Value) - Character'Pos ('A') + 10,
+         when others => raise Constraint_Error);
+
+   function Hex (Value : String) return Ada.Streams.Stream_Element_Array is
+      Result : Ada.Streams.Stream_Element_Array
+        (1 .. Ada.Streams.Stream_Element_Offset (Value'Length / 2));
+      Source : Positive := Value'First;
+   begin
+      for Element of Result loop
+         Element := Ada.Streams.Stream_Element
+           (16 * Nibble (Value (Source)) + Nibble (Value (Source + 1)));
+         Source := Source + 2;
+      end loop;
+      return Result;
+   end Hex;
+
+   function ID (Data : Ada.Streams.Stream_Element_Array) return Connection_ID
+   is
+      Result : Connection_ID;
+   begin
+      Result.Length := Natural (Data'Length);
+      Result.Data (1 .. Data'Length) := Data;
+      return Result;
+   end ID;
+
+   function Payload
+     (Item : Datagram) return Ada.Streams.Stream_Element_Array is
+     (Item.Data (1 .. Ada.Streams.Stream_Element_Offset (Item.Length)));
+
+   Certificate : constant Ada.Streams.Stream_Element_Array :=
+     Hex
+       ("3082013c3081efa0030201020214434e3e3873a520217edf913fba03f4" &
+        "ea17411e64300506032b657030143112301006035504030c096c6f6361" &
+        "6c686f7374301e170d3236303830373230323830385a170d3336303830" &
+        "343230323830385a30143112301006035504030c096c6f63616c686f73" &
+        "74302a300506032b65700321006380a1de85cdd187a3134d096ff12e8b" &
+        "1e47aa4c94cff3c4144bad3ee5f81eaea3533051301d0603551d0e0416" &
+        "0414d3dd952a2ff44a35af38d9249d71a454ced348ce301f0603551d23" &
+        "041830168014d3dd952a2ff44a35af38d9249d71a454ced348ce300f060" &
+        "3551d130101ff040530030101ff300506032b657003410024075a33b818" &
+        "be62a4f328b79bd8f79febe7d3710fb44ba7a7b2d8e12bc3d1e4056d5" &
+        "c20fba04e183430175b62ed1a107eb518dfaacf11045fa0e5a6feba2c0f");
+   Private_Key : constant Ed25519_Private_Key :=
+     Ed25519_Private_Key'
+       (Hex ("f491306c81165ffd97822f3ef58de891" &
+             "8779314457f5501e42d3f68504cd3aa8"));
+   ALPN : constant Ada.Streams.Stream_Element_Array := Hex ("6833");
+   Original_ID : constant Ada.Streams.Stream_Element_Array :=
+     Hex ("8394c8f03e515708");
+   Client_ID : constant Connection_ID := ID (Hex ("aabbccdd01020304"));
+   Server_ID : constant Connection_ID := ID (Hex ("1020304050607080"));
+
+   --  RFC 9002 section 6.2.1 with no RTT sample: 333ms smoothed plus four
+   --  times the 166.5ms variance. Handshake spaces add no max_ack_delay.
+   First_PTO : constant Timestamp := 999_000;
+
+   procedure Start (Client : in out Connection; Now : Timestamp;
+                    Flight : out Datagram_Batch)
+   is
+      Status : Operation_Status;
+   begin
+      Initialize_Client
+        (Client, ALPN, Transport_Settings'(others => <>), Certificate,
+         Original_ID, ID (Original_ID), Client_ID);
+      Start_Client (Client, Flight, Status, Now);
+      pragma Assert (Status = Succeeded and then Flight.Count = 1);
+      --  A client Initial is always padded to QUIC's 1,200-octet minimum.
+      pragma Assert (Flight.Items (1).Length = 1_200);
+   end Start;
+
+   procedure Accept_Initial
+     (Server : in out Connection;
+      Packet : Datagram;
+      Now    : Timestamp;
+      Flight : out Datagram_Batch)
+   is
+      Setup  : Server_Initialize_Status;
+      Status : Operation_Status;
+   begin
+      Initialize_Server_From_Initial
+        (Server, ALPN, Transport_Settings'(others => <>), Certificate,
+         Private_Key, Server_ID, Payload (Packet), Setup);
+      pragma Assert (Setup = Initialized);
+      Process_Datagram (Server, Payload (Packet), Flight, Status, Now);
+      pragma Assert (Status = Succeeded);
+   end Accept_Initial;
+
+   procedure Deliver
+     (Target : in out Connection;
+      Packet : Datagram;
+      Now    : Timestamp;
+      Output : out Datagram_Batch)
+   is
+      Status : Operation_Status;
+   begin
+      Process_Datagram (Target, Payload (Packet), Output, Status, Now);
+      pragma Assert (Status in Succeeded | Waiting_For_More);
+   end Deliver;
+
+   --  Hand every datagram of Flight to Target and return the last non-empty
+   --  response, which is how a peer observes one arriving flight.
+   procedure Deliver_All
+     (Target : in out Connection;
+      Flight : Datagram_Batch;
+      Now    : Timestamp;
+      Reply  : out Datagram_Batch)
+   is
+      Output : Datagram_Batch;
+   begin
+      Reply := (others => <>);
+      for Index in 1 .. Flight.Count loop
+         Deliver (Target, Flight.Items (Index), Now, Output);
+         if Output.Count > 0 then
+            Reply := Output;
+         end if;
+      end loop;
+   end Deliver_All;
+begin
+   --  A dropped client Initial is retransmitted by the probe timeout, and the
+   --  probe carries the ClientHello rather than only proving reachability.
+   declare
+      Client, Server : Connection;
+      Flight, Probes, Server_Flight, Reply, Trailing : Datagram_Batch;
+      Deadline : Timestamp;
+   begin
+      Start (Client, 0, Flight);
+      pragma Assert (Has_Recovery_Timeout (Client));
+      Deadline := Recovery_Deadline (Client);
+      pragma Assert (Deadline = First_PTO);
+
+      declare
+         Status : Timeout_Status;
+      begin
+         Process_Timeout (Client, Deadline - 1, Probes, Status);
+         pragma Assert (Status = Not_Due and then Probes.Count = 0);
+         Process_Timeout (Client, Deadline, Probes, Status);
+         pragma Assert (Status = Probes_Ready and then Probes.Count = 1);
+         --  The retransmission is a fresh packet number in a full-size
+         --  client Initial, not a copy of the dropped datagram.
+         pragma Assert (Probes.Items (1).Length = 1_200);
+         pragma Assert
+           (Probes.Items (1).Data /= Flight.Items (1).Data);
+         --  Exponential backoff doubles the next deadline.
+         pragma Assert
+           (Has_Recovery_Timeout (Client)
+            and then Recovery_Deadline (Client) = Deadline + 2 * First_PTO);
+      end;
+
+      --  Only the probe reaches the server, and it carries enough of the
+      --  handshake for the server to answer with its own flight.
+      Accept_Initial (Server, Probes.Items (1), 1_000_000, Server_Flight);
+      pragma Assert
+        (Server_Flight.Count >= 2 and then State (Server) = Server_Handshake);
+
+      Deliver_All (Client, Server_Flight, 1_100_000, Reply);
+      pragma Assert (Is_Connected (Client) and then Reply.Count = 1);
+      Deliver_All (Server, Reply, 1_200_000, Trailing);
+      pragma Assert
+        (Is_Connected (Server) and then Handshake_Confirmed (Server));
+      Deliver_All (Client, Trailing, 1_300_000, Reply);
+      --  A confirmed client owes nothing in either handshake space, so its
+      --  probe timer is disarmed and the connection stops retransmitting.
+      pragma Assert
+        (Handshake_Confirmed (Client)
+         and then not Has_Recovery_Timeout (Client));
+   end;
+
+   --  A dropped server handshake flight is retransmitted by the server's own
+   --  probe timeout while the client waits in Client_Handshake.
+   declare
+      Client, Server : Connection;
+      Flight, Server_Flight, Client_Reply, Probes, Reply, Trailing :
+        Datagram_Batch;
+      Handshake_Packets : Natural;
+      Deadline : Timestamp;
+   begin
+      Start (Client, 0, Flight);
+      Accept_Initial (Server, Flight.Items (1), 10_000, Server_Flight);
+      pragma Assert (Server_Flight.Count >= 2);
+      Handshake_Packets := Server_Flight.Count - 1;
+
+      --  Deliver only the server Initial; every Handshake packet is lost.
+      Deliver (Client, Server_Flight.Items (1), 20_000, Client_Reply);
+      pragma Assert
+        (not Is_Connected (Client) and then State (Client) = Client_Handshake);
+      --  With nothing to send in the Initial space the client still owes an
+      --  immediate acknowledgment, which is what retires the server Initial.
+      pragma Assert (Client_Reply.Count = 1);
+      Deliver_All (Server, Client_Reply, 30_000, Reply);
+      pragma Assert (Reply.Count = 0);
+
+      pragma Assert (Has_Recovery_Timeout (Server));
+      Deadline := Recovery_Deadline (Server);
+      declare
+         Status : Timeout_Status;
+      begin
+         Process_Timeout (Server, Deadline - 1, Probes, Status);
+         pragma Assert (Status = Not_Due and then Probes.Count = 0);
+         Process_Timeout (Server, Deadline, Probes, Status);
+         --  Only the unacknowledged Handshake ranges come back; the Initial
+         --  flight was acknowledged and is not retransmitted.
+         pragma Assert
+           (Status = Probes_Ready
+            and then Probes.Count = Handshake_Packets);
+      end;
+
+      Deliver_All (Client, Probes, Deadline + 10_000, Reply);
+      pragma Assert (Is_Connected (Client) and then Reply.Count = 1);
+      Deliver_All (Server, Reply, Deadline + 20_000, Trailing);
+      pragma Assert
+        (Is_Connected (Server) and then Handshake_Confirmed (Server));
+      Deliver_All (Client, Trailing, Deadline + 30_000, Reply);
+      pragma Assert (Handshake_Confirmed (Client));
+   end;
+
+   --  With its Initial flight acknowledged and no Handshake packet received,
+   --  a client still probes so the peer cannot be left waiting. RFC 9002
+   --  section 6.2.2.1 calls this the anti-deadlock probe.
+   declare
+      Client, Server : Connection;
+      Flight, Server_Flight, Client_Reply, Probes, Reply : Datagram_Batch;
+      Deadline : Timestamp;
+   begin
+      Start (Client, 0, Flight);
+      Accept_Initial (Server, Flight.Items (1), 10_000, Server_Flight);
+      Deliver (Client, Server_Flight.Items (1), 20_000, Client_Reply);
+      pragma Assert (State (Client) = Client_Handshake);
+
+      pragma Assert (Has_Recovery_Timeout (Client));
+      Deadline := Recovery_Deadline (Client);
+      declare
+         Status : Timeout_Status;
+      begin
+         Process_Timeout (Client, Deadline, Probes, Status);
+         pragma Assert (Status = Probes_Ready and then Probes.Count = 1);
+      end;
+
+      --  The probe is a Handshake packet, so the server accepts it and the
+      --  connection is still able to complete afterwards.
+      Deliver_All (Server, Probes, Deadline + 1_000, Reply);
+      Deliver_All (Client, Server_Flight, Deadline + 2_000, Reply);
+      pragma Assert (Is_Connected (Client) and then Reply.Count = 1);
+      Deliver_All (Server, Reply, Deadline + 3_000, Client_Reply);
+      pragma Assert
+        (Is_Connected (Server) and then Handshake_Confirmed (Server));
+   end;
+end Flyology.QUIC.Connections.Recovery_Smoke;

--- a/flyology_quic/tests/src/flyology-quic-handshake_space-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-handshake_space-smoke.adb
@@ -39,11 +39,11 @@ begin
    Initialize (Server, Server_Keys, Client_Keys, Client_ID, Server_ID);
 
    Build_Crypto_Packet
-     (Client, 0, Flight (1 .. 1_000), Packet_1, Built_1);
+     (Client, 0, Flight (1 .. 1_000), 100, Packet_1, Built_1);
    Build_Crypto_Packet
-     (Client, 1_000, Flight (1_001 .. 2_000), Packet_2, Built_2);
+     (Client, 1_000, Flight (1_001 .. 2_000), 100, Packet_2, Built_2);
    Build_Crypto_Packet
-     (Client, 2_000, Flight (2_001 .. 2_500), Packet_3, Built_3);
+     (Client, 2_000, Flight (2_001 .. 2_500), 100, Packet_3, Built_3);
    pragma Assert
      (Built_1.Status = Built and then Built_2.Status = Built
       and then Built_3.Status = Built
@@ -55,20 +55,20 @@ begin
      (Server,
       Packet_2
         (1 .. Ada.Streams.Stream_Element_Offset (Built_2.Packet_Length)),
-      Received);
+      200, 1_000, Received);
    pragma Assert
      (Received.Status = Processed and then Contiguous_Length (Server) = 0);
    Process_Packet
      (Server,
       Packet_1
         (1 .. Ada.Streams.Stream_Element_Offset (Built_1.Packet_Length)),
-      Received);
+      200, 1_000, Received);
    pragma Assert (Contiguous_Length (Server) = 2_000);
    Process_Packet
      (Server,
       Packet_3
         (1 .. Ada.Streams.Stream_Element_Offset (Built_3.Packet_Length)),
-      Received);
+      200, 1_000, Received);
    pragma Assert
      (Received.Status = Processed
       and then Contiguous_Length (Server) = Flight'Length);

--- a/flyology_quic/tests/src/flyology-quic-initial_space-smoke.adb
+++ b/flyology_quic/tests/src/flyology-quic-initial_space-smoke.adb
@@ -39,13 +39,11 @@ begin
      (Server, Initial_Connection.Server, Original_ID, Client_ID, Server_ID);
 
    Build_Crypto_Packet
-     (Client, (1 .. 0 => 0), 0, Flight (1 .. 1_000), Packet_1, Built_1);
+     (Client, 0, Flight (1 .. 1_000), 100, Packet_1, Built_1);
    Build_Crypto_Packet
-     (Client, (1 .. 0 => 0), 1_000, Flight (1_001 .. 2_000),
-      Packet_2, Built_2);
+     (Client, 1_000, Flight (1_001 .. 2_000), 100, Packet_2, Built_2);
    Build_Crypto_Packet
-     (Client, (1 .. 0 => 0), 2_000, Flight (2_001 .. 2_500),
-      Packet_3, Built_3);
+     (Client, 2_000, Flight (2_001 .. 2_500), 100, Packet_3, Built_3);
    pragma Assert
      (Built_1.Status = Built and then Built_2.Status = Built
       and then Built_3.Status = Built
@@ -57,7 +55,7 @@ begin
      (Server,
       Packet_2
         (1 .. Ada.Streams.Stream_Element_Offset (Built_2.Packet_Length)),
-      Received);
+      200, 1_000, Received);
    pragma Assert
      (Received.Status = Processed
       and then Received.Peer_Source = Client_ID
@@ -66,13 +64,13 @@ begin
      (Server,
       Packet_1
         (1 .. Ada.Streams.Stream_Element_Offset (Built_1.Packet_Length)),
-      Received);
+      200, 1_000, Received);
    pragma Assert (Contiguous_Length (Server) = 2_000);
    Process_Packet
      (Server,
       Packet_3
         (1 .. Ada.Streams.Stream_Element_Offset (Built_3.Packet_Length)),
-      Received);
+      200, 1_000, Received);
    pragma Assert (Contiguous_Length (Server) = Flight'Length);
    for Index in Crypto_Reassembly_Policy.Stream_Index
      range 0 .. Flight'Length - 1
@@ -82,7 +80,7 @@ begin
    end loop;
 
    Build_Crypto_Packet
-     (Server, (1 .. 0 => 0), 0, Flight (1 .. 32), Packet_1, Built_1);
+     (Server, 0, Flight (1 .. 32), 300, Packet_1, Built_1);
    pragma Assert
      (Built_1.Status = Built
       and then Built_1.Packet_Length < Max_Datagram_Length);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -112,6 +112,7 @@ development_certificates_smoke
 http3_public_smoke
 http3_server_integration
 http3_handshake_abandon
+http3_handshake_recovery
 flyology-http-http_3_frame_policy-smoke
 flyology-http-http_3_header_policy-smoke
 flyology-http-http_3_message_policy-smoke

--- a/src/flyology-http-client-http_3_internals.adb
+++ b/src/flyology-http-client-http_3_internals.adb
@@ -255,13 +255,17 @@ package body HTTP_3_Internals is
          Destination.Data (1 .. Stream_Element_Offset (Destination.Length)),
          Destination,
          Source);
-      QUIC.Start_Client (Connection.QUIC_Transport, Flight, Status);
+      QUIC.Start_Client
+        (Connection.QUIC_Transport, Flight, Status, Now (Connection.all));
       if Status /= QUIC.Succeeded then
          raise Protocol_Error with
            "QUIC client start failed: " & QUIC.Operation_Status'Image (Status);
       end if;
       Send
         (State, Connection, Flight, Started, Timeout, Token, Race_Token);
+      --  Receive_One bounds each wait by the QUIC recovery deadline, so a lost
+      --  Initial or a lost server flight is retransmitted by the RFC 9002
+      --  handshake probe timeout instead of stalling until Timeout expires.
       while not QUIC.Is_Connected (Connection.QUIC_Transport) loop
          Receive_One
            (State, Connection, Started, Timeout, Token, Race_Token);

--- a/src/flyology-http-server-http_3.adb
+++ b/src/flyology-http-server-http_3.adb
@@ -1651,6 +1651,9 @@ package body Flyology.HTTP.Server.HTTP_3 is
          Cleanup;
          return;
       end if;
+      --  Receive_One bounds each wait by the QUIC recovery deadline, so a lost
+      --  server Initial or Handshake flight is retransmitted by the RFC 9002
+      --  handshake probe timeout instead of stalling until Handshake_Timeout.
       while not QUIC.Is_Connected (State.Transport) loop
          if Handshake_Remaining = 0.0 then
             raise Flyology.IO.Timeout_Error;

--- a/tests/http3-conformance.md
+++ b/tests/http3-conformance.md
@@ -87,12 +87,22 @@ is independently configurable through
 `FLYOLOGY_HTTP3_STRESS_LOOP_POOL_SIZE`. This is reproducible mutation/load
 testing, not coverage-guided fuzzing or a portable performance benchmark.
 
+## Handshake loss recovery
+
+`tests/http3_handshake_recovery.adb` runs the routed Ada HTTP/3 server and the
+standard Ada client on either side of a UDP relay that discards one handshake
+flight. Dropping the client Initial and dropping the server Handshake flight
+are each covered; the request completes only because the losing endpoint rearms
+its RFC 9002 section 6.2 probe timeout and retransmits. The deterministic
+transport-level cases live in `flyology_quic/tests/qualification.md`.
+
 ## Evidence boundary
 
 The current external matrix does not qualify QUIC Retry, version negotiation,
 stateless reset, resumption, 0-RTT, key update, connection migration, ECN,
 PMTU discovery, ChaCha20, dynamic QPACK, HTTP/3 push, coverage-guided fuzzing,
-or adverse packet loss/reordering. IPv6 is covered by internal application integration but not
+or adverse packet loss and reordering beyond the single-flight handshake losses
+above. IPv6 is covered by internal application integration but not
 yet by the two external peers. These are unsupported or unqualified until a
 corresponding published-vector or independent-peer gate lands.
 

--- a/tests/http3_handshake_recovery.adb
+++ b/tests/http3_handshake_recovery.adb
@@ -1,0 +1,223 @@
+with Ada.Exceptions;
+with Ada.Streams;
+with Ada.Strings.Fixed;
+with Ada.Text_IO;
+with Flyology.Bytes;
+with Flyology.HTTP;
+with Flyology.HTTP.Client;
+with Flyology.HTTP.Server;
+with Flyology.HTTP.Server.Applications;
+with Flyology.HTTP.Server.Routing;
+with Flyology.IO;
+with Flyology.IO.Sockets;
+with Flyology.QUIC.Test_Connections;
+
+--  End-to-end proof that the HTTP/3 client and server drive the RFC 9002
+--  handshake probe timeout.
+--
+--  A UDP relay sits between the two endpoints and silently discards one
+--  handshake flight. Neither side is told; the exchange can only complete if
+--  the losing endpoint rearms its own probe timer and retransmits.
+procedure HTTP3_Handshake_Recovery is
+   package App renames Flyology.HTTP.Server.Applications;
+   package Client renames Flyology.HTTP.Client;
+   package Sockets renames Flyology.IO.Sockets;
+   package Fixtures renames Flyology.QUIC.Test_Connections;
+
+   use type Ada.Streams.Stream_Element;
+   use type Ada.Streams.Stream_Element_Offset;
+   use type Flyology.HTTP.Protocol;
+   use type Sockets.Endpoint;
+
+   function Decimal (Value : Natural) return String is
+     (Ada.Strings.Fixed.Trim (Natural'Image (Value), Ada.Strings.Both));
+
+   type Context is limited null record;
+   package Routing is new Flyology.HTTP.Server.Routing (Context);
+
+   procedure Hello (State : in out Context; X : in out App.Exchange) is
+      pragma Unreferenced (State);
+   begin
+      pragma Assert (X.Request_Protocol = Flyology.HTTP.HTTP_3_Protocol);
+      X.Text (200, "recovered");
+   end Hello;
+
+   --  Which handshake flight the relay swallows exactly once.
+   --  @enum Client_Initial The client's first Initial never reaches the server
+   --  @enum Server_Handshake The server's Handshake flight never reaches the
+   --    client, leaving it stalled after the ServerHello
+   type Loss_Kind is (Client_Initial, Server_Handshake);
+
+   --  QUIC v1 long-header packet types are visible without keys, which is all
+   --  a path element needs to drop one specific flight.
+   function Is_Long_Header (First : Ada.Streams.Stream_Element) return Boolean
+   is ((First and 16#80#) /= 0 and then (First and 16#40#) /= 0);
+
+   function Is_Initial (First : Ada.Streams.Stream_Element) return Boolean is
+     (Is_Long_Header (First) and then (First and 16#30#) = 16#00#);
+
+   function Is_Handshake (First : Ada.Streams.Stream_Element) return Boolean is
+     (Is_Long_Header (First) and then (First and 16#30#) = 16#20#);
+
+   Payload_Limit : constant := 2_048;
+
+   procedure Run (Loss : Loss_Kind) is
+      Server_Socket : aliased Sockets.Socket_Type;
+      Relay_Socket  : Sockets.Socket_Type;
+      Server_Address, Relay_Address : Sockets.Endpoint;
+      State  : Context;
+      Routes : Routing.Router
+        (Capacity => 1, Slashes => Routing.Strict_Slashes);
+
+      --  Written by the client lane and read by the relay lane after the
+      --  exchange settles; both are single-writer flags.
+      Finished : Boolean := False;
+      pragma Volatile (Finished);
+      Drops    : Natural := 0;
+      pragma Volatile (Drops);
+      Relay_Error : Flyology.Bytes.Unbounded_Bytes;
+      Server_Error : Flyology.Bytes.Unbounded_Bytes;
+   begin
+      Routes.Get ("/hello", Hello'Access, Name => "hello");
+      Sockets.Create_Socket
+        (Server_Socket, Sockets.IPv4, Sockets.Socket_Datagram);
+      Sockets.Bind_Socket
+        (Server_Socket,
+         Sockets.Network_Endpoint (Sockets.Loopback_IPv4, Sockets.Any_Port));
+      Server_Address := Sockets.Get_Socket_Name (Server_Socket);
+      Sockets.Create_Socket
+        (Relay_Socket, Sockets.IPv4, Sockets.Socket_Datagram);
+      Sockets.Bind_Socket
+        (Relay_Socket,
+         Sockets.Network_Endpoint (Sockets.Loopback_IPv4, Sockets.Any_Port));
+      Relay_Address := Sockets.Get_Socket_Name (Relay_Socket);
+
+      declare
+         task Server_Task;
+         task Relay_Task;
+
+         task body Server_Task is
+         begin
+            Routes.Serve_HTTP_3
+              (State, Server_Socket,
+               Fixtures.Server_Certificate,
+               Fixtures.Server_Private_Key,
+               Timeout => 20.0,
+               Handshake_Timeout => 20.0,
+               Max_Connection_Age => 30.0,
+               Max_Requests => 1);
+         exception
+            when Error : others =>
+               Server_Error := Flyology.Bytes.From_Byte_String
+                 (Ada.Exceptions.Exception_Information (Error));
+         end Server_Task;
+
+         --  Forward every datagram between the client and the server except
+         --  the one flight this scenario drops.
+         task body Relay_Task is
+            Buffer   : Ada.Streams.Stream_Element_Array (1 .. Payload_Limit);
+            Last     : Ada.Streams.Stream_Element_Offset;
+            Sent     : Ada.Streams.Stream_Element_Offset;
+            Metadata : Sockets.Datagram_Metadata;
+            Client_Address : Sockets.Endpoint;
+            Have_Client : Boolean := False;
+            From_Client : Boolean;
+            Drop : Boolean;
+         begin
+            while not Finished loop
+               begin
+                  Sockets.Receive_Datagram
+                    (Relay_Socket, Buffer, Last, Metadata, Timeout => 0.25);
+               exception
+                  when Flyology.IO.Timeout_Error =>
+                     goto Continue;
+               end;
+               if Last < Buffer'First then
+                  goto Continue;
+               end if;
+
+               From_Client := not Have_Client
+                 or else Metadata.Source /= Server_Address;
+               if From_Client then
+                  Client_Address := Metadata.Source;
+                  Have_Client := True;
+               end if;
+
+               Drop := False;
+               if Drops = 0 then
+                  case Loss is
+                     when Client_Initial =>
+                        Drop := From_Client
+                          and then Is_Initial (Buffer (Buffer'First));
+                     when Server_Handshake =>
+                        Drop := not From_Client
+                          and then Is_Handshake (Buffer (Buffer'First));
+                  end case;
+               end if;
+               if Drop then
+                  Drops := Drops + 1;
+                  goto Continue;
+               end if;
+
+               Sockets.Send_Datagram
+                 (Relay_Socket, Buffer (Buffer'First .. Last), Sent,
+                  Destination =>
+                    (if From_Client then Server_Address else Client_Address),
+                  Timeout => 2.0);
+               <<Continue>>
+            end loop;
+         exception
+            when Error : others =>
+               Relay_Error := Flyology.Bytes.From_Byte_String
+                 (Ada.Exceptions.Exception_Information (Error));
+         end Relay_Task;
+
+         HTTP : aliased Client.Client (Capacity => 1);
+         Request : Client.Request;
+      begin
+         Client.Configure
+           (HTTP,
+            Flyology.HTTP.Parse_Origin
+              ("https://127.0.0.1:"
+               & Decimal (Natural (Relay_Address.Port))),
+            Client.Require_HTTP_3,
+            HTTP_3_Certificate_DER => Fixtures.Server_Certificate);
+         Client.Set_Target (Request, "/hello");
+         declare
+            Reply : Client.Response :=
+              Client.Execute (HTTP, Request, Timeout => 20.0);
+         begin
+            pragma Assert (Client.Status (Reply) = 200);
+            pragma Assert
+              (Flyology.Bytes.To_Byte_String (Client.Read_All (Reply)) =
+                 "recovered");
+         end;
+         Client.Shutdown (HTTP, Timeout => 5.0);
+         Finished := True;
+      exception
+         when others =>
+            Finished := True;
+            raise;
+      end;
+
+      if Flyology.Bytes.Length (Relay_Error) > 0 then
+         raise Program_Error with
+           "relay failed: " & Flyology.Bytes.To_Byte_String (Relay_Error);
+      elsif Flyology.Bytes.Length (Server_Error) > 0 then
+         raise Program_Error with
+           "server failed: " & Flyology.Bytes.To_Byte_String (Server_Error);
+      end if;
+      --  The scenario is only meaningful when the flight really was lost.
+      pragma Assert (Drops = 1);
+      Sockets.Close_Socket (Relay_Socket);
+      Sockets.Close_Socket (Server_Socket);
+      Ada.Text_IO.Put_Line
+        ("HTTP/3 handshake recovered after dropping "
+         & Loss_Kind'Image (Loss));
+   end Run;
+begin
+   Run (Client_Initial);
+   Run (Server_Handshake);
+   Ada.Text_IO.Put_Line
+     ("flyology_http HTTP/3 handshake probe timeout verified");
+end HTTP3_Handshake_Recovery;

--- a/tests/http3_server_integration.adb
+++ b/tests/http3_server_integration.adb
@@ -1,5 +1,6 @@
 with Ada.Environment_Variables;
 with Ada.Exceptions;
+with Ada.Real_Time;
 with Ada.Streams;
 with Ada.Strings.Unbounded;
 with Flyology.Bytes;
@@ -10,6 +11,7 @@ with Flyology.HTTP.HTTP_3;
 with Flyology.HTTP.Server;
 with Flyology.HTTP.Server.Applications;
 with Flyology.HTTP.Server.Routing;
+with Flyology.IO;
 with Flyology.IO.Sockets;
 with Flyology.IO.TLS.ALPN;
 with Flyology.IO.TLS.OpenSSL;
@@ -32,6 +34,9 @@ procedure HTTP3_Server_Integration is
    use type H3.Event_Kind;
    use type H3.Operation_Status;
    use type QUIC.Operation_Status;
+   use type QUIC.Timeout_Status;
+   use type QUIC.Timestamp;
+   use type Ada.Real_Time.Time;
    use type Flyology.HTTP.Origin_Scheme;
    use type Flyology.HTTP.Protocol;
 
@@ -229,10 +234,6 @@ begin
          Transport : QUIC.Connection;
          Session : H3.Session;
          Flight : QUIC.Datagram_Batch;
-         --  Last handshake flight handed to the server. Handshake-space loss
-         --  recovery has no probe timeout below this test, so a discarded
-         --  datagram is retransmitted from here.
-         Handshake_Flight : QUIC.Datagram_Batch;
          QUIC_Status : QUIC.Operation_Status;
          H3_Status : H3.Operation_Status;
          Phase : Client_Phase := Initialize_Mixed_Client;
@@ -242,11 +243,59 @@ begin
          pragma Volatile (Exchange_Number);
          pragma Volatile (Attempt_Number);
 
+         --  The raw lane drives one QUIC connection directly, so it owns the
+         --  monotonic clock and the RFC 9002 recovery loop the pooled client
+         --  and the routed server keep internally.
+         Raw_Epoch : Ada.Real_Time.Time := Ada.Real_Time.Clock;
+
          function Failure_Context return String is
            (Sockets.Image (Raw_Address) &
             " phase=" & Client_Phase'Image (Phase) &
             " exchange=" & Decimal (Exchange_Number) &
             " attempt=" & Decimal (Attempt_Number));
+
+         function Raw_Now return QUIC.Timestamp is
+            Elapsed : constant Duration := Ada.Real_Time.To_Duration
+              (Ada.Real_Time.Clock - Raw_Epoch);
+         begin
+            return QUIC.Timestamp (Long_Long_Integer (Elapsed * 1_000_000.0));
+         end Raw_Now;
+
+         --  Wait no longer than the next probe deadline, so a handshake
+         --  flight lost on the loopback path is retransmitted rather than
+         --  stalling the whole attempt budget.
+         function Raw_Receive_Timeout return Duration is
+            Current : constant QUIC.Timestamp := Raw_Now;
+         begin
+            if not QUIC.Has_Recovery_Timeout (Transport) then
+               return 10.0;
+            end if;
+            declare
+               Deadline : constant QUIC.Timestamp :=
+                 QUIC.Recovery_Deadline (Transport);
+            begin
+               if Deadline <= Current then
+                  return 0.0;
+               end if;
+               return Duration'Min
+                 (10.0, Duration (Deadline - Current) / 1_000_000.0);
+            end;
+         end Raw_Receive_Timeout;
+
+         procedure Recover_Raw_Handshake is
+            Probes : QUIC.Datagram_Batch;
+            Status : QUIC.Timeout_Status;
+         begin
+            QUIC.Process_Timeout (Transport, Raw_Now, Probes, Status);
+            if Status = QUIC.Probes_Ready then
+               QUIC_IO.Send (Socket, Probes, Timeout => 10.0);
+            elsif Status not in QUIC.Not_Due | QUIC.No_Pending_Recovery then
+               raise Program_Error with
+                 "raw QUIC recovery failed: "
+                 & QUIC.Timeout_Status'Image (Status)
+                 & " " & Failure_Context;
+            end if;
+         end Recover_Raw_Handshake;
       begin
       declare
          HTTP : aliased Client.Client (Capacity => 2);
@@ -435,31 +484,29 @@ begin
       Sockets.Create_Socket
         (Socket, Raw_Address.Family, Sockets.Socket_Datagram);
       Sockets.Connect_Socket (Socket, Raw_Address);
-      QUIC.Start_Client (Transport, Flight, QUIC_Status);
+      Raw_Epoch := Ada.Real_Time.Clock;
+      QUIC.Start_Client (Transport, Flight, QUIC_Status, Raw_Now);
       pragma Assert (QUIC_Status = QUIC.Succeeded);
-      Handshake_Flight := Flight;
       QUIC_IO.Send (Socket, Flight, Timeout => 10.0);
 
       --  A listener whose connection registry is momentarily full discards a
-      --  QUIC Initial without answering it, and no handshake-space probe
-      --  timeout retransmits it. Spend the attempt budget on retransmission
-      --  rather than on one long wait, so a discarded datagram costs a probe
-      --  interval instead of the whole exchange.
-      for Attempt in 1 .. 8 loop
+      --  QUIC Initial without answering it. The transport now owns that
+      --  retransmission, so the loop drives its probe timeout rather than
+      --  resending the last flight itself, and a discarded datagram costs a
+      --  probe interval instead of the whole exchange.
+      for Attempt in 1 .. 16 loop
          exit when QUIC.Is_Connected (Transport);
          Attempt_Number := Attempt;
          begin
             QUIC_IO.Receive
-              (Socket, Transport, Flight, QUIC_Status, Timeout => 2.0);
+              (Socket, Transport, Flight, QUIC_Status,
+               Now => Raw_Now, Timeout => Raw_Receive_Timeout);
             pragma Assert
               (QUIC_Status in QUIC.Succeeded | QUIC.Waiting_For_More);
-            if Flight.Count > 0 then
-               Handshake_Flight := Flight;
-            end if;
             QUIC_IO.Send (Socket, Flight, Timeout => 10.0);
          exception
             when Flyology.IO.Timeout_Error =>
-               QUIC_IO.Send (Socket, Handshake_Flight, Timeout => 10.0);
+               Recover_Raw_Handshake;
          end;
       end loop;
       Attempt_Number := 0;

--- a/tests/http_tests.gpr
+++ b/tests/http_tests.gpr
@@ -46,6 +46,7 @@ project HTTP_Tests is
       "http3_public_smoke.adb",
       "http3_server_integration.adb",
       "http3_handshake_abandon.adb",
+      "http3_handshake_recovery.adb",
       "flyology-http-http_3_frame_policy-smoke.adb",
       "flyology-http-http_3_header_policy-smoke.adb",
       "flyology-http-http_3_message_policy-smoke.adb",


### PR DESCRIPTION
## Problem

`Flyology.QUIC.Connections` exposed loss recovery only for the application packet-number space. The Initial and Handshake spaces tracked nothing they had sent, parsed the peer's ACK frames and discarded them, and never acknowledged an ack-eliciting Initial or Handshake packet — which RFC 9000 §13.2.1 requires immediately. Nothing armed the RFC 9002 §6.2 probe timeout those spaces need.

Both HTTP/3 drivers inherited the gap. `Start_Connection` in `src/flyology-http-client-http_3_internals.adb` loops on `Receive_One` until the transport connects, and `Serve_Connection` in `src/flyology-http-server-http_3.adb` waits up to `Handshake_Timeout` for progress; neither retransmitted its own flight. One dropped datagram cost the caller's whole deadline instead of one probe timeout — which is how an ordinary transient loss became a hard CI failure in the raw handshake lane of `tests/http3_server_integration.adb`.

## Solution

**Retention.** New `Flyology.QUIC.Crypto_Flight` retains the CRYPTO ranges a space has sent, keyed by packet number, so a probe rebuilds a range under a *fresh* packet number rather than resending a packet QUIC forbids repeating. Capacity is a discriminant: 4 KiB for Initial, 18 KiB for Handshake.

**Per-space recovery.** `Initial_Space` and `Handshake_Space` each own a sent-packet ledger. Peer ACK frames now drive `Sent_Packet_Policy.Apply_ACK` and yield the delivery, loss, and RTT events the spaces previously threw away. Every packet a space builds carries the acknowledgment it owes, and a datagram producing no response sends an ACK-only packet, so a peer's probe timeout clears within one round trip.

**Path-wide timer.** `Connection_Driver` holds one `Recovery_Policy` state for both spaces — a single probe count backing off together, and a probe timeout that excludes `max_ack_delay` because handshake packets are acknowledged immediately. `Has_Recovery_Timeout` / `Recovery_Deadline` / `Process_Timeout` report the earlier of the handshake and application deadlines; an expired handshake timeout retransmits every unacknowledged CRYPTO range, or sends the §6.2.2.1 anti-deadlock probe when a client's peer has not completed address validation. Progress that can only follow delivery of a flight retires it without waiting for an ACK.

**Drivers.** Both already bounded each receive by `Recovery_Deadline` and processed an expired timer, so widening the timer made their loops retransmit. `Start_Client` gained a defaulted `Now` so the timer has an anchor. The raw QUIC lane in the server integration test now drives the same loop itself, since nothing else owns its clock.

### Judgment calls worth review

- Handshake-space congestion is accounted but never gates a send: the flight is far below the initial window and RFC 9002 permits probing regardless.
- Immediate acknowledgment costs one extra packet per silent datagram, including a padded 1200-byte client Initial ACK when only the ServerHello arrives. That is what lets a peer stop retransmitting after one round trip.

## Tests

- `flyology_quic/tests/src/flyology-quic-connections-recovery_smoke.adb` — deterministic, explicit clock: dropped client Initial (exact 999 ms first deadline, fresh packet number, doubled backoff), dropped server Handshake flight (only the unacknowledged ranges return, not the already-ACKed Initial flight), and the anti-deadlock probe.
- `tests/http3_handshake_recovery.adb` — routed server and standard client either side of a UDP relay that swallows one flight, classified by long-header packet type. Verified to have teeth: with the probe timer forced off it stalls the full 20 s and fails; with it, 1.8 s.

`./scripts/test.sh` passes (105 tests, QUIC crate suite included). `./scripts/docs.sh` regenerates `docs/api/index.html` with no new warnings. `./scripts/prove.sh` was not run — no proved policy unit changed, and `Crypto_Flight` is deliberately outside the SPARK set.
