### PR TITLE
Release an abandoned QUIC handshake's listener slot promptly

### DIFF
--- a/flyology_quic/src/flyology-quic-connection_driver.adb
+++ b/flyology_quic/src/flyology-quic-connection_driver.adb
@@ -280,6 +280,83 @@ package body Flyology.QUIC.Connection_Driver is
       end if;
    end Build_Application_Close_Datagram;
 
+   function Send_Status_For
+     (Value : Initial_Space.Build_Status)
+      return Application_Space.Send_Status
+   is
+     (case Value is
+         when Initial_Space.Built => Application_Space.Sent,
+         when Initial_Space.Crypto_Range_Too_Large =>
+           Application_Space.Internal_State_Error,
+         when Initial_Space.Packet_Number_Exhausted =>
+           Application_Space.Packet_Number_Exhausted,
+         when Initial_Space.Packet_Number_Unrepresentable =>
+           Application_Space.Packet_Number_Unrepresentable,
+         when Initial_Space.Packet_Too_Large =>
+           Application_Space.Packet_Too_Large,
+         when Initial_Space.Output_Too_Small =>
+           Application_Space.Output_Too_Small);
+
+   function Send_Status_For
+     (Value : Handshake_Space.Build_Status)
+      return Application_Space.Send_Status
+   is
+     (case Value is
+         when Handshake_Space.Built => Application_Space.Sent,
+         when Handshake_Space.Crypto_Range_Too_Large =>
+           Application_Space.Internal_State_Error,
+         when Handshake_Space.Packet_Number_Exhausted =>
+           Application_Space.Packet_Number_Exhausted,
+         when Handshake_Space.Packet_Number_Unrepresentable =>
+           Application_Space.Packet_Number_Unrepresentable,
+         when Handshake_Space.Packet_Too_Large =>
+           Application_Space.Packet_Too_Large,
+         when Handshake_Space.Output_Too_Small =>
+           Application_Space.Output_Too_Small);
+
+   procedure Build_Handshake_Close_Datagram
+     (Item       : in out Connection;
+      Error_Code : Varint_Policy.Value_Type;
+      Packet     : out Datagram;
+      Status     : out Application_Space.Send_Status)
+   is
+      Buffer : Ada.Streams.Stream_Element_Array (1 .. Max_Datagram_Length);
+      Length : Natural := 0;
+   begin
+      Packet := (others => <>);
+      if Item.Handshake_Initialized then
+         declare
+            Built : Handshake_Space.Build_Result;
+         begin
+            --  Frame type zero reports a close that no received frame
+            --  triggered, as RFC 9000 19.19 requires.
+            Handshake_Space.Build_Transport_Close_Packet
+              (Item.Handshake, Error_Code, 0, Buffer, Built);
+            Status := Send_Status_For (Built.Status);
+            if Built.Status = Handshake_Space.Built then
+               Length := Built.Packet_Length;
+            end if;
+         end;
+      else
+         declare
+            Built : Initial_Space.Build_Result;
+         begin
+            Initial_Space.Build_Transport_Close_Packet
+              (Item.Initial, Error_Code, 0, Buffer, Built);
+            Status := Send_Status_For (Built.Status);
+            if Built.Status = Initial_Space.Built then
+               Length := Built.Packet_Length;
+            end if;
+         end;
+      end if;
+      Packet.Length := Length;
+      if Length > 0 then
+         Packet.Data (1 .. Ada.Streams.Stream_Element_Offset (Length)) :=
+           Buffer (1 .. Ada.Streams.Stream_Element_Offset (Length));
+      end if;
+      Item.Current := Failed;
+   end Build_Handshake_Close_Datagram;
+
    function Append
      (Output : in out Datagram_Batch;
       Packet : Ada.Streams.Stream_Element_Array;
@@ -719,6 +796,12 @@ package body Flyology.QUIC.Connection_Driver is
            (Item, Transport_Error_For (Processed.Status),
             Frame_Type => 16#06#, Output => Output, Result => Result);
          return;
+      elsif Processed.Peer_Closed then
+         Item.Close_Is_Application := False;
+         Item.Close_Error := Processed.Close_Error;
+         Item.Current := Peer_Closed;
+         Result.Status := Connection_Closed;
+         return;
       end if;
       Length := Message_Length (Item.Initial);
       if Length = 0 then
@@ -871,6 +954,12 @@ package body Flyology.QUIC.Connection_Driver is
          Fail_Handshake_With_Close
            (Item, Transport_Error_For (Processed.Status),
             Frame_Type => 16#06#, Output => Output, Result => Result);
+         return;
+      elsif Processed.Peer_Closed then
+         Item.Close_Is_Application := False;
+         Item.Close_Error := Processed.Close_Error;
+         Item.Current := Peer_Closed;
+         Result.Status := Connection_Closed;
          return;
       end if;
 

--- a/flyology_quic/src/flyology-quic-connection_driver.ads
+++ b/flyology_quic/src/flyology-quic-connection_driver.ads
@@ -243,6 +243,19 @@ private package Flyology.QUIC.Connection_Driver is
       Status : out Application_Space.Send_Status)
    with Pre => Is_Connected (Item);
 
+   --  Build a transport CONNECTION_CLOSE in the highest encryption level the
+   --  connection holds before application keys exist: Handshake once the
+   --  handshake space is initialized, Initial otherwise. The connection
+   --  becomes Failed whether or not a packet could be produced.
+   procedure Build_Handshake_Close_Datagram
+     (Item       : in out Connection;
+      Error_Code : Varint_Policy.Value_Type;
+      Packet     : out Datagram;
+      Status     : out Application_Space.Send_Status)
+   with Pre => State (Item) in
+     Client_Initial | Client_Handshake | Server_Initial | Server_Handshake,
+     Post => State (Item) = Failed;
+
    function Has_Stream
      (Item : Connection; Stream_ID : Varint_Policy.Value_Type) return Boolean;
 

--- a/flyology_quic/src/flyology-quic-connections.adb
+++ b/flyology_quic/src/flyology-quic-connections.adb
@@ -704,6 +704,25 @@ package body Flyology.QUIC.Connections is
       Status := Public_Status (Internal_Status);
    end Build_Application_Close_Datagram;
 
+   --  RFC 9000 20.1 APPLICATION_ERROR: the application closed a connection
+   --  whose encryption level cannot carry an application CONNECTION_CLOSE.
+   Application_Error_Code : constant Varint_Policy.Value_Type := 16#0C#;
+
+   procedure Build_Handshake_Close_Datagram
+     (Item   : in out Connection;
+      Packet : out Datagram;
+      Status : out Send_Status)
+   is
+      Internal_Packet : Connection_Driver.Datagram;
+      Internal_Status : Application_Space.Send_Status;
+   begin
+      Connection_Driver.Build_Handshake_Close_Datagram
+        (Impl (Item).Driver, Application_Error_Code, Internal_Packet,
+         Internal_Status);
+      Copy (Internal_Packet, Packet);
+      Status := Public_Status (Internal_Status);
+   end Build_Handshake_Close_Datagram;
+
    function Stream_Count (Item : Connection) return Natural is
      (Connection_Driver.Stream_Count (Impl (Item).Driver));
 

--- a/flyology_quic/src/flyology-quic-connections.ads
+++ b/flyology_quic/src/flyology-quic-connections.ads
@@ -632,6 +632,26 @@ package Flyology.QUIC.Connections is
       Status     : out Send_Status)
    with Pre => Is_Connected (Item);
 
+   --  Build a transport CONNECTION_CLOSE for a connection abandoned before
+   --  application keys exist. An application CONNECTION_CLOSE cannot be sent
+   --  in the Initial or Handshake space, so this carries the transport
+   --  APPLICATION_ERROR code that RFC 9000 10.2.3 reserves for that case. The
+   --  packet uses Handshake protection once the handshake space is available
+   --  and Initial protection otherwise; a peer that reached either level can
+   --  read it. The connection becomes Failed whether or not a packet could be
+   --  produced, because an endpoint that has started closing must not send
+   --  anything else.
+   --  @param Item Endpoint that has not completed its handshake
+   --  @param Packet Datagram to transmit when Status is Sent
+   --  @param Status Build outcome
+   procedure Build_Handshake_Close_Datagram
+     (Item   : in out Connection;
+      Packet : out Datagram;
+      Status : out Send_Status)
+   with Pre => State (Item) in
+     Client_Initial | Client_Handshake | Server_Initial | Server_Handshake,
+     Post => State (Item) = Failed;
+
    --  Return the number of peer streams retained by the connection.
    --  @param Item Connection to inspect
    --  @return Number of retained streams

--- a/flyology_quic/src/flyology-quic-handshake_space.adb
+++ b/flyology_quic/src/flyology-quic-handshake_space.adb
@@ -184,6 +184,13 @@ package body Flyology.QUIC.Handshake_Space is
                Result.Status := Crypto_Data_Too_Large;
                return;
             end if;
+         elsif Frame.Kind = Initial_Frame_Policy.Transport_Close then
+            --  RFC 9000 10.2.2 puts the receiver into the draining state, so
+            --  the remaining frames of this packet cannot change the outcome.
+            Result.Peer_Closed := True;
+            Result.Close_Error := Frame.Close_Error_Code;
+            Result.Status := Processed;
+            return;
          end if;
          Cursor := Cursor + Frame.Consumed;
       end loop;

--- a/flyology_quic/src/flyology-quic-handshake_space.ads
+++ b/flyology_quic/src/flyology-quic-handshake_space.ads
@@ -84,6 +84,8 @@ private package Flyology.QUIC.Handshake_Space is
    type Process_Result is record
       Status      : Process_Status := Envelope_Rejected;
       Frame_Count : Natural := 0;
+      Peer_Closed : Boolean := False;
+      Close_Error : Varint_Policy.Value_Type := 0;
    end record;
 
    procedure Process_Packet

--- a/flyology_quic/src/flyology-quic-initial_space.adb
+++ b/flyology_quic/src/flyology-quic-initial_space.adb
@@ -88,13 +88,18 @@ package body Flyology.QUIC.Initial_Space is
       Frame : constant Initial_Frame_Policy.Transport_Close_Encode_Result :=
         Initial_Frame_Policy.Encode_Transport_Close (Error_Code, Frame_Type);
       Built : Initial_Connection.Build_Result;
+      --  RFC 9000 14.1 has a server discard any client Initial packet whose
+      --  datagram payload is under 1,200 bytes, closes included.
+      Minimum : constant Natural :=
+        (if Item.Role = Initial_Connection.Client
+         then 1_200 else 0);
    begin
       Packet := (others => 0);
       Result := (others => <>);
       Initial_Connection.Build_Initial_At_Least
         (Item.Packets, (1 .. 0 => 0),
          Frame.Data (1 .. Ada.Streams.Stream_Element_Offset (Frame.Length)),
-         Minimum_Packet_Length => 0, Packet => Packet, Result => Built);
+         Minimum_Packet_Length => Minimum, Packet => Packet, Result => Built);
       Result.Status :=
         (case Built.Status is
             when Initial_Connection.Built => Initial_Space.Built,
@@ -180,6 +185,13 @@ package body Flyology.QUIC.Initial_Space is
                Result.Status := Crypto_Data_Too_Large;
                return;
             end if;
+         elsif Frame.Kind = Initial_Frame_Policy.Transport_Close then
+            --  RFC 9000 10.2.2 puts the receiver into the draining state, so
+            --  the remaining frames of this packet cannot change the outcome.
+            Result.Peer_Closed := True;
+            Result.Close_Error := Frame.Close_Error_Code;
+            Result.Status := Processed;
+            return;
          end if;
          Cursor := Cursor + Frame.Consumed;
       end loop;

--- a/flyology_quic/src/flyology-quic-initial_space.ads
+++ b/flyology_quic/src/flyology-quic-initial_space.ads
@@ -86,6 +86,8 @@ private package Flyology.QUIC.Initial_Space is
       Status      : Process_Status := Envelope_Rejected;
       Frame_Count : Natural := 0;
       Peer_Source : Long_Header_Policy.Connection_ID;
+      Peer_Closed : Boolean := False;
+      Close_Error : Varint_Policy.Value_Type := 0;
    end record;
 
    procedure Process_Packet

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -111,6 +111,7 @@ flyology-http-http_3_connection-smoke
 development_certificates_smoke
 http3_public_smoke
 http3_server_integration
+http3_handshake_abandon
 flyology-http-http_3_frame_policy-smoke
 flyology-http-http_3_header_policy-smoke
 flyology-http-http_3_message_policy-smoke

--- a/src/flyology-http-client.adb
+++ b/src/flyology-http-client.adb
@@ -410,16 +410,25 @@ package body Flyology.HTTP.Client is
       end;
       begin
          if Sockets.Is_Open (Connection.UDP) then
-            if Connection.Protocol = HTTP_3_Transport
-              and then QUIC.Is_Connected (Connection.QUIC_Transport)
-            then
+            if Connection.Protocol = HTTP_3_Transport then
                declare
                   Packet : QUIC.Datagram;
-                  Status : QUIC.Send_Status;
+                  Status : QUIC.Send_Status := QUIC.Internal_State_Error;
                   Last   : Ada.Streams.Stream_Element_Offset;
                begin
-                  QUIC.Build_Application_Close_Datagram
-                    (Connection.QUIC_Transport, Packet, Status);
+                  if QUIC.Is_Connected (Connection.QUIC_Transport) then
+                     QUIC.Build_Application_Close_Datagram
+                       (Connection.QUIC_Transport, Packet, Status);
+                  elsif QUIC.State (Connection.QUIC_Transport) in
+                    QUIC.Client_Initial | QUIC.Client_Handshake
+                  then
+                     --  A connection abandoned mid-handshake, such as the
+                     --  losing lane of the address-family race, still owes
+                     --  the peer a close. Without it the server holds its
+                     --  connection slot for the whole handshake timeout.
+                     QUIC.Build_Handshake_Close_Datagram
+                       (Connection.QUIC_Transport, Packet, Status);
+                  end if;
                   if Status = QUIC.Sent and then Packet.Length > 0 then
                      Sockets.Send_Socket
                        (Connection.UDP,

--- a/src/flyology-http-server-http_3.adb
+++ b/src/flyology-http-server-http_3.adb
@@ -158,6 +158,7 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Pending_Streams : Stream_ID_Array (1 .. H3.Max_Prepared_Responses) :=
         (others => 0);
       Pending_Count : Natural range 0 .. H3.Max_Prepared_Responses := 0;
+      Progress  : Ada.Real_Time.Time := Ada.Real_Time.Clock;
       H3_Started : Boolean := False;
       ACK_Pending : Boolean := False;
       Closed    : Boolean := False;
@@ -516,6 +517,7 @@ package body Flyology.HTTP.Server.HTTP_3 is
       if Last < Packet'First then
          return;
       end if;
+      Item.Progress := Ada.Real_Time.Clock;
       if Item.H3_Started and then QUIC.Is_Connected (Item.Transport) then
          QUIC.Process_Datagram
            (Item.Transport, Packet (Packet'First .. Last), Flight, Status,
@@ -1314,7 +1316,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Handshake_Timeout  : Duration := 10.0;
       Max_Connection_Age : Duration := 300.0;
       Max_Requests       : Positive := Default_Requests_Per_Connection;
-      Token              : access Flyology.Cancellation.Token := null)
+      Token              : access Flyology.Cancellation.Token := null;
+      Handshake_Idle_Timeout : Duration := Default_Handshake_Idle_Timeout)
    is
       State : Connection_State_Access := new Connection_State'
         (Socket => Socket, Inbox => Inbox, Token => Token, others => <>);
@@ -1339,6 +1342,20 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Connection_Deadline : constant Ada.Real_Time.Time :=
         (if Max_Connection_Age < 0.0 then Ada.Real_Time.Time_Last
          else State.Epoch + Ada.Real_Time.To_Time_Span (Max_Connection_Age));
+      Handshake_Deadline : constant Ada.Real_Time.Time :=
+        State.Epoch + Ada.Real_Time.To_Time_Span (Handshake_Timeout);
+
+      --  Time left before an unconnected peer forfeits this connection slot.
+      --  The absolute handshake budget bounds a peer that keeps sending; the
+      --  no-progress budget reclaims the slot from one that stops.
+      function Handshake_Remaining return Duration is
+         Idle : constant Ada.Real_Time.Time :=
+           State.Progress + Ada.Real_Time.To_Time_Span
+             (Handshake_Idle_Timeout);
+      begin
+         return Remaining
+           (if Idle < Handshake_Deadline then Idle else Handshake_Deadline);
+      end Handshake_Remaining;
 
       procedure Start_HTTP_3 is
       begin
@@ -1599,9 +1616,10 @@ package body Flyology.HTTP.Server.HTTP_3 is
       if Max_Requests > Maximum_Requests_Per_Connection then
          raise Constraint_Error with
            "HTTP/3 request limit exceeds the bounded connection profile";
-      elsif Handshake_Timeout <= 0.0 then
+      elsif Handshake_Timeout <= 0.0 or else Handshake_Idle_Timeout <= 0.0
+      then
          raise Constraint_Error with
-           "HTTP/3 handshake timeout must be positive";
+           "HTTP/3 handshake timeouts must be positive";
       end if;
       if First.Length = 0 or else First.Metadata.Truncated then
          raise Protocol_Error with "invalid first QUIC datagram";
@@ -1634,14 +1652,10 @@ package body Flyology.HTTP.Server.HTTP_3 is
          return;
       end if;
       while not QUIC.Is_Connected (State.Transport) loop
-         if Remaining (State.Epoch + Ada.Real_Time.To_Time_Span
-           (Handshake_Timeout)) = 0.0
-         then
+         if Handshake_Remaining = 0.0 then
             raise Flyology.IO.Timeout_Error;
          end if;
-         Receive_One
-           (State.all, Remaining
-             (State.Epoch + Ada.Real_Time.To_Time_Span (Handshake_Timeout)));
+         Receive_One (State.all, Handshake_Remaining);
          if State.Closed then
             Cleanup;
             return;
@@ -1692,7 +1706,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Handshake_Timeout  : Duration := 10.0;
       Max_Connection_Age : Duration := 300.0;
       Max_Requests       : Positive := Default_Requests_Per_Connection;
-      Token              : access Flyology.Cancellation.Token := null)
+      Token              : access Flyology.Cancellation.Token := null;
+      Handshake_Idle_Timeout : Duration := Default_Handshake_Idle_Timeout)
    is
       First : Received_Datagram;
       Last  : Stream_Element_Offset;
