### PR TITLE
fix(http2): accept empty HEAD stream completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject fixed-response overruns before transport writes, fail underruns at
   stream completion, isolate failed HTTP/2 and HTTP/3 streams, and preserve the
   declared representation length while suppressing `HEAD` response bodies.
+- Accept legal HTTP/2 `HEAD` responses that complete with an empty DATA frame
+  after advertising the representation's nonzero `Content-Length`.
 
 ## [0.1.1] - 2026-08-21
 

--- a/scripts/http2-test.sh
+++ b/scripts/http2-test.sh
@@ -51,7 +51,7 @@ run_client () {
   require_tester
   build_test http2_client_integration http2-integration
   for model in native lightweight; do
-    for scenario in basic prior fallback require-failure multiplex continuation peer-capacity stream-order flow upload early-final reset-race zero-read bad-preface informational-end flood shutdown-race goaway refused refused-post; do
+    for scenario in basic prior fallback require-failure multiplex continuation peer-capacity stream-order flow upload early-final head-empty-data reset-race zero-read bad-preface informational-end flood shutdown-race goaway refused refused-post; do
       run_dir=$(mktemp -d "${TMPDIR:-/tmp}/flyology-http2.XXXXXX")
       port_file="$run_dir/port"
       log_file="$run_dir/events.jsonl"

--- a/src/flyology-http-http_2_client_connection.adb
+++ b/src/flyology-http-http_2_client_connection.adb
@@ -1162,6 +1162,7 @@ package body Flyology.HTTP.HTTP_2_Client_Connection is
          end if;
          if End_Stream then
             if Streams (Index).Has_Expected_Length
+              and then not Streams (Index).Body_Forbidden
               and then Streams (Index).Received_Length /=
                 Streams (Index).Expected_Length
             then

--- a/tests/http2_client_integration.adb
+++ b/tests/http2_client_integration.adb
@@ -8,6 +8,7 @@ with Flyology;
 with Flyology.Bytes;
 with Flyology.HTTP;
 with Flyology.HTTP.Client;
+with Flyology.HTTP.Methods;
 with Flyology.IO.TLS.OpenSSL;
 
 procedure HTTP2_Client_Integration is
@@ -289,6 +290,8 @@ begin
                end if;
             elsif Scenario = "refused-post" then
                Client.Set_Method (Value, Flyology.HTTP.To_Method ("POST"));
+            elsif Scenario = "head-empty-data" then
+               Client.Set_Method (Value, Flyology.HTTP.Methods.HEAD);
             end if;
             if Scenario in
               "require-failure" | "refused-post" | "bad-preface" |
@@ -316,6 +319,12 @@ begin
                      Check_Flow (Reply);
                   elsif Scenario = "early-final" then
                      pragma Assert (Client.Status (Reply) = 413);
+                     pragma Assert
+                       (Flyology.Bytes.Length (Client.Read_All (Reply)) = 0);
+                  elsif Scenario = "head-empty-data" then
+                     pragma Assert
+                       (Client.Header (Reply, "content-length") =
+                          "5368709129");
                      pragma Assert
                        (Flyology.Bytes.Length (Client.Read_All (Reply)) = 0);
                   elsif Scenario = "zero-read" then

--- a/tests/http2_peer.py
+++ b/tests/http2_peer.py
@@ -207,6 +207,14 @@ def serve_connection(
                     )
                 if state.scenario == "early-final":
                     pass
+                elif state.scenario == "head-empty-data":
+                    connection.send_headers(
+                        stream_id,
+                        [(":status", "200"), ("content-length", "5368709129")],
+                        end_stream=False,
+                    )
+                    connection.send_data(stream_id, b"", end_stream=True)
+                    state.record("head-empty-data", stream=stream_id)
                 elif state.scenario == "informational-end":
                     # Literal :status 103, carried in an invalid final
                     # informational HEADERS frame.
@@ -244,6 +252,7 @@ def serve_connection(
                     return True
                 if state.scenario in {
                     "early-final",
+                    "head-empty-data",
                     "informational-end",
                     "flood",
                     "shutdown-race",
@@ -345,6 +354,7 @@ def main() -> None:
             "upload",
             "refused-post",
             "early-final",
+            "head-empty-data",
             "reset-race",
             "zero-read",
             "bad-preface",

--- a/tests/http2_server_integration.adb
+++ b/tests/http2_server_integration.adb
@@ -232,6 +232,9 @@ procedure HTTP2_Server_Integration is
       X.Begin_Stream
         (200, "application/octet-stream",
          Content_Length => 5 * 1_024 * 1_024 * 1_024 + 9);
+      --  Let the server emit HEADERS before End_Stream. This deterministically
+      --  exercises the legal empty DATA END_STREAM completion path for HEAD.
+      delay 0.01;
       X.End_Stream;
    end Fixed_Head;
 


### PR DESCRIPTION
## Summary

- accept a legal empty DATA+END_STREAM after an HTTP/2 HEAD response with a nonzero representation Content-Length
- continue rejecting nonempty HEAD DATA while avoiding an invalid body-length equality check for body-forbidden responses
- add deterministic in-process and independent h2 peer regressions with a 5+ GiB logical Content-Length

## Qualification

- `./scripts/http2-test.sh client` (native and lightweight matrices)
- fixed HTTP/2 server integration repeated 30/30
- `./scripts/test.sh`

## Release impact

This is a prerequisite correction for the pending `flyology_http=0.1.2` fixed-length response release. No tag or index entry has been published yet.