### PR TITLE
Select HTTP connection test hooks without Ada preprocessing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,38 @@ jobs:
       - name: Check the WPT gate wiring
         run: ./flyology_iri/scripts/wpt-gate-test.sh
 
+  hook-elision:
+    name: Test-hook elision (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Check out sources
+        timeout-minutes: 5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Alire
+        timeout-minutes: 15
+        uses: alire-project/setup-alire@fc4c8ce471aa30b3af0d39ce15add1ee9eaf28f2 # v6.0.0
+        with:
+          version: 2.1.1
+          toolchain: >-
+            gnat_native=16.1.0
+            gprbuild=26.0.1
+          cache: true
+      - name: Configure Flyology index
+        timeout-minutes: 5
+        run: |
+          alr index --reset-community
+          alr index --add=git+https://github.com/flyology-ada/alire-index.git --name=flyology --before=community
+      - name: Use the in-tree QUIC prerequisite
+        run: alr pin flyology_quic --use=flyology_quic
+      - name: Check both hook selections and every optimization mode
+        timeout-minutes: 20
+        run: ./scripts/check-test-hook-elision.sh
+
   proof:
     name: SPARK proof
     runs-on: ubuntu-latest

--- a/flyology_http.gpr
+++ b/flyology_http.gpr
@@ -7,21 +7,24 @@ project Flyology_HTTP is
    type Connection_Test_Hooks_Type is ("false", "true");
    Connection_Test_Hooks : Connection_Test_Hooks_Type :=
      external ("FLYOLOGY_CONNECTION_TEST_HOOKS", "false");
-   Connection_Test_Hook_Switch :=
-     "-gnateDFLYOLOGY_CONNECTION_TEST_HOOKS=False";
+   --  Select one private implementation instead of exporting an Ada
+   --  preprocessor symbol through every project-aware consumer tool.
+   Connection_Test_Hook_Source_Dir :=
+     "src/test_hooks/connection/disabled/";
    case Connection_Test_Hooks is
       when "false" =>
          null;
       when "true" =>
-         Connection_Test_Hook_Switch :=
-           "-gnateDFLYOLOGY_CONNECTION_TEST_HOOKS=True";
+         Connection_Test_Hook_Source_Dir :=
+           "src/test_hooks/connection/enabled/";
    end case;
 
    for Languages use ("Ada");
    for Library_Name use "Flyology_HTTP";
    for Library_Version use
      Project'Library_Name & ".so." & Flyology_HTTP_Config.Crate_Version;
-   for Source_Dirs use ("src/", "config/");
+   for Source_Dirs use
+     ("src/", "config/", Connection_Test_Hook_Source_Dir);
 
    type Documentation_Mode_Type is ("false", "true");
    Documentation_Mode : Documentation_Mode_Type :=
@@ -91,7 +94,7 @@ project Flyology_HTTP is
    package Compiler is
       for Default_Switches ("Ada") use
         Flyology_HTTP_Config.Ada_Compiler_Switches
-        & ("-gnatwJ", Connection_Test_Hook_Switch);
+        & ("-gnatwJ");
    end Compiler;
 
    package Binder is

--- a/scripts/check-test-hook-elision.sh
+++ b/scripts/check-test-hook-elision.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+set -eu
+
+project_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+alr=$("$project_root/scripts/find-alr.sh")
+
+if [ "${FLYOLOGY_HTTP_HOOK_ELISION_IN_ALIRE:-0}" != 1 ]; then
+  "$alr" build >/dev/null
+  FLYOLOGY_HTTP_HOOK_ELISION_IN_ALIRE=1
+  export FLYOLOGY_HTTP_HOOK_ELISION_IN_ALIRE
+  exec "$alr" exec -- "$0"
+fi
+
+temp_root=$(mktemp -d "${TMPDIR:-/tmp}/flyology-http-hook-elision.XXXXXX")
+
+cleanup () {
+  rm -rf -- "$temp_root"
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+undefined_symbols () {
+  nm -u "$1" | awk '
+    {
+      found = 0
+      for (i = 1; i <= NF; i++) {
+        if ($i == "U") {
+          print $(i + 1)
+          found = 1
+        }
+      }
+      if (!found && NF == 1 && $1 !~ /:$/) print $1
+    }
+  '
+}
+
+check_project_selection () {
+  state=$1
+  if [ "$state" = enabled ]; then
+    value=true
+    opposite=disabled
+  else
+    value=false
+    opposite=enabled
+  fi
+
+  inspection=$(gprinspect \
+    -P "$project_root/flyology_http.gpr" \
+    --attributes --display=textual --views=flyology_http \
+    -XFLYOLOGY_CONNECTION_TEST_HOOKS="$value")
+  expected="/src/test_hooks/connection/$state"
+  unexpected="/src/test_hooks/connection/$opposite"
+  if ! printf '%s\n' "$inspection" | grep -F "$expected" >/dev/null; then
+    printf '%s\n' "connection hooks omit $expected" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$inspection" | grep -F "$unexpected" >/dev/null; then
+    printf '%s\n' "connection hooks include $unexpected" >&2
+    exit 1
+  fi
+}
+
+check_archive () {
+  state=$1
+  mode=$2
+  shift 2
+  if [ "$state" = enabled ]; then
+    value=true
+  else
+    value=false
+  fi
+  subdir="hook-elision-$state-$mode"
+  build_log="$temp_root/$state-$mode.log"
+
+  if ! env -u GPR_CONFIG gprbuild \
+    -P "$project_root/flyology_http.gpr" \
+    --subdirs="$subdir" -f -p -q -j0 \
+    -XFLYOLOGY_CONNECTION_TEST_HOOKS="$value" \
+    -XFLYOLOGY_HTTP_LIBRARY_TYPE=static \
+    -cargs:Ada "$@" >"$build_log" 2>&1
+  then
+    cat "$build_log" >&2
+    exit 1
+  fi
+
+  archive="$project_root/lib/$subdir/libFlyology_HTTP.a"
+  if [ ! -f "$archive" ]; then
+    printf '%s\n' "hook-elision build did not produce $archive" >&2
+    exit 1
+  fi
+  symbols=$(undefined_symbols "$archive")
+  if printf '%s\n' "$symbols" | grep -F \
+    flyology_http_disabled_hook_must_be_elided >/dev/null
+  then
+    printf '%s\n' \
+      "disabled connection-hook sentinel survived in $state $mode" >&2
+    exit 1
+  fi
+
+  real_symbols='flyology_test_connection_barrier_arrive
+flyology_test_connection_barrier_released
+flyology_http_test_connection_receive_limit
+flyology_http_test_connection_receive_observed'
+  for symbol in $real_symbols; do
+    if [ "$state" = enabled ]; then
+      if ! printf '%s\n' "$symbols" | grep -F "$symbol" >/dev/null; then
+        printf '%s\n' \
+          "enabled connection hook $symbol disappeared in $mode" >&2
+        exit 1
+      fi
+    elif printf '%s\n' "$symbols" | grep -F "$symbol" >/dev/null; then
+      printf '%s\n' \
+        "production connection hook $symbol survived in $mode" >&2
+      exit 1
+    fi
+  done
+}
+
+if git -C "$project_root" grep -n -- '-gnateD' -- '*.gpr' >/dev/null; then
+  printf '%s\n' "global Ada preprocessor switches reappeared" >&2
+  exit 1
+fi
+if git -C "$project_root" grep -n -E \
+  '^#(if|else|end if)' -- '*.adb' '*.ads' >/dev/null
+then
+  printf '%s\n' "Ada preprocessing directives reappeared" >&2
+  exit 1
+fi
+
+printf '%s\n' 'HTTP test-hook elision: both project selections'
+check_project_selection disabled
+check_project_selection enabled
+
+printf '%s\n' 'HTTP test-hook elision: strict -O0 archives'
+check_archive disabled O0-strict \
+  -O0 -fno-inline -fno-inline-functions -fno-tree-dce -fno-dce
+check_archive enabled O0-strict \
+  -O0 -fno-inline -fno-inline-functions -fno-tree-dce -fno-dce
+
+printf '%s\n' 'HTTP test-hook elision: every supported optimization mode'
+for mode in O0 Og O1 O2 O3 Os Oz Ofast; do
+  check_archive disabled "$mode" "-$mode"
+  check_archive enabled "$mode" "-$mode"
+done
+
+printf '%s\n' 'HTTP test-hook elision: PASS'

--- a/showcases/http3_client_benchmark.gpr
+++ b/showcases/http3_client_benchmark.gpr
@@ -16,8 +16,7 @@ project HTTP3_Client_Benchmark is
    package Compiler is
       for Default_Switches ("Ada") use
         Flyology_HTTP_Showcases_Config.Ada_Compiler_Switches
-        & ("-gnat2022", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ",
-           "-gnateDFLYOLOGY_CONNECTION_TEST_HOOKS=False");
+        & ("-gnat2022", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ");
       for Default_Switches ("C") use ("-O2", "-Wall", "-Wextra");
    end Compiler;
 end HTTP3_Client_Benchmark;

--- a/showcases/showcases.gpr
+++ b/showcases/showcases.gpr
@@ -27,8 +27,7 @@ project Flyology_HTTP_Showcases is
    package Compiler is
       for Default_Switches ("Ada") use
         Flyology_HTTP_Showcases_Config.Ada_Compiler_Switches
-        & ("-gnat2022", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ",
-           "-gnateDFLYOLOGY_CONNECTION_TEST_HOOKS=False");
+        & ("-gnat2022", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ");
       for Default_Switches ("C") use ("-O2", "-Wall", "-Wextra");
    end Compiler;
 end Flyology_HTTP_Showcases;

--- a/src/flyology-http-client-http_1_internals.adb
+++ b/src/flyology-http-client-http_1_internals.adb
@@ -80,7 +80,9 @@ package body HTTP_1_Internals is
          elsif Whole_Wait < 0.0 then Maximum_Wait
          else Duration'Min (Whole_Wait, Maximum_Wait));
    begin
-      Client_Test_Barrier (3);
+      if Connection_Test_Hooks.Enabled then
+         Connection_Test_Hooks.Barrier (3);
+      end if;
       if Token /= null and then Token.Requested then
          raise Flyology.Cancellation.Operation_Cancelled;
       elsif Data.Timeout >= 0.0

--- a/src/flyology-http-client.adb
+++ b/src/flyology-http-client.adb
@@ -6,6 +6,7 @@ with System.Address_To_Access_Conversions;
 with System.Storage_Elements;
 with Flyology.Buffers.Drivers;
 with Flyology.HTTP.Client_Policy;
+with Flyology.HTTP.Client_Connection_Test_Hooks;
 with Flyology.HTTP.HTTP_2_Client_Connection;
 with Flyology.HTTP.HTTP_2_Requests;
 with Flyology.HTTP.HTTP_3;
@@ -20,9 +21,6 @@ with Flyology.Time_Math;
 with Flyology.IO.TLS.ALPN;
 with Flyology.Wake_Sources;
 with Flyology.QUIC.Connections;
-#if FLYOLOGY_CONNECTION_TEST_HOOKS then
-with Interfaces.C;
-#end if;
 
 package body Flyology.HTTP.Client is
    use Ada.Strings.Unbounded;
@@ -35,48 +33,9 @@ package body Flyology.HTTP.Client is
    use type Flyology.Operations.Driver_Event;
    use type System.Storage_Elements.Storage_Offset;
 
-#if FLYOLOGY_CONNECTION_TEST_HOOKS then
-   function Test_Barrier_Arrive
-     (Point : Interfaces.C.int) return Interfaces.C.int
-     with Import,
-          Convention => C,
-          External_Name => "flyology_test_connection_barrier_arrive";
-   function Test_Barrier_Released
-     (Point : Interfaces.C.int) return Interfaces.C.int
-     with Import,
-          Convention => C,
-          External_Name => "flyology_test_connection_barrier_released";
-   function Test_Receive_Limit
-     (Requested : Interfaces.C.int) return Interfaces.C.int
-     with Import,
-          Convention => C,
-          External_Name => "flyology_http_test_connection_receive_limit";
-   procedure Test_Receive_Observed
-     with Import,
-          Convention => C,
-          External_Name => "flyology_http_test_connection_receive_observed";
-
-   procedure Client_Test_Barrier (Point : Natural) is
-      Position : constant Interfaces.C.int := Interfaces.C.int (Point);
-   begin
-      if Test_Barrier_Arrive (Position) /= 0 then
-         while Test_Barrier_Released (Position) = 0 loop
-            delay 0.0;
-         end loop;
-      end if;
-   end Client_Test_Barrier;
-
-   function Client_Test_Receive_Limit (Requested : Positive) return Positive
-   is (Positive (Test_Receive_Limit (Interfaces.C.int (Requested))));
-   procedure Client_Test_Receive_Observed renames Test_Receive_Observed;
-#else
-   procedure Client_Test_Barrier (Point : Natural) is null;
-   function Client_Test_Receive_Limit (Requested : Positive) return Positive
-   is (Requested);
-   procedure Client_Test_Receive_Observed is null;
-#end if;
-
    package Connections renames Flyology.IO.Connections;
+   package Connection_Test_Hooks renames
+     Flyology.HTTP.Client_Connection_Test_Hooks;
    package Connection_Drivers renames
      Flyology.IO.Connections.Drivers;
    package H2_Connections renames
@@ -3250,7 +3209,9 @@ package body Flyology.HTTP.Client is
                   --  The test seam widens this exact handoff boundary. Recheck
                   --  caller interruption afterward before creating a socket
                   --  or starting the retained connect/QUIC child.
-                  Client_Test_Barrier (16);
+                  if Connection_Test_Hooks.Enabled then
+                     Connection_Test_Hooks.Barrier (16);
+                  end if;
                   if State.Token_Item /= null
                     and then State.Token_Item.Requested
                   then
@@ -3339,7 +3300,9 @@ package body Flyology.HTTP.Client is
             begin
                if not Is_Numeric then
                   State.Result.Last_Phase := Resolving;
-                  Client_Test_Barrier (15);
+                  if Connection_Test_Hooks.Enabled then
+                     Connection_Test_Hooks.Barrier (15);
+                  end if;
                   if State.Token_Item /= null
                     and then State.Token_Item.Requested
                   then
@@ -3393,7 +3356,9 @@ package body Flyology.HTTP.Client is
                   State.Result.Admission := Possibly_Admitted;
                   State.Output_Cursor := State.Output_Cursor
                     + Natural (Last - Data'First + 1);
-                  Client_Test_Barrier (2);
+                  if Connection_Test_Hooks.Enabled then
+                     Connection_Test_Hooks.Barrier (2);
+                  end if;
                   if State.Token_Item /= null
                     and then State.Token_Item.Requested
                   then
@@ -3714,9 +3679,13 @@ package body Flyology.HTTP.Client is
          Last   : Ada.Streams.Stream_Element_Offset;
          Result : Connection_Drivers.Step_Result;
          Limit  : constant Positive :=
-           Client_Test_Receive_Limit (State.Buffer'Length);
+           (if Connection_Test_Hooks.Enabled then
+               Connection_Test_Hooks.Receive_Limit (State.Buffer'Length)
+            else State.Buffer'Length);
       begin
-         Client_Test_Barrier (3);
+         if Connection_Test_Hooks.Enabled then
+            Connection_Test_Hooks.Barrier (3);
+         end if;
          if State.Token_Item /= null and then State.Token_Item.Requested then
             Fail_Exchange
               (Item, Cancelled, Flyology.Operations.Cancelled);
@@ -3733,7 +3702,9 @@ package body Flyology.HTTP.Client is
             Last, Result);
          case Result is
             when Connection_Drivers.Made_Progress =>
-               Client_Test_Receive_Observed;
+               if Connection_Test_Hooks.Enabled then
+                  Connection_Test_Hooks.Receive_Observed;
+               end if;
                if Last >= State.Buffer'First then
                   State.Result.Admission := Response_Observed;
                   State.Metadata.Saw_Response_Bytes := True;

--- a/src/test_hooks/connection/disabled/flyology-http-client_connection_test_hooks.ads
+++ b/src/test_hooks/connection/disabled/flyology-http-client_connection_test_hooks.ads
@@ -1,0 +1,26 @@
+--  Disabled client connection test seams selected by the owning project.
+--  Imported-only declarations make a missed static guard visible to symbol
+--  inspection without supplying any production implementation.
+private package Flyology.HTTP.Client_Connection_Test_Hooks is
+
+   --  Keep this a literal compile-time constant. GNAT removes code guarded by
+   --  a literal False even at -O0; a function returning False can retain both
+   --  its call and references inside the guarded branch.
+   Enabled : constant Boolean := False;
+
+   procedure Barrier (Point : Natural)
+   with Import,
+        External_Name =>
+          "flyology_http_disabled_hook_must_be_elided_barrier";
+
+   function Receive_Limit (Requested : Positive) return Positive
+   with Import,
+        External_Name =>
+          "flyology_http_disabled_hook_must_be_elided_receive_limit";
+
+   procedure Receive_Observed
+   with Import,
+        External_Name =>
+          "flyology_http_disabled_hook_must_be_elided_receive_observed";
+
+end Flyology.HTTP.Client_Connection_Test_Hooks;

--- a/src/test_hooks/connection/enabled/flyology-http-client_connection_test_hooks.adb
+++ b/src/test_hooks/connection/enabled/flyology-http-client_connection_test_hooks.adb
@@ -1,0 +1,47 @@
+with Interfaces.C;
+
+package body Flyology.HTTP.Client_Connection_Test_Hooks is
+   use type Interfaces.C.int;
+
+   function Test_Barrier_Arrive
+     (Point : Interfaces.C.int) return Interfaces.C.int
+   with Import,
+        Convention => C,
+        External_Name => "flyology_test_connection_barrier_arrive";
+
+   function Test_Barrier_Released
+     (Point : Interfaces.C.int) return Interfaces.C.int
+   with Import,
+        Convention => C,
+        External_Name => "flyology_test_connection_barrier_released";
+
+   function Test_Receive_Limit
+     (Requested : Interfaces.C.int) return Interfaces.C.int
+   with Import,
+        Convention => C,
+        External_Name => "flyology_http_test_connection_receive_limit";
+
+   procedure Test_Receive_Observed
+   with Import,
+        Convention => C,
+        External_Name => "flyology_http_test_connection_receive_observed";
+
+   procedure Barrier (Point : Natural) is
+      Position : constant Interfaces.C.int := Interfaces.C.int (Point);
+   begin
+      if Test_Barrier_Arrive (Position) /= 0 then
+         while Test_Barrier_Released (Position) = 0 loop
+            delay 0.0;
+         end loop;
+      end if;
+   end Barrier;
+
+   function Receive_Limit (Requested : Positive) return Positive
+   is (Positive (Test_Receive_Limit (Interfaces.C.int (Requested))));
+
+   procedure Receive_Observed is
+   begin
+      Test_Receive_Observed;
+   end Receive_Observed;
+
+end Flyology.HTTP.Client_Connection_Test_Hooks;

--- a/src/test_hooks/connection/enabled/flyology-http-client_connection_test_hooks.ads
+++ b/src/test_hooks/connection/enabled/flyology-http-client_connection_test_hooks.ads
@@ -1,0 +1,15 @@
+--  Enabled client connection test seams selected by the owning project.
+--  Native test controls widen narrowly identified ownership and readiness
+--  race windows.
+private package Flyology.HTTP.Client_Connection_Test_Hooks is
+
+   --  Keep this a literal compile-time constant. GNAT removes code guarded by
+   --  a literal False even at -O0; a function returning False can retain both
+   --  its call and references inside the guarded branch.
+   Enabled : constant Boolean := True;
+
+   procedure Barrier (Point : Natural);
+   function Receive_Limit (Requested : Positive) return Positive;
+   procedure Receive_Observed;
+
+end Flyology.HTTP.Client_Connection_Test_Hooks;

--- a/tests/http_tests.gpr
+++ b/tests/http_tests.gpr
@@ -1,19 +1,6 @@
 with "../flyology_http.gpr";
 
 project HTTP_Tests is
-   type Connection_Test_Hooks_Type is ("false", "true");
-   Connection_Test_Hooks : Connection_Test_Hooks_Type :=
-     external ("FLYOLOGY_CONNECTION_TEST_HOOKS", "false");
-   Connection_Test_Hook_Switch :=
-     "-gnateDFLYOLOGY_CONNECTION_TEST_HOOKS=False";
-   case Connection_Test_Hooks is
-      when "false" =>
-         null;
-      when "true" =>
-         Connection_Test_Hook_Switch :=
-           "-gnateDFLYOLOGY_CONNECTION_TEST_HOOKS=True";
-   end case;
-
    for Languages use ("Ada", "C");
    for Source_Dirs use (".", "native", "compile_fail");
    for Object_Dir use "obj/http_tests";
@@ -102,8 +89,7 @@ project HTTP_Tests is
 
    package Compiler is
       for Default_Switches ("Ada") use
-        ("-gnat2022", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ",
-         Connection_Test_Hook_Switch);
+        ("-gnat2022", "-gnata", "-gnatVa", "-gnatwa", "-gnatwJ");
       for Default_Switches ("C") use
         ("-std=c11", "-Wall", "-Wextra");
    end Compiler;


### PR DESCRIPTION
Problem

Flyology.HTTP exports FLYOLOGY_CONNECTION_TEST_HOOKS through a global -gnateD compiler switch. Project-aware consumer tools inherit that preprocessing policy, which blocks maintained GNATformat use and makes production hook elision depend on preprocessing inside the client body.

Solution

Select enabled or disabled private connection-hook packages through GPR source directories, guarded by a literal compile-time Enabled constant. Preserve the existing native C test ABI in the enabled body and use imported sentinels in the disabled spec so any missed static guard is visible in the archive. Remove all Ada preprocessing directives and hook -gnateD switches from the library, tests, and showcases.

Add a macOS/Linux CI gate that checks both GPR source selections and scans isolated static archives at strict -O0 plus O0, Og, O1, O2, O3, Os, Oz, and Ofast. Production archives must retain neither sentinel nor real hook symbols; enabled archives must retain all four native hook imports.

Verification

- ./scripts/check-test-hook-elision.sh
- ./scripts/test.sh
- ./scripts/docs.sh
- ./scripts/prove.sh: 3,016 checks proved
- git diff --check
- shell syntax and workflow YAML parse
- deliberate P0/P1/P2 findings sweep: no actionable findings

No public HTTP API, protocol behavior, website guide content, version, tag, or release changes.