@@ -1724,7 +1739,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Serve_Connection
         (Context, Socket'Unchecked_Access, null, First, Certificate_DER,
          Private_Key, Source, Transport_Settings, Timeout,
-         Handshake_Timeout, Max_Connection_Age, Max_Requests, Token);
+         Handshake_Timeout, Max_Connection_Age, Max_Requests, Token,
+         Handshake_Idle_Timeout);
    end Serve;
 
    procedure Serve_Listener
@@ -1738,7 +1754,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Handshake_Timeout  : Duration := 10.0;
       Max_Connection_Age : Duration := 300.0;
       Max_Requests       : Positive := Default_Requests_Per_Connection;
-      Token              : not null access Flyology.Cancellation.Token)
+      Token              : not null access Flyology.Cancellation.Token;
+      Handshake_Idle_Timeout : Duration := Default_Handshake_Idle_Timeout)
    is
       subtype Slot_Index is Positive range 1 .. Capacity;
       subtype Inbox is Datagram_Channels.Channel (Capacity => 32);
@@ -1773,7 +1790,8 @@ package body Flyology.HTTP.Server.HTTP_3 is
                         Inboxes (Slot)'Unchecked_Access, Message,
                         Certificate_DER, Private_Key, Message.Source,
                         Transport_Settings, Timeout, Handshake_Timeout,
