### PR TITLE
Release flyology_quic 0.1.1

### DIFF
--- a/flyology_quic/alire.toml
+++ b/flyology_quic/alire.toml
@@ -1,6 +1,6 @@
 name = "flyology_quic"
 description = "Ada-native QUIC transport for Flyology tasks"
-version = "0.1.1-dev"
+version = "0.1.1"
 
 authors = ["Yurii Rashkovskii"]
 maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]
@@ -11,7 +11,7 @@ tags = ["ada", "quic", "transport", "udp"]
 project-files = ["flyology_quic.gpr"]
 
 [[depends-on]]
-flyology = "~0.1.1-dev"
+flyology = "~0.1.0"
 
 [[actions]]
 type = "test"


### PR DESCRIPTION
## Problem

The merged HTTP client uses QUIC handshake-close and client-start APIs newer than the published `flyology_quic=0.1.0`. Releasing HTTP with a `~0.1.0` QUIC constraint would therefore claim compatibility that does not compile.

## Solution

- release `flyology_quic=0.1.1`
- replace its development Flyology constraint with the stable `~0.1.0` line
- validate the implementation against exactly the oldest published `flyology=0.1.0`

## Qualification

- `flyology_quic/scripts/test.sh` — PASS, complete behavioral and published RFC-vector suite against exactly `flyology=0.1.0`
- `flyology_quic/scripts/prove.sh` — PASS, all 2,090 checks proved against exactly `flyology=0.1.0`
- `alr show` — PASS; manifest reports `flyology_quic=0.1.1` and `flyology~0.1.0`
