### PR TITLE
Assert documented WebSocket compression refusals

### DIFF
--- a/scripts/check-websocket-verdicts.mjs
+++ b/scripts/check-websocket-verdicts.mjs
@@ -12,7 +12,20 @@ if (!reportDir || !profile || !lane) {
 const allowed = new Set(["OK", "NON-STRICT", "INFORMATIONAL"]);
 const fields = ["behavior", "behaviorClose"];
 const counts = Object.fromEntries(fields.map((field) => [field, new Map()]));
+const expectedUnimplemented = new Set();
 let failed = false;
+
+if (profile === "compression" || profile === "compression-wss") {
+  //  Autobahn 13.3.* and 13.5.* require server_max_window_bits=9. The public
+  //  server contract deliberately declines values below 15 because outbound
+  //  compression uses a 32 KiB history. Keep the cases in the campaign and
+  //  require their exact refusal instead of broadly allowing UNIMPLEMENTED.
+  for (const subcategory of [3, 5]) {
+    for (let caseNumber = 1; caseNumber <= 18; caseNumber += 1) {
+      expectedUnimplemented.add(`case_13_${subcategory}_${caseNumber}.json`);
+    }
+  }
+}
 
 let files;
 try {
@@ -47,10 +60,22 @@ for (const name of files) {
       continue;
     }
     counts[field].set(verdict, (counts[field].get(verdict) ?? 0) + 1);
-    if (!allowed.has(verdict)) {
+    const expectedRefusal =
+      field === "behavior" &&
+      verdict === "UNIMPLEMENTED" &&
+      [...expectedUnimplemented].find((suffix) => name.endsWith(suffix));
+    if (expectedRefusal) {
+      expectedUnimplemented.delete(expectedRefusal);
+    } else if (!allowed.has(verdict)) {
+      console.error(`${name}: unexpected ${field} verdict ${verdict}`);
       failed = true;
     }
   }
+}
+
+for (const suffix of [...expectedUnimplemented].sort()) {
+  console.error(`missing expected documented compression refusal ${suffix}`);
+  failed = true;
 }
 
 function printCounts(label, values) {

--- a/scripts/test-websocket-publication.sh
+++ b/scripts/test-websocket-publication.sh
@@ -6,4 +6,6 @@ project_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 sh -n "$project_root/scripts/websocket-conformance.sh"
 node --check "$project_root/scripts/websocket-run-provenance.mjs"
 node --check "$project_root/scripts/publish-websocket-conformance.mjs"
+node --check "$project_root/scripts/check-websocket-verdicts.mjs"
+node --test "$project_root/tests/check_websocket_verdicts_test.mjs"
 node --test "$project_root/tests/websocket_run_provenance_test.mjs"

--- a/tests/check_websocket_verdicts_test.mjs
+++ b/tests/check_websocket_verdicts_test.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const projectRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const checker = join(projectRoot, "scripts/check-websocket-verdicts.mjs");
+
+async function fixture(t) {
+  const directory = await mkdtemp(join(tmpdir(), "flyology-websocket-verdicts-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+async function writeCase(directory, id, behavior = "OK", behaviorClose = "OK") {
+  const name = `flyology_case_${id.replaceAll(".", "_")}.json`;
+  await writeFile(
+    join(directory, name),
+    `${JSON.stringify({ behavior, behaviorClose })}\n`
+  );
+}
+
+async function writeCompressionCampaign(directory) {
+  await writeCase(directory, "12.1.1");
+  for (const subcategory of [3, 5]) {
+    for (let caseNumber = 1; caseNumber <= 18; caseNumber += 1) {
+      await writeCase(
+        directory,
+        `13.${subcategory}.${caseNumber}`,
+        "UNIMPLEMENTED"
+      );
+    }
+  }
+}
+
+function check(directory, profile = "compression") {
+  return spawnSync(process.execPath, [checker, directory, profile, "native"], {
+    cwd: projectRoot,
+    encoding: "utf8",
+  });
+}
+
+test("accepts only the documented 9-bit compression refusals", async (t) => {
+  const directory = await fixture(t);
+  await writeCompressionCampaign(directory);
+
+  const result = check(directory);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /36 UNIMPLEMENTED/);
+});
+
+test("rejects a missing documented refusal", async (t) => {
+  const directory = await fixture(t);
+  await writeCompressionCampaign(directory);
+  await writeCase(directory, "13.3.1", "OK");
+
+  const result = check(directory);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /missing expected documented compression refusal case_13_3_1\.json/
+  );
+});
+
+test("rejects an additional unimplemented compression case", async (t) => {
+  const directory = await fixture(t);
+  await writeCompressionCampaign(directory);
+  await writeCase(directory, "13.4.1", "UNIMPLEMENTED");
+
+  const result = check(directory);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /flyology_case_13_4_1\.json: unexpected behavior verdict UNIMPLEMENTED/
+  );
+});
+
+test("rejects unimplemented behavior outside compression profiles", async (t) => {
+  const directory = await fixture(t);
+  await writeCase(directory, "1.1.1", "UNIMPLEMENTED");
+
+  const result = check(directory, "core");
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unexpected behavior verdict UNIMPLEMENTED/);
+});
+
+test("rejects a failed close for an expected compression refusal", async (t) => {
+  const directory = await fixture(t);
+  await writeCompressionCampaign(directory);
+  await writeCase(directory, "13.5.18", "UNIMPLEMENTED", "FAILED");
+
+  const result = check(directory);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unexpected behaviorClose verdict FAILED/);
+});


### PR DESCRIPTION
## Problem

The scheduled WebSocket compression lanes run all Autobahn 12.* and 13.* cases. Cases 13.3.* and 13.5.* require `server_max_window_bits=9`, while the documented Flyology HTTP compressor uses a 32 KiB history and deliberately declines offers below 15. The generic verdict checker rejects every `UNIMPLEMENTED` outcome, so all four compression lanes fail despite 180 supported cases and all 216 close handshakes passing.

## Solution

Keep those cases in the campaign and assert their exact documented refusal:

- accept `UNIMPLEMENTED` only for the 36 exact 13.3.* and 13.5.* case reports in compression profiles;
- fail if any expected refusal is missing;
- continue rejecting every additional or cross-profile `UNIMPLEMENTED` and any failed close;
- add focused positive and negative tests to the maintained WebSocket publication check.

## Verification

- `node --test tests/check_websocket_verdicts_test.mjs`
- `./scripts/test-websocket-publication.sh`
- `./scripts/test.sh` (outside sandbox; pass)
- `git diff --check`
- Ubuntu Docker, pinned Autobahn 25.10.1 image and exact CI release/runtime build: 13.3.1 => `UNIMPLEMENTED`/`OK` close; adjacent supported 13.4.1 => `OK`/`OK` close

The checker remains strict; no case is skipped and no broad verdict allowance is added.