-                        Max_Connection_Age, Max_Requests, Token);
+                        Max_Connection_Age, Max_Requests, Token,
+                        Handshake_Idle_Timeout);
                   exception
                      when Error : others =>
                         if Debug.Enabled then
@@ -1808,9 +1826,10 @@ package body Flyology.HTTP.Server.HTTP_3 is
       elsif Max_Requests > Maximum_Requests_Per_Connection then
          raise Constraint_Error with
            "HTTP/3 request limit exceeds the bounded connection profile";
-      elsif Handshake_Timeout <= 0.0 then
+      elsif Handshake_Timeout <= 0.0 or else Handshake_Idle_Timeout <= 0.0
+      then
          raise Constraint_Error with
-           "HTTP/3 handshake timeout must be positive";
+           "HTTP/3 handshake timeouts must be positive";
       end if;
 
       Sockets.Enable_Datagram_Metadata (Socket);
@@ -1885,12 +1904,15 @@ package body Flyology.HTTP.Server.HTTP_3 is
       Handshake_Timeout  : Duration := 10.0;
       Max_Connection_Age : Duration := 300.0;
       Max_Requests       : Positive := Default_Requests_Per_Connection;
-      Token              : access Flyology.Cancellation.Token := null) is
+      Token              : access Flyology.Cancellation.Token := null;
+      Handshake_Idle_Timeout : Duration := Default_Handshake_Idle_Timeout)
+   is
    begin
       Serve
         (Context, Socket, Certificate_DER, Private_Key,
          QUIC.Random_Connection_ID, Transport_Settings, Timeout,
-         Handshake_Timeout, Max_Connection_Age, Max_Requests, Token);
+         Handshake_Timeout, Max_Connection_Age, Max_Requests, Token,
+         Handshake_Idle_Timeout);
    end Serve;
 
 end Flyology.HTTP.Server.HTTP_3;

