### PR TITLE
Update shared agents for corrected macOS power detection

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-30T04:58:32.819151+00:00'
+generated_at: '2026-08-31T20:21:05.517906+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: _local/repository
@@ -25,7 +25,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-ada-library-profile
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/profiles/ada-library
@@ -35,7 +35,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-ada-interface-values
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/ada-interface-values
@@ -51,7 +51,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-ada-source-style
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/ada-source-style
@@ -67,7 +67,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-alire-release-policy
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/alire-release-policy
@@ -83,7 +83,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-decision-authority
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/decision-authority
@@ -99,7 +99,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-goal-stewardship
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/goal-stewardship
@@ -115,7 +115,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-grounded-communication
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/grounded-communication
@@ -131,7 +131,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-performance-testing
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/performance-testing
@@ -147,7 +147,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-problem-solution-commits
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/problem-solution-commits
@@ -163,7 +163,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-repository-workflow
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/repository-workflow
@@ -179,7 +179,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-review-cycle
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/review-cycle
@@ -195,7 +195,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-tla-plus-assurance
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/instructions/tla-plus-assurance
@@ -211,7 +211,7 @@ dependencies:
 - repo_url: flyology-ada/agents
   name: flyology-ada-skills
   host: github.com
-  resolved_commit: 39f2c8139965d11380cc211f7b2ac399815bcea5
+  resolved_commit: 8389888ac6824c7f7635fa305b9964a26f1d74e1
   resolved_ref: main
   version: 0.1.0
   virtual_path: packages/skills
@@ -307,6 +307,9 @@ dependencies:
   - .agents/skills/performance-testing
   - .agents/skills/performance-testing/SKILL.md
   - .agents/skills/performance-testing/scripts/check-power-profile.sh
+  - .agents/skills/performance-testing/tests/bin/pmset
+  - .agents/skills/performance-testing/tests/bin/uname
+  - .agents/skills/performance-testing/tests/check-power-profile.sh
   - .agents/skills/tla-plus
   - .agents/skills/tla-plus-learning
   - .agents/skills/tla-plus-learning/SKILL.md
@@ -411,6 +414,9 @@ dependencies:
   - .claude/skills/performance-testing
   - .claude/skills/performance-testing/SKILL.md
   - .claude/skills/performance-testing/scripts/check-power-profile.sh
+  - .claude/skills/performance-testing/tests/bin/pmset
+  - .claude/skills/performance-testing/tests/bin/uname
+  - .claude/skills/performance-testing/tests/check-power-profile.sh
   - .claude/skills/tla-plus
   - .claude/skills/tla-plus-learning
   - .claude/skills/tla-plus-learning/SKILL.md
@@ -499,8 +505,11 @@ dependencies:
     .agents/skills/gnattest/references/test-skeletons.md: sha256:baaaf48c32a9dbdd712db7c41848822aa78cf4aa42e807dd04596b4f546342ec
     .agents/skills/gnattest/references/workflow.md: sha256:fe94afe889db7c6476838b4d688962d4c2742c16d6877e813b7eea0817ca6554
     .agents/skills/maintain-agent-instructions/SKILL.md: sha256:688c9f6c4a116826878602c825f360b2dee03fb95232a07923c4def90af77301
-    .agents/skills/performance-testing/SKILL.md: sha256:e3b16b3b4d6262d70493a707c2ffe4e17d0c8defd870f6b23dc1045d254656d6
-    .agents/skills/performance-testing/scripts/check-power-profile.sh: sha256:985b719f5882147ae7fa41b4b64321f5e554ec38ff6e3601d80e30ae6103446f
+    .agents/skills/performance-testing/SKILL.md: sha256:ed0d4c265b683cc977f8022011e0ccdffcc0d500221b556d045129ab2b8c8d52
+    .agents/skills/performance-testing/scripts/check-power-profile.sh: sha256:f0a0b961b3c4d849bce37dbeb0857450fdd974a8d2e546c59c09f157bc467a16
+    .agents/skills/performance-testing/tests/bin/pmset: sha256:181b774c39dc7259e685b6751e2f87988a52c5ad23e550b1294bd13d28a5e43c
+    .agents/skills/performance-testing/tests/bin/uname: sha256:351692124668bc856ef4654e02dd2ea29e5ce3e40f0a8058299c33cd41a4e09c
+    .agents/skills/performance-testing/tests/check-power-profile.sh: sha256:bcb167169810a3e354919c3ddf79df7e778eeab2304c2879426482ae92b4eca9
     .agents/skills/tla-plus-learning/SKILL.md: sha256:81d2c5f8f2af55f05e2a8360188f6a962600b9f1edc7301b4c06af5ea1bff44b
     .agents/skills/tla-plus-learning/references/model-checking.md: sha256:6540c75d52a460241cb83529924b36341ddaace50c021ec29c8d89319c5e6a02
     .agents/skills/tla-plus-learning/references/modeling.md: sha256:e60d726e2dd6b2ff3848e54d74a5ad80ec65071221d547b78465a34e6bfe3123
