### PR TITLE
Release flyology_http 0.1.1

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "flyology_http"
 description = "HTTP client and server library for Flyology tasks"
-version = "0.1.1-dev"
+version = "0.1.1"
 
 authors = ["Yurii Rashkovskii"]
 maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]
@@ -11,12 +11,9 @@ tags = ["ada", "http", "client", "server", "websocket", "sse"]
 project-files = ["flyology_http.gpr"]
 
 [[depends-on]]
-flyology = "~0.1.1-dev"
-flyology_cachelines = "~0.1.1-dev"
-flyology_quic = "~0.1.1-dev"
-
-[[pins]]
-flyology_quic = { path = "flyology_quic" }
+flyology = "=0.1.0"
+flyology_cachelines = "=0.1.0"
+flyology_quic = "=0.1.1"
 
 [[actions]]
 type = "test"


### PR DESCRIPTION
Publishes the merged S3 prerequisite work as flyology_http 0.1.1. Removes the local QUIC pin and development dependencies, resolving the deterministic stable set flyology=0.1.0, flyology_cachelines=0.1.0, and flyology_quic=0.1.1. Local qualification: ./scripts/test.sh passed against that exact set; ./scripts/prove.sh passed all 2917 checks (the nested QUIC proof harness retains its documented development proof dependency context).