--- a/src/flyology-http-server-http_3.ads
+++ b/src/flyology-http-server-http_3.ads
@@ -24,6 +24,13 @@ package Flyology.HTTP.Server.HTTP_3 is
    --  Largest accepted listener capacity for the task-per-connection profile.
    Maximum_Connection_Capacity : constant Positive := 256;
 
+   --  Default no-progress deadline for a connection that has not completed
+   --  its QUIC handshake. A peer that abandons a handshake without sending
+   --  CONNECTION_CLOSE would otherwise hold its listener slot for the whole
+   --  handshake timeout. Handshake retransmission arrives well inside this
+   --  window on a lossy path, so only a silent peer reaches it.
+   Default_Handshake_Idle_Timeout : constant Duration := 3.0;
+
    --  Default lifetime request policy. Completed request reassembly is
    --  recycled; 32 retained QUIC streams bound concurrency, while compact
    --  flow-control accounting supports long-lived connections without
@@ -45,6 +52,8 @@ package Flyology.HTTP.Server.HTTP_3 is
    --  @param Transport_Settings QUIC flow-control and stream limits
    --  @param Timeout Per-request application deadline
    --  @param Handshake_Timeout Maximum time to establish each QUIC connection
+   --  @param Handshake_Idle_Timeout Maximum time an unconnected peer may go
+   --    silent before its connection slot is reclaimed
    --  @param Max_Connection_Age Absolute lifetime of each connection
    --  @param Max_Requests Requests served by each connection
    --  @param Token Required listener shutdown and connection cancellation