@@ -582,8 +591,11 @@ dependencies:
     .claude/skills/gnattest/references/test-skeletons.md: sha256:baaaf48c32a9dbdd712db7c41848822aa78cf4aa42e807dd04596b4f546342ec
     .claude/skills/gnattest/references/workflow.md: sha256:fe94afe889db7c6476838b4d688962d4c2742c16d6877e813b7eea0817ca6554
     .claude/skills/maintain-agent-instructions/SKILL.md: sha256:688c9f6c4a116826878602c825f360b2dee03fb95232a07923c4def90af77301
-    .claude/skills/performance-testing/SKILL.md: sha256:e3b16b3b4d6262d70493a707c2ffe4e17d0c8defd870f6b23dc1045d254656d6
-    .claude/skills/performance-testing/scripts/check-power-profile.sh: sha256:985b719f5882147ae7fa41b4b64321f5e554ec38ff6e3601d80e30ae6103446f
+    .claude/skills/performance-testing/SKILL.md: sha256:ed0d4c265b683cc977f8022011e0ccdffcc0d500221b556d045129ab2b8c8d52
+    .claude/skills/performance-testing/scripts/check-power-profile.sh: sha256:f0a0b961b3c4d849bce37dbeb0857450fdd974a8d2e546c59c09f157bc467a16
+    .claude/skills/performance-testing/tests/bin/pmset: sha256:181b774c39dc7259e685b6751e2f87988a52c5ad23e550b1294bd13d28a5e43c
+    .claude/skills/performance-testing/tests/bin/uname: sha256:351692124668bc856ef4654e02dd2ea29e5ce3e40f0a8058299c33cd41a4e09c
+    .claude/skills/performance-testing/tests/check-power-profile.sh: sha256:bcb167169810a3e354919c3ddf79df7e778eeab2304c2879426482ae92b4eca9
     .claude/skills/tla-plus-learning/SKILL.md: sha256:81d2c5f8f2af55f05e2a8360188f6a962600b9f1edc7301b4c06af5ea1bff44b
     .claude/skills/tla-plus-learning/references/model-checking.md: sha256:6540c75d52a460241cb83529924b36341ddaace50c021ec29c8d89319c5e6a02
     .claude/skills/tla-plus-learning/references/modeling.md: sha256:e60d726e2dd6b2ff3848e54d74a5ad80ec65071221d547b78465a34e6bfe3123
@@ -595,7 +607,7 @@ dependencies:
     .claude/skills/tlaplus-from-source/SKILL.md: sha256:e3fc651973a5b5d96dc02e2ee7c3baf25fafb30b3af1da56e257832ed228e913
     .claude/skills/tlaplus-split-action/SKILL.md: sha256:7ea84ceeabd3b44f85d6548e74a365adc9b1d2355689831f840e2b1819e448d7
     .claude/skills/workflow-improvement/SKILL.md: sha256:65a1aa4ea6c0b39383046e6a74a353f4eb2e1d54e8cdef2ddb9c188b7f7a0f25
-  content_hash: sha256:fb3758e7266e89aceec7befe95707f1e8801bdc43e68c17090daca584f994b5c
+  content_hash: sha256:48a3ef76f3249e459149e8d737707549e71ca1d507871fca3c4b72d64059cf87
 deployments:
 - kind: project-relative
   target: claude
@@ -1487,7 +1499,7 @@ deployments:
   owners:
   - flyology-ada/agents/packages/skills
   active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e3b16b3b4d6262d70493a707c2ffe4e17d0c8defd870f6b23dc1045d254656d6
