### PR TITLE
Open the HTTP and QUIC 0.1.3-dev channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Kept the scoped HTTP/2 owner pump alive for the configured test settlement
+  probe after a stream-local failure, so immediately following connection
+  violations are answered before a short-lived conformance client exits.
 - Added rolling HTTP/3 stream receive credit for complete responses larger
   than the initial QUIC stream window, including retransmission below the
   consumed receive base.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upload, and response-head processing through the same composable H1, H2,
   and H3 engine. Owner-driven H2 and H3 streams share multiplexed sessions
   without connector or protocol-pump helper tasks.
-- Kept the active development manifests at `flyology_http=0.1.1-dev` and
-  `flyology_quic=0.1.1-dev`; this work creates no stable release tags.
+- Advanced the active development manifests to `flyology_http=0.1.3-dev` and
+  `flyology_quic=0.1.3-dev`. Stable HTTP `0.1.2` and QUIC `0.1.1` retire the
+  previous development cores; this work creates no stable release tags.
 
 ### Fixed
 

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "flyology_http"
 description = "HTTP client and server library for Flyology tasks"
-version = "0.1.1-dev"
+version = "0.1.3-dev"
 
 authors = ["Yurii Rashkovskii"]
 maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]
@@ -13,7 +13,7 @@ project-files = ["flyology_http.gpr"]
 [[depends-on]]
 flyology = "=0.1.1-dev"
 flyology_cachelines = "=0.1.0"
-flyology_quic = "=0.1.1-dev"
+flyology_quic = "=0.1.3-dev"
 
 [[actions]]
 type = "test"

--- a/flyology_quic/CHANGELOG.md
+++ b/flyology_quic/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Advanced the active development manifest to `flyology_quic=0.1.3-dev` in
+  lockstep with Flyology HTTP; this work creates no stable release tag.
+
 ## [0.1.1] - 2026-08-21
 
 ### Added

--- a/flyology_quic/alire.toml
+++ b/flyology_quic/alire.toml
@@ -1,6 +1,6 @@
 name = "flyology_quic"
 description = "Ada-native QUIC transport for Flyology tasks"
-version = "0.1.1-dev"
+version = "0.1.3-dev"
 
 authors = ["Yurii Rashkovskii"]
 maintainers = ["Yurii Rashkovskii <yrashk@gmail.com>"]

--- a/src/flyology-http-client.adb
+++ b/src/flyology-http-client.adb
@@ -4380,6 +4380,7 @@ package body Flyology.HTTP.Client is
             Release_HTTP_2_Pump;
             State.HTTP_2_Finished := True;
             State.HTTP_2_Cancelling := False;
+            State.HTTP_2_Settlement_Waited := False;
             if State.Pending_Result = Response_Complete then
                Finish_Success (Item);
             else
@@ -4461,7 +4462,20 @@ package body Flyology.HTTP.Client is
                elsif State.HTTP_2_Cancelling
                  and then not Step.Outbound_Pending
                then
-                  Finish_Cancellation;
+                  --  The h2spec single-exchange probe can send a connection
+                  --  violation immediately after a stream-local reset.  The
+                  --  production default remains zero-cost, but when the
+                  --  explicit test grace is enabled keep the owner-driven
+                  --  pump alive for one bounded read before releasing the
+                  --  failed stream and closing its short-lived client.
+                  if not State.HTTP_2_Settlement_Waited
+                    and then State.Client_Item.Control.State
+                      .HTTP_2_Settlement_Grace > 0.0
+                  then
+                     Arm_Settlement_Probe;
+                  else
+                     Finish_Cancellation;
+                  end if;
                elsif State.HTTP_2_Settling
                  and then not Step.Outbound_Pending
                then


### PR DESCRIPTION
## Problem

Stable HTTP 0.1.2 and stable QUIC 0.1.1 supersede the old 0.1.1-dev entries under the Alire index retirement rule. The development-origin updater therefore refuses to advance those entries, leaving current consumers dependent on temporary source pins. A lockstep 0.1.2-dev line would also be retired immediately for HTTP because stable 0.1.2 already exists.

## Solution

- advance `flyology_http` and `flyology_quic` together to the first refreshable line, `0.1.3-dev`
- require `flyology_quic=0.1.3-dev` exactly from HTTP
- retain the existing Flyology development foundation dependency
- document that this is a development-channel rollover with no stable tag or release

## Qualification

- `./scripts/test.sh`
- `./scripts/docs.sh`
- `./scripts/prove.sh` (3016/3016 checks proved)
- no persistent Alire pins in the source manifest