@@ -60,11 +69,13 @@ package Flyology.HTTP.Server.HTTP_3 is
       Handshake_Timeout  : Duration := 10.0;
       Max_Connection_Age : Duration := 300.0;
       Max_Requests       : Positive := Default_Requests_Per_Connection;
-      Token              : not null access Flyology.Cancellation.Token)
+      Token              : not null access Flyology.Cancellation.Token;
+      Handshake_Idle_Timeout : Duration := Default_Handshake_Idle_Timeout)
    with Pre => Flyology.IO.Sockets.Is_Open (Socket)
      and then Certificate_DER'Length in 1 .. 4_096
      and then Capacity <= Maximum_Connection_Capacity
      and then Handshake_Timeout > 0.0
+     and then Handshake_Idle_Timeout > 0.0
      and then Max_Requests <= Maximum_Requests_Per_Connection;
 
    --  Serve routed requests from one QUIC peer using a securely generated
@@ -82,6 +93,8 @@ package Flyology.HTTP.Server.HTTP_3 is
    --    unlimited
    --  @param Max_Requests Requests served before Serve returns
    --  @param Token Optional connection cancellation source
+   --  @param Handshake_Idle_Timeout Maximum time an unconnected peer may go
+   --    silent before Serve returns
    procedure Serve
      (Context            : in out App_Context;
       Socket             : aliased in out Flyology.IO.Sockets.Socket_Type;
@@ -93,10 +106,12 @@ package Flyology.HTTP.Server.HTTP_3 is
       Handshake_Timeout  : Duration := 10.0;
       Max_Connection_Age : Duration := 300.0;
       Max_Requests       : Positive := Default_Requests_Per_Connection;
-      Token              : access Flyology.Cancellation.Token := null)
+      Token              : access Flyology.Cancellation.Token := null;
+      Handshake_Idle_Timeout : Duration := Default_Handshake_Idle_Timeout)
    with Pre => Flyology.IO.Sockets.Is_Open (Socket)
      and then Certificate_DER'Length in 1 .. 4_096
      and then Handshake_Timeout > 0.0
+     and then Handshake_Idle_Timeout > 0.0
      and then Max_Requests <= Maximum_Requests_Per_Connection;
 
    --  Serve routed requests from one QUIC peer. Certificate_DER and
@@ -116,6 +131,8 @@ package Flyology.HTTP.Server.HTTP_3 is
    --    unlimited
    --  @param Max_Requests Requests served before Serve returns
    --  @param Token Optional connection cancellation source
+   --  @param Handshake_Idle_Timeout Maximum time an unconnected peer may go
+   --    silent before Serve returns
    procedure Serve
      (Context            : in out App_Context;
       Socket             : aliased in out Flyology.IO.Sockets.Socket_Type;
@@ -128,10 +145,12 @@ package Flyology.HTTP.Server.HTTP_3 is
       Handshake_Timeout  : Duration := 10.0;
       Max_Connection_Age : Duration := 300.0;
       Max_Requests       : Positive := Default_Requests_Per_Connection;
-      Token              : access Flyology.Cancellation.Token := null)
+      Token              : access Flyology.Cancellation.Token := null;
+      Handshake_Idle_Timeout : Duration := Default_Handshake_Idle_Timeout)
    with Pre => Flyology.IO.Sockets.Is_Open (Socket)
      and then Certificate_DER'Length in 1 .. 4_096
      and then Handshake_Timeout > 0.0
