### PR TITLE
Document this crate and nothing else in the API reference

### DIFF
--- a/flyology_http.gpr
+++ b/flyology_http.gpr
@@ -98,8 +98,24 @@ project Flyology_HTTP is
    end Binder;
 
    package Documentation is
+      --  GNATdoc documents every project in the closure that is not excluded
+      --  here, so a documented spec that names a dependency drags that
+      --  dependency's entities into the generated index. This reference
+      --  publishes the HTTP API, as its own footer says, so every dependency
+      --  is excluded and the index lists this crate's units alone.
+      --
+      --  Each is named through the prefix Alire exports for its crate rather
+      --  than a path under FLYOLOGY_ROOT: the Flyology crate vendors copies
+      --  of these sources, so the two resolve to different build directories,
+      --  and GNATdoc rejects an excluded file that is not the project it
+      --  actually loaded rather than quietly ignoring it.
       for Excluded_Project_Files use
-        (external ("FLYOLOGY_ROOT", "") & "/flyology.gpr");
+        (external ("FLYOLOGY_ROOT", "") & "/flyology.gpr",
+         external ("FLYOLOGY_CACHELINES_ALIRE_PREFIX", "")
+         & "/flyology_cachelines.gpr",
+         external ("FLYOLOGY_ALLOCATORS_ALIRE_PREFIX", "")
+         & "/flyology_allocators.gpr",
+         external ("FLYOLOGY_QUIC_ALIRE_PREFIX", "") & "/flyology_quic.gpr");
       for Resources_Dir ("html") use "docs/gnatdoc/html";
    end Documentation;
 


### PR DESCRIPTION
The Pages workflow has failed on every push to `main` since "The router's
dispatch-read words share a region with writer state", with the same two
failures each time:

```
api/index.html: missing target: df52f7db….html
api/index.html: missing target: 810ae57d….html
Site check failed with 2 problem(s).
```

That commit added `private with Flyology_Cachelines.Padded_Groups` to
`flyology-http-server-routing.ads`, one of the specs the documentation build
documents. GNATdoc walks every project in the closure that
`Documentation.Excluded_Project_Files` does not name, so the private with
dragged the cachelines crate in with it, and its two tagged types —
`Fitted_Groups.Grouped_Array` and `Padded_Groups.Grouped_Array` — landed in the
index's tagged-type section linked to pages of their own. GNATdoc writes a page
per tagged type only under `--html-oop-style`, which this build does not pass.
This crate's own tagged types are linked as unit page plus fragment and resolve;
those two never could.

CI is unaffected — the two workflows fail independently, and only Pages was ever
red — but the published site has been frozen at the last green deploy since.

## What this does

Names every dependency in `Excluded_Project_Files`, beside the Flyology runtime
that was already there. Excluding cachelines alone would clear the two broken
links, but the closure walk is why they were reachable at all, and the same walk
had already put twenty-four pages of QUIC and allocator internals into a
reference whose own footer reads "Public HTTP API only".

|                 | before        | after            |
| --------------- | ------------- | ---------------- |
| generated pages | 66            | 42               |
| index entries   | 88 (2 broken) | 62, all HTTP     |
| search index    | 3585 names    | 2441, no deps    |
| site check      | 2 failures    | passed           |

Removing those pages breaks no link: their only inbound references were the
index entries that go away with them, confirmed by scanning every website page
and every generated page for their file names.

Each exclusion names its project through the prefix Alire exports for that crate
rather than a path under `FLYOLOGY_ROOT`. The Flyology crate vendors copies of
the cachelines and allocator sources, so the two resolve to different build
directories, and GNATdoc rejects an excluded file that is not the project it
loaded — `unable to resolve project file path`, a hard error rather than a
silent no-op, so naming the vendored copy fails the run outright. A bare project
name fails the same way.

## Verification

`./scripts/build-site.sh`, which is what the workflow runs, with `docs/api`
deleted first — that directory is never cleaned between runs, and a stale page
left behind by an earlier run hides a link the workflow cannot resolve:

```
Site check passed: 70 HTML files and 136 total files.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)