### PR TITLE
Fix scheduled HTTP and WebSocket CI stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      scheduled_qualification:
+        description: Run the schedule-only HTTP/2 and WebSocket qualifications
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: "23 6 * * *"
 
@@ -234,7 +240,8 @@ jobs:
         run: ./scripts/http-client-differential.sh run
       - name: Run HTTP/2 qualification
         run: |
-          if [ "${{ github.event_name }}" = schedule ]; then
+          if [ "${{ github.event_name }}" = schedule ] \
+            || [ "${{ inputs.scheduled_qualification }}" = true ]; then
             ./scripts/http2-test.sh nightly
           else
             ./scripts/http2-test.sh qualification
@@ -306,7 +313,10 @@ jobs:
 
   websocket-conformance:
     name: WebSocket conformance (${{ matrix.profile }}, ${{ matrix.lane }})
-    if: github.event_name == 'schedule'
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.scheduled_qualification)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /alire/
+/alire_install/
 /build/
 /config/
 /lib/

--- a/scripts/websocket-run-provenance.mjs
+++ b/scripts/websocket-run-provenance.mjs
@@ -2,6 +2,7 @@
 
 import { createHash } from "node:crypto";
 import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import {
   lstat,
   readFile,
@@ -23,6 +24,7 @@ const fullGitObject = /^[0-9a-f]{40}$/;
 const sha256 = /^[0-9a-f]{64}$/;
 const sha256Digest = /^sha256:[0-9a-f]{64}$/;
 const isoInstant = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const inTreeQuicPin = "\n[[pins]]\nflyology_quic = { path='flyology_quic' }\n";
 
 function fail(context, message) {
   throw new Error(`${context}: ${message}`);
@@ -102,24 +104,72 @@ function sourceStatus(projectRoot) {
   };
 }
 
+function inTreeQuicProvisioning(projectRoot, status) {
+  if (
+    status.entries !== 1 ||
+    status.trackedChanges !== 1 ||
+    status.untracked !== 0
+  ) {
+    return null;
+  }
+  const raw = git(
+    projectRoot,
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+    "--ignore-submodules=none"
+  );
+  if (raw !== "M alire.toml") return null;
+
+  const committed = execFileSync("git", ["show", "HEAD:alire.toml"], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const actual = readFileSync(resolve(projectRoot, "alire.toml"), "utf8");
+  if (actual !== `${committed}${inTreeQuicPin}`) return null;
+
+  const diff = execFileSync(
+    "git",
+    ["diff", "--no-ext-diff", "--", "alire.toml"],
+    {
+      cwd: projectRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }
+  );
+  return {
+    kind: "alire-in-tree-pin",
+    manifest: "alire.toml",
+    dependency: "flyology_quic",
+    path: "flyology_quic",
+    diffSha256: digest(diff),
+  };
+}
+
 export function captureSourceSnapshot(projectRoot) {
   const submoduleRaw = git(projectRoot, "submodule", "status", "--recursive");
+  const status = sourceStatus(projectRoot);
+  const provisioning = status.clean
+    ? null
+    : inTreeQuicProvisioning(projectRoot, status);
   const source = {
     revision: git(projectRoot, "rev-parse", "HEAD"),
     tree: git(projectRoot, "rev-parse", "HEAD^{tree}"),
     headRef: optionalGit(projectRoot, "symbolic-ref", "--quiet", "--short", "HEAD"),
-    status: sourceStatus(projectRoot),
+    status,
     submodules: {
       digest: digest(submoduleRaw),
       entries: submoduleRaw ? submoduleRaw.split("\n").length : 0,
     },
   };
-  if (!source.status.clean) {
+  if (!source.status.clean && !provisioning) {
     throw new Error(
-      `WebSocket run requires a clean worktree ` +
+      `WebSocket run requires a clean worktree or the exact in-tree QUIC pin ` +
         `(${source.status.trackedChanges} tracked, ${source.status.untracked} untracked)`
     );
   }
+  if (provisioning) source.provisioning = provisioning;
   return source;
 }
 
@@ -260,6 +310,11 @@ function requireSameInitialState(initial, finalSource, finalConfigSha256) {
     ["source.headRef", initial.source.headRef, finalSource.headRef],
     ["source.status", JSON.stringify(initial.source.status), JSON.stringify(finalSource.status)],
     [
+      "source.provisioning",
+      JSON.stringify(initial.source.provisioning || null),
+      JSON.stringify(finalSource.provisioning || null),
+    ],
+    [
       "source.submodules",
       JSON.stringify(initial.source.submodules),
       JSON.stringify(finalSource.submodules),
@@ -373,11 +428,47 @@ export function validateRunMetadata(metadata, expected, context = "run metadata"
   requireString(source.tree, `${context}.source.tree`, fullGitObject);
   if (source.headRef !== null) requireString(source.headRef, `${context}.source.headRef`);
   const status = requireObject(source.status, `${context}.source.status`);
-  requireEqual(status.clean, true, `${context}.source.status.clean`);
   requireString(status.digest, `${context}.source.status.digest`, sha256);
-  requireEqual(status.entries, 0, `${context}.source.status.entries`);
-  requireEqual(status.trackedChanges, 0, `${context}.source.status.trackedChanges`);
-  requireEqual(status.untracked, 0, `${context}.source.status.untracked`);
+  if (status.clean) {
+    requireEqual(status.entries, 0, `${context}.source.status.entries`);
+    requireEqual(status.trackedChanges, 0, `${context}.source.status.trackedChanges`);
+    requireEqual(status.untracked, 0, `${context}.source.status.untracked`);
+    requireEqual(source.provisioning, undefined, `${context}.source.provisioning`);
+  } else {
+    requireEqual(status.clean, false, `${context}.source.status.clean`);
+    requireEqual(status.entries, 1, `${context}.source.status.entries`);
+    requireEqual(status.trackedChanges, 1, `${context}.source.status.trackedChanges`);
+    requireEqual(status.untracked, 0, `${context}.source.status.untracked`);
+    const provisioning = requireObject(
+      source.provisioning,
+      `${context}.source.provisioning`
+    );
+    requireEqual(
+      provisioning.kind,
+      "alire-in-tree-pin",
+      `${context}.source.provisioning.kind`
+    );
+    requireEqual(
+      provisioning.manifest,
+      "alire.toml",
+      `${context}.source.provisioning.manifest`
+    );
+    requireEqual(
+      provisioning.dependency,
+      "flyology_quic",
+      `${context}.source.provisioning.dependency`
+    );
+    requireEqual(
+      provisioning.path,
+      "flyology_quic",
+      `${context}.source.provisioning.path`
+    );
+    requireString(
+      provisioning.diffSha256,
+      `${context}.source.provisioning.diffSha256`,
+      sha256
+    );
+  }
   const submodules = requireObject(source.submodules, `${context}.source.submodules`);
   requireString(submodules.digest, `${context}.source.submodules.digest`, sha256);
   if (!Number.isInteger(submodules.entries) || submodules.entries < 0) {

--- a/src/flyology-http-client.adb
+++ b/src/flyology-http-client.adb
@@ -6881,7 +6881,11 @@ package body Flyology.HTTP.Client is
          Cancelled   : Boolean := False;
          Selected    : Natural;
       begin
-         H2_Connections.Wait_Source
+         --  Try_Claim_Pump registered this stream as a fair pump waiter.
+         --  Observe that handoff directly: the stream-data source can consume
+         --  the same latched notification before response data is published,
+         --  leaving the reserved pump owner asleep behind its siblings.
+         H2_Connections.Pump_Wait_Source
            (Item.Data.Connection.HTTP_2.all, Item.Data.HTTP_2_Stream,
             Stream_FD, Ready_Now);
          if Ready_Now then

--- a/tests/websocket_run_provenance_test.mjs
+++ b/tests/websocket_run_provenance_test.mjs
@@ -203,8 +203,9 @@ async function createRepository(t) {
   t.after(() => rm(root, { recursive: true, force: true }));
   await mkdir(join(root, "tests/autobahn"), { recursive: true });
   await writeFile(join(root, "tests/autobahn/fuzzingclient.json"), "{}\n");
+  await writeFile(join(root, "alire.toml"), 'name = "fixture"\n');
   await writeFile(join(root, "source.txt"), "source\n");
-  await writeFile(join(root, ".gitignore"), "/build/\n");
+  await writeFile(join(root, ".gitignore"), "/alire_install/\n/build/\n");
   git(root, "init", "-q");
   git(root, "add", ".");
   git(
@@ -412,6 +413,51 @@ test("initial capture rejects real tracked and untracked dirt", async (t) => {
   await assert.rejects(() => beginFixture(untracked), /0 tracked, 1 untracked/);
 });
 
+test("capture records only the exact provisioned in-tree QUIC pin", async (t) => {
+  const root = await createRepository(t);
+  await mkdir(join(root, "alire_install/bin"), { recursive: true });
+  await writeFile(join(root, "alire_install/bin/alr"), "ignored tool fixture\n");
+  await writeFile(
+    join(root, "alire.toml"),
+    'name = "fixture"\n\n[[pins]]\nflyology_quic = { path=\'flyology_quic\' }\n'
+  );
+  const initial = await beginFixture(root);
+  assert.equal(initial.source.status.clean, false);
+  assert.equal(initial.source.status.entries, 1);
+  assert.deepEqual(
+    {
+      ...initial.source.provisioning,
+      diffSha256: "digest",
+    },
+    {
+      kind: "alire-in-tree-pin",
+      manifest: "alire.toml",
+      dependency: "flyology_quic",
+      path: "flyology_quic",
+      diffSha256: "digest",
+    }
+  );
+  const metadata = await finalizeRunMetadata({
+    initial,
+    projectRoot: root,
+    observed: observedFacts("plain"),
+    finalizedAt: "2026-08-05T12:44:56.000Z",
+  });
+  assert.equal(metadata.source.provisioning.dependency, "flyology_quic");
+
+  await writeFile(join(root, "source.txt"), "other tracked change\n");
+  await assert.rejects(() => beginFixture(root), /exact in-tree QUIC pin/);
+});
+
+test("capture rejects a different Alire pin as source dirt", async (t) => {
+  const root = await createRepository(t);
+  await writeFile(
+    join(root, "alire.toml"),
+    'name = "fixture"\n\n[[pins]]\nflyology_quic = { path=\'../other\' }\n'
+  );
+  await assert.rejects(() => beginFixture(root), /exact in-tree QUIC pin/);
+});
+
 test("finalization rejects real mid-run edits, config changes, and commits", async (t) => {
   const edited = await createRepository(t);
   const editInitial = await beginFixture(edited);
@@ -495,6 +541,13 @@ test("metadata schema validates actual environment and transport-specific TLS", 
   const leaked = metadataFor(profiles[0]);
   leaked.environment.privacy.hostnameRecorded = true;
   assert.throws(() => validateRunMetadata(leaked, expectedFor(profiles[0])), /hostnameRecorded/);
+
+  const nonBooleanClean = metadataFor(profiles[0]);
+  nonBooleanClean.source.status.clean = 0;
+  assert.throws(
+    () => validateRunMetadata(nonBooleanClean, expectedFor(profiles[0])),
+    /source\.status\.clean/
+  );
 });
 
 test("campaign guard defines common facts and transport-specific TLS facts", () => {


### PR DESCRIPTION
## Problem

Scheduled CI has two independent product/configuration failures:

- Every WebSocket matrix job rejects the checkout before Autobahn because `setup-alire` creates `alire_install/` and the in-tree QUIC pin appends an exact stanza to `alire.toml` before provenance capture.
- The nightly HTTP/2 soak can reserve the shared pump for a synchronous reader, consume that handoff through the stream-data wait before response bytes are published, and leave the reserved owner asleep while sibling streams time out.

## Solution

- Ignore only the setup-alire installation directory and record only the exact expected in-tree QUIC pin as source provisioning. Every other tracked or untracked change remains rejected, and finalization requires the same provisioning digest.
- Arm synchronous readers on the pump wait source after a failed pump claim.
- Add an explicit manual scheduled-qualification input so the schedule-only HTTP/2 and WebSocket paths can be verified on demand after merge.

## Verification

- Exact Linux GNAT 16.1.0/GPRbuild 26.0.1 Docker reproduction: unfixed stalled after 3,172 responses; fixed passed 300 seconds with 43,585 completed exchanges and 1,797 cancellations.
- macOS native soak: 180 seconds across 3 epochs, 1,255,402 completed exchanges and 51,775 cancellations.
- `./scripts/test.sh`
- `./scripts/test-websocket-publication.sh` (30/30)
- `git diff --check`
- workflow YAML parse

The provenance gate is not skipped or weakened: unexpected source dirt still fails, and the exact provisioning mutation is captured in the published metadata.