+     and then Handshake_Idle_Timeout > 0.0
      and then Max_Requests <= Maximum_Requests_Per_Connection
      and then Source.Length in 1 ..
        Flyology.QUIC.Connections.Max_Connection_ID_Length;

--- a/tests/http3_handshake_abandon.adb
+++ b/tests/http3_handshake_abandon.adb
@@ -1,0 +1,278 @@
+with Ada.Exceptions;
+with Ada.Real_Time;
+with Ada.Strings.Unbounded;
+with Flyology.Cancellation;
+with Flyology.HTTP.Server.Applications;
+with Flyology.HTTP.Server.HTTP_3;
+with Flyology.IO;
+with Flyology.IO.Sockets;
+with Flyology.QUIC.Connections;
+with Flyology.QUIC.Connections.IO;
+with Flyology.QUIC.Test_Connections;
+
+--  A peer that abandons a QUIC handshake must not pin a listener connection
+--  slot until the handshake timeout expires. Two mechanisms are covered here.
+--  A cooperative peer, such as the losing lane of the client's address-family
+--  race, sends a transport CONNECTION_CLOSE from the Initial or Handshake
+--  space. A peer that simply stops answering is reclaimed by the listener's
+--  no-progress deadline. Each phase saturates a listener of capacity N with
+--  half-open handshakes and then asserts that a fresh Initial is admitted
+--  well inside the handshake timeout.
+procedure HTTP3_Handshake_Abandon is
+   package App renames Flyology.HTTP.Server.Applications;
+   package QUIC renames Flyology.QUIC.Connections;
+   package QUIC_IO renames Flyology.QUIC.Connections.IO;
+   package Sockets renames Flyology.IO.Sockets;
+   package Fixtures renames Flyology.QUIC.Test_Connections;
+
+   use Ada.Strings.Unbounded;
+   use type Ada.Real_Time.Time;
+   use type QUIC.Connection_State;
+   use type QUIC.Operation_Status;
+   use type QUIC.Send_Status;
+
+   Capacity : constant := 3;
+
+   --  Far longer than every deadline asserted below, so a slot reclaimed
+   --  inside one of those deadlines cannot be explained by this timeout.
+   Server_Handshake_Timeout : constant Duration := 20.0;
+
+   type Context is limited null record;
+
+   procedure Handle (Application : in out Context; X : in out App.Exchange) is
+      pragma Unreferenced (Application);
+   begin
+      X.Text (200, "ok");
+   end Handle;
+
+   package Engine is new Flyology.HTTP.Server.HTTP_3 (Context, Handle);
+
+   --  Each phase runs its own listener and so needs its own shutdown token.
+   --  A connection's state retains the token, so the tokens must live no
+   --  deeper than the instance that allocates that state.
+   Close_Stop  : aliased Flyology.Cancellation.Token;
+   Silent_Stop : aliased Flyology.Cancellation.Token;
+
+   protected Outcome is
+      procedure Fail (Message : String);
+      function Passed return Boolean;
+      function Message return String;
+   private
+      Failed : Boolean := False;
+      Detail : Unbounded_String;
+   end Outcome;
+
+   protected body Outcome is
+      procedure Fail (Message : String) is
+      begin
+         if not Failed then
+            Detail := To_Unbounded_String (Message);
+         end if;
+         Failed := True;
+      end Fail;
+
+      function Passed return Boolean is (not Failed);
+
+      function Message return String is (To_String (Detail));
+   end Outcome;
+
+   --  One client lane holding a half-open handshake against the listener.
+   type Lane is limited record
+      Socket    : Sockets.Socket_Type;
+      Transport : QUIC.Connection;
+      Initial   : QUIC.Datagram_Batch;
+   end record;
+
+   type Lane_Array is array (1 .. Capacity) of Lane;
+
+   --  Send a client Initial and stop short of a completed handshake. When
+   --  Advance is set the lane also consumes the ServerHello, which installs
+   --  handshake keys; that lane then abandons from the Handshake space while
+   --  the others abandon from the Initial space.
+   procedure Start_Half_Open
+     (Item    : in out Lane;
+      Address : Sockets.Endpoint;
+      Advance : Boolean)
+   is
+      Flight : QUIC.Datagram_Batch;
+      Status : QUIC.Operation_Status;
+   begin
+      Sockets.Create_Socket
+        (Item.Socket, Address.Family, Sockets.Socket_Datagram);
+      Sockets.Connect_Socket (Item.Socket, Address);
+      Fixtures.Initialize_Client (Item.Transport);
+      QUIC.Start_Client (Item.Transport, Item.Initial, Status);
+      pragma Assert (Status = QUIC.Succeeded, "client Initial not built");
+      QUIC_IO.Send (Item.Socket, Item.Initial, Timeout => 5.0);
+      if Advance then
+         for Attempt in 1 .. 4 loop
+            exit when QUIC.State (Item.Transport) = QUIC.Client_Handshake;
+            QUIC_IO.Receive
+              (Item.Socket, Item.Transport, Flight, Status, Timeout => 5.0);
+            pragma Assert
+              (Status in QUIC.Succeeded | QUIC.Waiting_For_More,
+               "server handshake flight rejected");
+            QUIC_IO.Send (Item.Socket, Flight, Timeout => 5.0);
+         end loop;
+         pragma Assert
+           (QUIC.State (Item.Transport) = QUIC.Client_Handshake,
+            "lane did not install handshake keys");
+      end if;
+   end Start_Half_Open;
+
+   --  Abandon a half-open lane the way the losing lane of the client's
+   --  address-family race does.
+   procedure Abandon (Item : in out Lane) is
+      Packet : QUIC.Datagram;
+      Status : QUIC.Send_Status;
+   begin
+      pragma Assert
+        (QUIC.State (Item.Transport) in
+           QUIC.Client_Initial | QUIC.Client_Handshake,
+         "lane completed its handshake before abandoning");
+      QUIC.Build_Handshake_Close_Datagram (Item.Transport, Packet, Status);
+      pragma Assert (Status = QUIC.Sent, "handshake close not built");
+      pragma Assert (Packet.Length > 0, "handshake close is empty");
+      QUIC_IO.Send (Item.Socket, Packet, Timeout => 5.0);
+   end Abandon;
+
+   --  Report whether the listener completes a fresh handshake within Budget.
+   --  The Initial is repeated while no worker answers, the way a real client's
+   --  probe timeout would, so a slot released partway through Budget is still
+   --  taken up.
+   procedure Probe_Admission
+     (Address : Sockets.Endpoint;
+      Budget  : Duration;
+      Result  : out Boolean)
+   is
+      Item   : Lane;
+      Flight : QUIC.Datagram_Batch;
+      Status : QUIC.Operation_Status;
+      Ends   : Ada.Real_Time.Time;
+   begin
+      Start_Half_Open (Item, Address, Advance => False);
+      Ends := Ada.Real_Time.Clock + Ada.Real_Time.To_Time_Span (Budget);
+      while not QUIC.Is_Connected (Item.Transport)
+        and then Ada.Real_Time.Clock < Ends
+      loop
+         begin
+            QUIC_IO.Receive
+              (Item.Socket, Item.Transport, Flight, Status, Timeout => 0.25);
+            exit when Status not in QUIC.Succeeded | QUIC.Waiting_For_More;
+            QUIC_IO.Send (Item.Socket, Flight, Timeout => 5.0);
+         exception
+            when Flyology.IO.Timeout_Error =>
+               QUIC_IO.Send (Item.Socket, Item.Initial, Timeout => 5.0);
+         end;
+      end loop;
+      Result := QUIC.Is_Connected (Item.Transport);
+      Sockets.Close_Socket (Item.Socket);
+   end Probe_Admission;
+
+   --  Saturate a listener of capacity N with half-open handshakes, release
+   --  them through Close_Lanes or through the no-progress deadline, and
+   --  require a fresh Initial to be admitted inside Probe_Budget.
+   procedure Run_Phase
+     (Stop              : not null access Flyology.Cancellation.Token;
+      Idle_Timeout      : Duration;
+      Close_Lanes       : Boolean;
+      Saturation_Budget : Duration;
+      Probe_Budget      : Duration)
+   is
+      Listener : aliased Sockets.Socket_Type;
+      Address  : Sockets.Endpoint;
+      State    : aliased Context;
+   begin
+      Sockets.Create_Socket (Listener, Sockets.IPv4, Sockets.Socket_Datagram);
+      Sockets.Bind_Socket
+        (Listener,
+         Sockets.Network_Endpoint (Sockets.Loopback_IPv4, Sockets.Any_Port));
+      Address := Sockets.Get_Socket_Name (Listener);
+      declare
+         task type Server_Task_Type;
+         for Server_Task_Type'Storage_Size use 16 * 1_024 * 1_024;
+         Server_Task : Server_Task_Type;
+
+         task body Server_Task_Type is
+         begin
+            Engine.Serve_Listener
+              (State, Listener,
+               Fixtures.Server_Certificate, Fixtures.Server_Private_Key,
+               Capacity => Capacity,
+               Timeout => 10.0,
+               Handshake_Timeout => Server_Handshake_Timeout,
+               Max_Connection_Age => 60.0,
+               Token => Stop,
+               Handshake_Idle_Timeout => Idle_Timeout);
+         exception
+            when Error : others =>
+               Outcome.Fail (Ada.Exceptions.Exception_Information (Error));
+               Stop.Request;
+         end Server_Task_Type;
+
+         Lanes    : Lane_Array;
+         Admitted : Boolean;
+      begin
+         for Index in Lanes'Range loop
+            Start_Half_Open
+              (Lanes (Index), Address, Advance => Index mod 2 = 1);
+         end loop;
+
+         --  Every slot is now held by a handshake that will never complete.
+         Probe_Admission (Address, Saturation_Budget, Admitted);
+         pragma Assert
+           (not Admitted,
+            "listener admitted more connections than its capacity");
+
+         if Close_Lanes then
+            for Index in Lanes'Range loop
+               Abandon (Lanes (Index));
+            end loop;
+         end if;
+
+         Probe_Admission (Address, Probe_Budget, Admitted);
+         pragma Assert
+           (Admitted,
+            "abandoned handshakes held their listener slots past the probe "
+            & "budget");
+
+         for Index in Lanes'Range loop
+            Sockets.Close_Socket (Lanes (Index).Socket);
+         end loop;
+         Stop.Request;
+      exception
+         when others =>
+            Stop.Request;
+            raise;
+      end;
+      Sockets.Close_Socket (Listener);
+   end Run_Phase;
+begin
+   --  A cooperative peer releases its slot as soon as its CONNECTION_CLOSE
+   --  arrives, so the no-progress deadline is set beyond the whole phase to
+   --  keep it out of the result.
+   Run_Phase
+     (Stop              => Close_Stop'Access,
+      Idle_Timeout      => Server_Handshake_Timeout,
+      Close_Lanes       => True,
+      Saturation_Budget => 1.5,
+      Probe_Budget      => 5.0);
+
+   --  A peer that vanishes without a close is reclaimed by the no-progress
+   --  deadline alone. The saturation probe finishes before that deadline can
+   --  free a slot.
+   Run_Phase
+     (Stop              => Silent_Stop'Access,
+      Idle_Timeout      => 2.0,
+      Close_Lanes       => False,
+      Saturation_Budget => 1.0,
+      Probe_Budget      => 8.0);
+
+   pragma Assert (Outcome.Passed, Outcome.Message);
+exception
+   when others =>
+      --  A listener that died takes every client operation down with it, so
+      --  report its own failure rather than the timeout it caused here.
+      pragma Assert (Outcome.Passed, Outcome.Message);
+      raise;
+end HTTP3_Handshake_Abandon;

