### PR TITLE
Make APM lock reproduction clean

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-28T14:52:32.279307+00:00'
+generated_at: '2026-08-29T03:23:19.641794+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: _local/repository
@@ -591,924 +591,6 @@ dependencies:
     .claude/skills/tlaplus-split-action/SKILL.md: sha256:7ea84ceeabd3b44f85d6548e74a365adc9b1d2355689831f840e2b1819e448d7
   content_hash: sha256:2fc5bb6753a2525de31d527165475dc0344a813c2fb143b223acb3c0b4e47718
 deployments:
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-api-contract-review
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-api-contract-review/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:ee95c75b0cd67f94ffc0644e48f4a904c3c5f801ccd9a4346b14366b8921994d
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-concurrency-ownership-review
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-concurrency-ownership-review/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:f10c924e5fd3975b7aadaec91b7e736ff6ad562151ade8c828f84038e7747d6f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-generated-source-review
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-generated-source-review/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:d0b609df71c5dd9540952107ffb6ac99d5b3fb1532a3b795d11f771ac2198ff9
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-hardcoded-constants
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-hardcoded-constants/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e4732330c0821d017c435c74c18b725c83d5b88687842861a2cc1868dc1e9775
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-native-boundary-review
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-native-boundary-review/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e8a8702e3d79daa7bcf67f1832c50be0694f8990858685c40cccd23d11a3b282
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-portability-review
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/ada-portability-review/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:b2f9f2b7d5c2cbdb5164a57d7ec22f3d7a38357745a5f15f61e66155f0806da5
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire-release-review
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire-release-review/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:34cf8c54a2df2cf76ac5258bd87c0ea0020de4529a5b02969b843717c98af7d2
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:101f0bc3f43679c21b2e297c610e68f2e1f4379c80899e2d063348f9e410aeab
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-build.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:55b7368007a34d979bc61d8f5dc780e9bb904e43b32fa5e046e0c39853c5e9c4
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-exec.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:2e16d8d158c04e90f444cf6ed29a57ce603b7e9931079dd81713a3f938101653
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-get.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:667d5c82dac4f43b4a3b7d0eb87773d0be1d8c71e24d97f658fef251042018e5
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-init.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:192ce5671f403249fa12c49ed5570ba679b2a99415d02f79ae7fc2bbe2ebc8d7
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-install.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:3026d61e1ad28f93eb836a18082b9bd03ca9039bbec73fdd0985b6eb7f106ceb
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-pin.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:b0a4d1255df7b4b5f802ee78f946ea931760cd67807050918838c89fb68452c9
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-printenv.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:d99f18f1c576b829f412af4c298cf882fe7acc0e908bfed626b4af26918ae893
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-run.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:0aed65e1d896fc475a62079bafa5f3d799efb97a43aa129c84f92de92884c694
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-search.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:918ee60fde180f3b47b15dfd8455be5cc1c87b88ec34f701ee43c2115219eca2
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-toolchain.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:c1ddd67e856a9279d3b13fce8c549bb238d4e5f23d85270717bcaa4b14a4ffa6
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/alire-with.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:96aa3eeac6bc413e4339495ae3482074b36e1ebb9abe53ddb773e48abe933dbc
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/installation.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:517c192d2a077a84c9798b9d53c67e016b499747cd6a47ca5baa8a1a72683a34
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/raspberry-pi-pico.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:f47c5514b09e591581a1cfea7c517c074e707d94d9e9e799e106a0a77722dab9
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/testing.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:da30b1e2fbd15823dd206c1d77f47bb3780b8753593bc6c0e954b772c43a51b8
-- kind: project-relative
-  target: agents
-  value: .agents/skills/alire/references/zephyr.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:c9017496759fe5e5a672c0a79dc0dbb18393ba94728f8606482382ea90dba75e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/flyology-crate-spinout
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/flyology-crate-spinout/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:c703a30046dc69934e6592bb8875fed8e2ebe74ddd7d0f4cd5de84ba0d6ce938
-- kind: project-relative
-  target: agents
-  value: .agents/skills/flyology-crate-spinout/references/repository-decision.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:36b54c6fc01a9ab4535d2d3376a8bc969183d18c71d99e7174ec49e9641f3329
-- kind: project-relative
-  target: agents
-  value: .agents/skills/flyology-crate-spinout/references/spinout-execution.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:814fb2c05571651d40e3e7c82310d42709ac0c362cebe9216c699e550537400e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/flyology-website-content
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/flyology-website-content/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:d06ab4b5b5128de1af10e5adaaed72134100641750caf19562672feb4a2ee921
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatdoc
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatdoc/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:225bd5f25e320beceaeda14157e78dfb589eca6ae09e45449742347d2b53bd7a
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatdoc/references/annotations.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:a65e5086a7b07a4f40567c96200d461a605f0b3a684708e84f27262b69a39b85
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatdoc/references/backends.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:8b4fc6ea8c3a0a19b824c409568fecb6c6ccbf34af2536a0499c0743a353fb05
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatdoc/references/command-reference.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:80b24c741ec5beb00cd70908a6254b8b373d326e39cc83a72091abbacb538d93
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatdoc/references/project-setup.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:0b9546e49f2be55263ad3cd21ae0f8ab2055ead6fe08d3a7814f3f5fcb788c9e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatdoc/references/styles.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:589899212f7c1308fe1c10c916c347864e0b04ccd72da1c0a7417b2f98b7a9e7
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:868601c5a1a60160ab08bf925265dd888bd645bb64e8ee2a1f66f801ca00e5b7
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/gnatprove/command-reference.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:d09733f97ba49d2cec7177bc14fe82e080974f5784c231831dc92d9c732ca938
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/gnatprove/gnatprove-out.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:228cf6bfa831fe1a8b72635c16c1df444fb819cfa9a264fb7e40eec0f934ba4c
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/gnatprove/gnatprove.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:478ed0d5eeadd85235a4646813238a76df7c7a682bd525fc2f7ebc9681d27cde
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/dynamic-accessibility.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:4d045f266e7e399e9ff51189575b70960a7fe295ee715e4c595b860a37a2fd12
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/floating-point.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:826b36cc806948d3cc1e3abc8a393700d4b9667f03f44de360ff68140182ea98
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/loops.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:ba85dead2edda9964a54421086e68a166df966941be33bcd83a39e574d06f19e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/mutable-discriminants.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:0e8f209fca8abab63781393788a95fde42d7da26ba98e40a02ff74957c8863bd
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/overflow-patterns.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e0298c3a86138ec5911bcfda1c3ddd814df98a0c6e4e7bcf8e1794948192a668
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/proof-debugging.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:d143a1ddda79e076560ec698350d140d2640f3c58bbe92fa9104b1cc9efea9d0
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/proof-in-ci.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:b83611c21411be83d6827328e2aa8f0e7794d6212f26c51ea2f8f00c15e8d010
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/proof.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:2ac566bfc0dbb6c6fa5654b107e575481b5ec163c000535c30036ddc1719355d
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/refactoring-for-proof.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:be17c0380d1edc3505506b203e3d89fc71188351827e05e168ba40fd1c73cac4
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/unchecked-conversion-unused-bits.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:51e3bd37042e08e49c242919b6e409a52654d4c8cd3a7586b9b4ec6c7af81974
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/workflow-subagent.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:badb7ccbdbf691cc5a4cd051f8374e898462f6802eb8faaaf40f3680329d39af
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/proof/workflow.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:576ac8b908388fe8a4688bbe4b4c53da9897c702374eb5cc9fbbad00f69bbe18
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/access-types.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:9b026cdad8d272f0737e7be020cd7074ad11437fbdcddfc9771f6a0bc8ee90aa
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/contracts.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:19b75d6336176a50c39378f127cac3713c3194379e2f003349bc43fc89a2f379
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/ffi.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:0fcd1b6cdfc3ad3aa172d71e9f1afc9c16ce837077ffefa31af877f825d0acf5
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/ghost-code-and-lemmas.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:06de109f9ff36de59ffd7493250b5deffd061e42cb2dfbc87c75c29afdb19021
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/idioms.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:068df8135ea3b375903ab608df73524eb37b71b472851d883d8425289f9b4f7d
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/ownership-and-reclamation.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:daa6003d3d017855dc2942db1333f4506067673e1b26b6d825bf7edf35595e6c
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/package-state.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:366742af59f5a383db7e0152f5fa2e658338a7f8055df37cce8562327b62dc8e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnatprove/references/spark/spark.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:cee59cf5cd7085aca1d1e24cc9b00a1904f930300fd42d7b610f79ebe0f519be
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:3be35068734b7cf6fdb9883f300ce33008018f42ca00592af895951f7b25a23c
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/command-reference.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:d53b211a7f523d711244c825639f501990063f235dc3dad157683d1292c6c1d1
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/contracts.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:60d9af40f1d635cb9a90c054f8cc4443e8bc211c5a5ed0a776739e39b729e9cc
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/experimental-test-gen.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:5e3dd5733290166ff2da2a6ccbfc9192003179b326ac7d63e28d475b43675788
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/gnatcoverage-integration.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:36df68e7d7924e1e6501f4d92c39c43a8d39382ffa29cd5a8e34217c3c7bafc9
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/library-projects.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:042a1e7ee0a5ba72ef6d8e050b6385ca5cf88c4785de17ffe699bef7bb06ac40
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/project-setup.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:b2ec46580d16011c02989526b5ab3bc51a2a18d0396483b4f1669526bd661ff8
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/separate-drivers.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:dae1d56293872615a7243a10a4f2ca828d8a9240296b1420ae43d0ef7a85e358
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/stubbing.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:d885315bd2e308e83f9c1e6d198db34948fc52df21105f9041cd76be0df87acd
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/tagged-types-and-inheritance.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:6a0f49d78c374d8771c6f373422ee12304f979577fcbaffcd13042d88c4df0d0
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/test-skeletons.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:baaaf48c32a9dbdd712db7c41848822aa78cf4aa42e807dd04596b4f546342ec
-- kind: project-relative
-  target: agents
-  value: .agents/skills/gnattest/references/workflow.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:fe94afe889db7c6476838b4d688962d4c2742c16d6877e813b7eea0817ca6554
-- kind: project-relative
-  target: agents
-  value: .agents/skills/maintain-agent-instructions
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/maintain-agent-instructions/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:688c9f6c4a116826878602c825f360b2dee03fb95232a07923c4def90af77301
-- kind: project-relative
-  target: agents
-  value: .agents/skills/performance-testing
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/performance-testing/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e3b16b3b4d6262d70493a707c2ffe4e17d0c8defd870f6b23dc1045d254656d6
-- kind: project-relative
-  target: agents
-  value: .agents/skills/performance-testing/scripts/check-power-profile.sh
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:985b719f5882147ae7fa41b4b64321f5e554ec38ff6e3601d80e30ae6103446f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus-learning
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus-learning/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:81d2c5f8f2af55f05e2a8360188f6a962600b9f1edc7301b4c06af5ea1bff44b
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus-learning/references/model-checking.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:6540c75d52a460241cb83529924b36341ddaace50c021ec29c8d89319c5e6a02
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus-learning/references/modeling.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e60d726e2dd6b2ff3848e54d74a5ad80ec65071221d547b78465a34e6bfe3123
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus-learning/references/proofs.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:ab762e94b55a0003abd4ebc5816823b7017a2d1c66f6eee2716cc4d1bb44bd29
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus-learning/references/resources.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e62a2bc37c1e0c2a821428ee0f880d3f5b980bfad66f1c97287e5037634d1489
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:04058169e1e08e46b47de27c1db9bdf57e4a14d8a85ec4a35f2a2c8dc9a46bb2
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tla-plus/references/runner-and-reporting.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:2a4b2c6955854bfebdbc88106b4bb097fec2420d956c737302bd3358d6956d8f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tlaplus-add-variable
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tlaplus-add-variable/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:9e43d627cef529602aa88fcf4b729e26bdc4082cdf06e23af33c8f08931dec6e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tlaplus-from-source
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tlaplus-from-source/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e3fc651973a5b5d96dc02e2ee7c3baf25fafb30b3af1da56e257832ed228e913
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tlaplus-split-action
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/tlaplus-split-action/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - flyology-ada/agents/packages/skills
-  active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:7ea84ceeabd3b44f85d6548e74a365adc9b1d2355689831f840e2b1819e448d7
 - kind: project-relative
   target: claude
   value: .claude/rules/ada-interface-values.md