+  content_hash: sha256:ed0d4c265b683cc977f8022011e0ccdffcc0d500221b556d045129ab2b8c8d52
 - kind: project-relative
   target: claude
   value: .claude/skills/performance-testing/scripts/check-power-profile.sh
@@ -1496,7 +1508,34 @@ deployments:
   owners:
   - flyology-ada/agents/packages/skills
   active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:985b719f5882147ae7fa41b4b64321f5e554ec38ff6e3601d80e30ae6103446f
+  content_hash: sha256:f0a0b961b3c4d849bce37dbeb0857450fdd974a8d2e546c59c09f157bc467a16
+- kind: project-relative
+  target: claude
+  value: .claude/skills/performance-testing/tests/bin/pmset
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:181b774c39dc7259e685b6751e2f87988a52c5ad23e550b1294bd13d28a5e43c
+- kind: project-relative
+  target: claude
+  value: .claude/skills/performance-testing/tests/bin/uname
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:351692124668bc856ef4654e02dd2ea29e5ce3e40f0a8058299c33cd41a4e09c
+- kind: project-relative
+  target: claude
+  value: .claude/skills/performance-testing/tests/check-power-profile.sh
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:bcb167169810a3e354919c3ddf79df7e778eeab2304c2879426482ae92b4eca9
 - kind: project-relative
   target: claude
   value: .claude/skills/tla-plus
@@ -2423,7 +2462,7 @@ deployments:
   owners:
   - flyology-ada/agents/packages/skills
   active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:e3b16b3b4d6262d70493a707c2ffe4e17d0c8defd870f6b23dc1045d254656d6
+  content_hash: sha256:ed0d4c265b683cc977f8022011e0ccdffcc0d500221b556d045129ab2b8c8d52
 - kind: project-relative
   target: codex
   value: .agents/skills/performance-testing/scripts/check-power-profile.sh
@@ -2432,7 +2471,34 @@ deployments:
   owners:
   - flyology-ada/agents/packages/skills
   active_owner: flyology-ada/agents/packages/skills
-  content_hash: sha256:985b719f5882147ae7fa41b4b64321f5e554ec38ff6e3601d80e30ae6103446f
+  content_hash: sha256:f0a0b961b3c4d849bce37dbeb0857450fdd974a8d2e546c59c09f157bc467a16
+- kind: project-relative
+  target: codex
+  value: .agents/skills/performance-testing/tests/bin/pmset
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:181b774c39dc7259e685b6751e2f87988a52c5ad23e550b1294bd13d28a5e43c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/performance-testing/tests/bin/uname
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:351692124668bc856ef4654e02dd2ea29e5ce3e40f0a8058299c33cd41a4e09c
+- kind: project-relative
+  target: codex
+  value: .agents/skills/performance-testing/tests/check-power-profile.sh
+  runtime: null
+  scope: project
+  owners:
+  - flyology-ada/agents/packages/skills
+  active_owner: flyology-ada/agents/packages/skills
+  content_hash: sha256:bcb167169810a3e354919c3ddf79df7e778eeab2304c2879426482ae92b4eca9
 - kind: project-relative
   target: codex
   value: .agents/skills/tla-plus


### PR DESCRIPTION
## Summary

- update every selected `flyology-ada/agents` package from `39f2c8139965d11380cc211f7b2ac399815bcea5` to `8389888ac6824c7f7635fa305b9964a26f1d74e1`
- deploy the corrected macOS `pmset` power-profile detector metadata and its test fixtures
- keep generated client resources reproducible through the APM lockfile

## Validation

- APM CLI: `0.28.0`
- `apm install --frozen`
- `apm compile --target codex`
- `apm audit --ci` — all 10 checks passed; no drift
- `git diff --check`
- Codex CLI `0.147.0`, fresh ephemeral read-only sessions:
  - explicit activation prompt selected the performance-testing skill and its repository script
  - implicit benchmark-preflight prompt ran the script and reported `profile=high-power reduced_performance=false`
  - unrelated LICENSE prompt did not activate the performance-testing skill
- Claude Code `2.1.238` fresh-session probe was unavailable because its OAuth session had expired; the rollout owner explicitly approved proceeding without that client gate
- review sweep: no actionable P0, P1, or P2 findings

APM also warned that `flyology-ada/.github-private` policy was unavailable and applied the configured fail-open behavior; the maintained audit still passed.