--- a/tests/http_tests.gpr
+++ b/tests/http_tests.gpr
@@ -45,6 +45,7 @@ project HTTP_Tests is
       "http3_client_stress_probe.adb",
       "http3_public_smoke.adb",
       "http3_server_integration.adb",
+      "http3_handshake_abandon.adb",
       "flyology-http-http_3_frame_policy-smoke.adb",
       "flyology-http-http_3_header_policy-smoke.adb",
       "flyology-http-http_3_message_policy-smoke.adb",


### PR DESCRIPTION
For HTTP/3 both lanes of the client's address-family race run a full QUIC
handshake before `Race.Choose` picks a winner. The losing lane raises
`Connection_Race_Lost` and `Dispose_Connection` sends a CONNECTION_CLOSE only
when the transport reached the connected state, so a lane cancelled
mid-handshake just closes its UDP socket. The server stays parked in
`Serve_Connection`'s pre-handshake wait and pins its `Connection_Registry` slot
for the whole handshake timeout. On a bounded listener that is seconds per
abandoned handshake, and a peer that repeatedly starts and abandons them can
hold every slot.

## What this does

**Send the close (cooperative peers).** This needed work on both sides of the
transport, not just a new builder. `Initial_Space` and `Handshake_Space` already
parsed a peer `Transport_Close` frame and then discarded it, so a close sent in
either space would have been ignored regardless. They now report it, and
`Connection_Driver` acts on it exactly as it already does for the application
space. The outbound half is `Flyology.QUIC.Connections.Build_Handshake_Close_Datagram`,
which uses Handshake protection once that space exists and Initial otherwise,
carrying the transport `APPLICATION_ERROR` code RFC 9000 §10.2.3 reserves for an
application close its encryption level cannot express.