@@ -2538,6 +1620,924 @@ deployments:
 - kind: project-relative
   target: claude
   value: .claude/skills/tlaplus-split-action/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:7ea84ceeabd3b44f85d6548e74a365adc9b1d2355689831f840e2b1819e448d7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-api-contract-review
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-api-contract-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:ee95c75b0cd67f94ffc0644e48f4a904c3c5f801ccd9a4346b14366b8921994d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-concurrency-ownership-review
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-concurrency-ownership-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:f10c924e5fd3975b7aadaec91b7e736ff6ad562151ade8c828f84038e7747d6f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-generated-source-review
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-generated-source-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:d0b609df71c5dd9540952107ffb6ac99d5b3fb1532a3b795d11f771ac2198ff9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-hardcoded-constants
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-hardcoded-constants/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:e4732330c0821d017c435c74c18b725c83d5b88687842861a2cc1868dc1e9775
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-native-boundary-review
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-native-boundary-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:e8a8702e3d79daa7bcf67f1832c50be0694f8990858685c40cccd23d11a3b282
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-portability-review
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/ada-portability-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:b2f9f2b7d5c2cbdb5164a57d7ec22f3d7a38357745a5f15f61e66155f0806da5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire-release-review
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire-release-review/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:34cf8c54a2df2cf76ac5258bd87c0ea0020de4529a5b02969b843717c98af7d2
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:101f0bc3f43679c21b2e297c610e68f2e1f4379c80899e2d063348f9e410aeab
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-build.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:55b7368007a34d979bc61d8f5dc780e9bb904e43b32fa5e046e0c39853c5e9c4
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-exec.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:2e16d8d158c04e90f444cf6ed29a57ce603b7e9931079dd81713a3f938101653
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-get.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:667d5c82dac4f43b4a3b7d0eb87773d0be1d8c71e24d97f658fef251042018e5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-init.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:192ce5671f403249fa12c49ed5570ba679b2a99415d02f79ae7fc2bbe2ebc8d7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-install.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:3026d61e1ad28f93eb836a18082b9bd03ca9039bbec73fdd0985b6eb7f106ceb
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-pin.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:b0a4d1255df7b4b5f802ee78f946ea931760cd67807050918838c89fb68452c9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-printenv.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:d99f18f1c576b829f412af4c298cf882fe7acc0e908bfed626b4af26918ae893
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-run.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:0aed65e1d896fc475a62079bafa5f3d799efb97a43aa129c84f92de92884c694
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-search.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:918ee60fde180f3b47b15dfd8455be5cc1c87b88ec34f701ee43c2115219eca2
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-toolchain.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:c1ddd67e856a9279d3b13fce8c549bb238d4e5f23d85270717bcaa4b14a4ffa6
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/alire-with.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:96aa3eeac6bc413e4339495ae3482074b36e1ebb9abe53ddb773e48abe933dbc
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/installation.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:517c192d2a077a84c9798b9d53c67e016b499747cd6a47ca5baa8a1a72683a34
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/raspberry-pi-pico.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:f47c5514b09e591581a1cfea7c517c074e707d94d9e9e799e106a0a77722dab9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/testing.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:da30b1e2fbd15823dd206c1d77f47bb3780b8753593bc6c0e954b772c43a51b8
+- kind: project-relative
+  target: codex
+  value: .agents/skills/alire/references/zephyr.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:c9017496759fe5e5a672c0a79dc0dbb18393ba94728f8606482382ea90dba75e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/flyology-crate-spinout
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/flyology-crate-spinout/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:c703a30046dc69934e6592bb8875fed8e2ebe74ddd7d0f4cd5de84ba0d6ce938
+- kind: project-relative
+  target: codex
+  value: .agents/skills/flyology-crate-spinout/references/repository-decision.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:36b54c6fc01a9ab4535d2d3376a8bc969183d18c71d99e7174ec49e9641f3329
+- kind: project-relative
+  target: codex
+  value: .agents/skills/flyology-crate-spinout/references/spinout-execution.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:814fb2c05571651d40e3e7c82310d42709ac0c362cebe9216c699e550537400e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/flyology-website-content
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/flyology-website-content/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:d06ab4b5b5128de1af10e5adaaed72134100641750caf19562672feb4a2ee921
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatdoc
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatdoc/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:225bd5f25e320beceaeda14157e78dfb589eca6ae09e45449742347d2b53bd7a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatdoc/references/annotations.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:a65e5086a7b07a4f40567c96200d461a605f0b3a684708e84f27262b69a39b85
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatdoc/references/backends.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:8b4fc6ea8c3a0a19b824c409568fecb6c6ccbf34af2536a0499c0743a353fb05
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatdoc/references/command-reference.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:80b24c741ec5beb00cd70908a6254b8b373d326e39cc83a72091abbacb538d93
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatdoc/references/project-setup.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:0b9546e49f2be55263ad3cd21ae0f8ab2055ead6fe08d3a7814f3f5fcb788c9e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatdoc/references/styles.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:589899212f7c1308fe1c10c916c347864e0b04ccd72da1c0a7417b2f98b7a9e7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:868601c5a1a60160ab08bf925265dd888bd645bb64e8ee2a1f66f801ca00e5b7
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/gnatprove/command-reference.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:d09733f97ba49d2cec7177bc14fe82e080974f5784c231831dc92d9c732ca938
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/gnatprove/gnatprove-out.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:228cf6bfa831fe1a8b72635c16c1df444fb819cfa9a264fb7e40eec0f934ba4c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/gnatprove/gnatprove.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:478ed0d5eeadd85235a4646813238a76df7c7a682bd525fc2f7ebc9681d27cde
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/dynamic-accessibility.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:4d045f266e7e399e9ff51189575b70960a7fe295ee715e4c595b860a37a2fd12
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/floating-point.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:826b36cc806948d3cc1e3abc8a393700d4b9667f03f44de360ff68140182ea98
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/loops.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:ba85dead2edda9964a54421086e68a166df966941be33bcd83a39e574d06f19e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/mutable-discriminants.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:0e8f209fca8abab63781393788a95fde42d7da26ba98e40a02ff74957c8863bd
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/overflow-patterns.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:e0298c3a86138ec5911bcfda1c3ddd814df98a0c6e4e7bcf8e1794948192a668
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/proof-debugging.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:d143a1ddda79e076560ec698350d140d2640f3c58bbe92fa9104b1cc9efea9d0
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/proof-in-ci.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:b83611c21411be83d6827328e2aa8f0e7794d6212f26c51ea2f8f00c15e8d010
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/proof.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:2ac566bfc0dbb6c6fa5654b107e575481b5ec163c000535c30036ddc1719355d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/refactoring-for-proof.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:be17c0380d1edc3505506b203e3d89fc71188351827e05e168ba40fd1c73cac4
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/unchecked-conversion-unused-bits.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:51e3bd37042e08e49c242919b6e409a52654d4c8cd3a7586b9b4ec6c7af81974
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/workflow-subagent.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:badb7ccbdbf691cc5a4cd051f8374e898462f6802eb8faaaf40f3680329d39af
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/proof/workflow.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:576ac8b908388fe8a4688bbe4b4c53da9897c702374eb5cc9fbbad00f69bbe18
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/access-types.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:9b026cdad8d272f0737e7be020cd7074ad11437fbdcddfc9771f6a0bc8ee90aa
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/contracts.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:19b75d6336176a50c39378f127cac3713c3194379e2f003349bc43fc89a2f379
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/ffi.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:0fcd1b6cdfc3ad3aa172d71e9f1afc9c16ce837077ffefa31af877f825d0acf5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/ghost-code-and-lemmas.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:06de109f9ff36de59ffd7493250b5deffd061e42cb2dfbc87c75c29afdb19021
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/idioms.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:068df8135ea3b375903ab608df73524eb37b71b472851d883d8425289f9b4f7d
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/ownership-and-reclamation.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:daa6003d3d017855dc2942db1333f4506067673e1b26b6d825bf7edf35595e6c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/package-state.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:366742af59f5a383db7e0152f5fa2e658338a7f8055df37cce8562327b62dc8e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnatprove/references/spark/spark.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:cee59cf5cd7085aca1d1e24cc9b00a1904f930300fd42d7b610f79ebe0f519be
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:3be35068734b7cf6fdb9883f300ce33008018f42ca00592af895951f7b25a23c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/command-reference.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:d53b211a7f523d711244c825639f501990063f235dc3dad157683d1292c6c1d1
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/contracts.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:60d9af40f1d635cb9a90c054f8cc4443e8bc211c5a5ed0a776739e39b729e9cc
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/experimental-test-gen.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:5e3dd5733290166ff2da2a6ccbfc9192003179b326ac7d63e28d475b43675788
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/gnatcoverage-integration.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:36df68e7d7924e1e6501f4d92c39c43a8d39382ffa29cd5a8e34217c3c7bafc9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/library-projects.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:042a1e7ee0a5ba72ef6d8e050b6385ca5cf88c4785de17ffe699bef7bb06ac40
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/project-setup.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:b2ec46580d16011c02989526b5ab3bc51a2a18d0396483b4f1669526bd661ff8
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/separate-drivers.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:dae1d56293872615a7243a10a4f2ca828d8a9240296b1420ae43d0ef7a85e358
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/stubbing.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:d885315bd2e308e83f9c1e6d198db34948fc52df21105f9041cd76be0df87acd
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/tagged-types-and-inheritance.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:6a0f49d78c374d8771c6f373422ee12304f979577fcbaffcd13042d88c4df0d0
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/test-skeletons.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:baaaf48c32a9dbdd712db7c41848822aa78cf4aa42e807dd04596b4f546342ec
+- kind: project-relative
+  target: codex
+  value: .agents/skills/gnattest/references/workflow.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:fe94afe889db7c6476838b4d688962d4c2742c16d6877e813b7eea0817ca6554
+- kind: project-relative
+  target: codex
+  value: .agents/skills/maintain-agent-instructions
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/maintain-agent-instructions/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:688c9f6c4a116826878602c825f360b2dee03fb95232a07923c4def90af77301
+- kind: project-relative
+  target: codex
+  value: .agents/skills/performance-testing
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/performance-testing/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:e3b16b3b4d6262d70493a707c2ffe4e17d0c8defd870f6b23dc1045d254656d6
+- kind: project-relative
+  target: codex
+  value: .agents/skills/performance-testing/scripts/check-power-profile.sh
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:985b719f5882147ae7fa41b4b64321f5e554ec38ff6e3601d80e30ae6103446f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus-learning
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus-learning/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:81d2c5f8f2af55f05e2a8360188f6a962600b9f1edc7301b4c06af5ea1bff44b
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus-learning/references/model-checking.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:6540c75d52a460241cb83529924b36341ddaace50c021ec29c8d89319c5e6a02
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus-learning/references/modeling.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:e60d726e2dd6b2ff3848e54d74a5ad80ec65071221d547b78465a34e6bfe3123
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus-learning/references/proofs.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:ab762e94b55a0003abd4ebc5816823b7017a2d1c66f6eee2716cc4d1bb44bd29
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus-learning/references/resources.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:e62a2bc37c1e0c2a821428ee0f880d3f5b980bfad66f1c97287e5037634d1489
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:04058169e1e08e46b47de27c1db9bdf57e4a14d8a85ec4a35f2a2c8dc9a46bb2
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tla-plus/references/runner-and-reporting.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:2a4b2c6955854bfebdbc88106b4bb097fec2420d956c737302bd3358d6956d8f
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tlaplus-add-variable
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tlaplus-add-variable/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:9e43d627cef529602aa88fcf4b729e26bdc4082cdf06e23af33c8f08931dec6e
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tlaplus-from-source
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tlaplus-from-source/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:e3fc651973a5b5d96dc02e2ee7c3baf25fafb30b3af1da56e257832ed228e913
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tlaplus-split-action
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/tlaplus-split-action/SKILL.md
   runtime: null
   scope: project
   owners:


### PR DESCRIPTION
## Summary

- regenerate APM deployment metadata from a genuinely clean worktree
- make the documented frozen install and Codex compile sequence leave tracked output unchanged
- retain the shared formatting guidance pinned at a6d124a
- restore transitive Goal Stewardship output where clean regeneration shows it was omitted

This follows the shared-guidance rollout PR, whose dependency pin is correct but whose deployment ledger was generated in a worktree containing installed resources.

## Verification

- second independent clean worktree
- apm install --frozen
- apm compile --target codex
- apm audit --ci (all 10 checks passed)
- git diff --check
- git diff --exit-code -- AGENTS.md apm.lock.yaml