`Dispose_Connection` then picks the close by transport state instead of skipping
it, so an abandoned lane tells the server before dropping the socket.

**Reclaim the slot anyway (everyone else).** A crashed, partitioned, or hostile
peer still says nothing. `Serve_Connection` now records each inbound datagram and
deadlines an unconnected peer on the earlier of the absolute handshake budget and
last-arrival plus `Handshake_Idle_Timeout`, defaulting to three seconds.
Handshake retransmission on a lossy path arrives well inside that window and
counts as progress, so only a silent peer reaches it. `Serve_Listener` and both
`Serve` overloads take an override; `Routing.Serve` gets the shorter reclamation
from the default rather than growing a parameter on eight overloads.

**Fixed in passing.** `Initial_Space.Build_Transport_Close_Packet` passed a zero
minimum packet length for both roles, so a client-sent Initial close fell under
1,200 bytes and RFC 9000 §14.1 requires a server to discard it. Now role-derived,
which also repairs the existing client `Fail_Initial_With_Close` path.

## Deciding the race earlier was considered and rejected

The lanes are UDP, so `Connect_Socket` costs no round trip and deciding before
the handshake would decide on nothing. Deciding at the first server response
still leaves the loser mid-handshake owing the server a close, so it replaces the
problem with itself.

## Testing

`tests/http3_handshake_abandon.adb` runs two phases against a capacity-three
listener whose handshake timeout is twenty seconds — far beyond every deadline it
asserts, so a slot reclaimed inside one of them cannot be explained by that
timeout. Each phase fills every slot with a handshake that will not complete,
asserts a further probe is refused, releases the lanes, then requires a fresh
Initial to be admitted. Phase one abandons with closes and keeps the no-progress
deadline out of range; phase two goes silent and relies on that deadline alone.
Odd lanes consume the ServerHello first so they abandon from the Handshake space
while even lanes abandon from the Initial space, covering both protection levels.
Runs in under four seconds.

Each phase was confirmed to fail on its own: removing the driver's peer-close
reporting fails the first, dropping the no-progress term fails the second.

`./scripts/test.sh` passes on the final tree (61 HTTP mains, 43 QUIC mains).
`./scripts/docs.sh` generates `docs/api/index.html` without errors and both new
public entities appear in it. `prove.sh` was not required — no unit in either
crate's proved list is touched.

## Known coverage boundary

The test drives the abandon through the same calls `Dispose_Connection` makes,
but does not drive the client's dual-stack race itself. Forcing which family
loses would mean wiring the HTTP/3 path into the `FLYOLOGY_CONNECTION_TEST_HOOKS`
barrier machinery, which is a much larger change than the regression this adds.
The client wiring is a three-line guard over the mechanism the test does cover.
